### PR TITLE
feat: add contact email address to web accessibility policy

### DIFF
--- a/content/articles/products/accessibility/policy.mdx
+++ b/content/articles/products/accessibility/policy.mdx
@@ -145,4 +145,8 @@ SmartHRは「[社会の非合理を、ハックする。](https://smarthr.co.jp/
 
 ## 問い合わせ先
 
-https://github.com/kufu/smarthr-ui/issues
+<address style="font-style: normal">
+  <p>株式会社SmartHR プログレッシブデザイングループ</p>
+  <a href="mailto:accessibility@smarthr.co.jp">accessibility@smarthr.co.jp</a>
+</address>
+


### PR DESCRIPTION
## 課題・背景

accessibility@smarthr.co.jp を作ったので、アクセシビリティ関係の問い合わせに利用したい

## やったこと

- ウェブアクセシビリティ方針の問い合わせ先をGitHubのissuesのURLからメールアドレスに変更

## やらなかったこと
- 特にナシ

## 動作確認
- メールアドレスクリックでメールが送信できるか
- メールアドレスが間違ってないか
 
## キャプチャ

|Before|After|
| --- | --- |
| <img width="530" alt="画面のスクショ。問い合わせ先 リンク:https://github.com/kufu/smarthr-ui/issues" src="https://user-images.githubusercontent.com/6724665/164176323-3a898cea-8c4f-4655-9ac1-2f8e8cb85e1b.png"> | <img width="479" alt="画面のスクショ。問い合わせ先 株式会社SmartHR プログレッシブデザイングループ リンク accessibility@smarthr.co.jp" src="https://user-images.githubusercontent.com/6724665/164175990-9cb3ee31-3d5a-474a-8055-310f9a146b4a.png"> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
