### PR TITLE
Airtableコンテンツでマークダウンが利用できるように

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "postinstall": "husky install"
   },
   "dependencies": {
+    "@types/marked": "^4.0.3",
     "algoliasearch": "^4.13.0",
     "color": "^4.2.3",
     "dotenv": "^16.0.0",
@@ -48,6 +49,7 @@
     "gatsby-plugin-google-gtag": "^4.8.0",
     "gatsby-plugin-mdx": "^3.9.1",
     "gatsby-source-airtable": "^2.2.1",
+    "marked": "^4.0.14",
     "react": "^17.0.2",
     "react-docgen-typescript": "^2.2.2",
     "react-dom": "^17.0.2",

--- a/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
+++ b/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
@@ -4,6 +4,7 @@ import { graphql, useStaticQuery } from 'gatsby'
 import { Text } from 'smarthr-ui'
 import { FragmentTitle } from '../../article/FragmentTitle/FragmentTitle'
 import reactStringReplace from 'react-string-replace'
+import { marked } from 'marked'
 
 const query = graphql`
   query BasicConceptTable {
@@ -28,7 +29,7 @@ export const BasicConceptTable: VFC = () => {
   const basicConceptData = data.basicConceptData.edges
     .map(({ node }) => ({
       name: node.data?.name,
-      description: node.data?.description,
+      description: marked.parse(node.data?.description || ''),
       discussion: node.data?.discussion,
       source: node.data?.source,
       recordId: node.data?.record_id,
@@ -68,7 +69,7 @@ export const BasicConceptTable: VFC = () => {
                   説明
                 </FragmentTitle>
               )}
-              {description && getReplaceLinkText(description)}
+              {description && <div dangerouslySetInnerHTML={{ __html: description }} />}
               {discussion && (
                 <FragmentTitle tag="h3" id={fragmentId('2')}>
                   議事録

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -194,7 +194,6 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
 }
 
 const Wrapper = styled.div`
-  overflow-x: scroll;
   & th,
   td {
     vertical-align: baseline;

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -194,6 +194,7 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
 }
 
 const Wrapper = styled.div`
+  overflow-x: scroll;
   & th,
   td {
     vertical-align: baseline;

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -4,6 +4,7 @@ import { Link, graphql, useStaticQuery } from 'gatsby'
 import { Body, Cell, Head, Row, Table, Text } from 'smarthr-ui'
 import { FragmentTitle } from '../../article/FragmentTitle/FragmentTitle'
 import reactStringReplace from 'react-string-replace'
+import { marked } from 'marked'
 
 const query = graphql`
   query IdiomaticUsageTable {
@@ -69,7 +70,7 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
   const idiomaticUsageReason = data.idiomaticUsageReason.edges
     .map(({ node }) => ({
       name: node.data?.name,
-      description: node.data?.description,
+      description: marked.parse(node.data?.description || ''),
       discussion: node.data?.discussion,
       source: node.data?.source,
       recordId: node.data?.record_id,
@@ -170,7 +171,7 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
                       説明
                     </FragmentTitle>
                   )}
-                  {description && getReplaceLinkText(description)}
+                  {description && <div dangerouslySetInnerHTML={{ __html: description }} />}
                   {discussion && (
                     <FragmentTitle tag="h3" id={fragmentId('2')}>
                       議事録

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,6 +2856,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
 
+"@types/marked@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.3.tgz#2098f4a77adaba9ce881c9e0b6baf29116e5acc4"
+  integrity sha512-HnMWQkLJEf/PnxZIfbm0yGJRRZYYMhb++O9M36UCTA9z53uPvVoSlAwJr3XOpDEryb7Hwl1qAx/MV6YIW1RXxg==
+
 "@types/mdast@^3.0.0":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
@@ -9961,6 +9966,11 @@ markdown-table@^2.0.0:
   integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
   dependencies:
     repeat-string "^1.0.0"
+
+marked@^4.0.14:
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.14.tgz#7a3a5fa5c80580bac78c1ed2e3b84d7bd6fc3870"
+  integrity sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==
 
 match-index@^1.0.1, match-index@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/894
https://github.com/kufu/smarthr-design-system-issues/issues/911

## やったこと
- Airtable由来のコンテンツのうち、`description`部分でマークダウンを利用できるようにしました
  - [Marked](https://www.npmjs.com/package/marked) パッケージを導入しました
- [用事用語一覧ページ](https://smarthr.design/products/contents/idiomatic-usage/data/) で、コンテンツの量によりテーブル幅が広がっているようなので、横スクロールを追加しました。

## 動作確認
**マークダウン記法の反映**
https://deploy-preview-35--smarthr-design-system.netlify.app//products/contents/writing-style/
https://deploy-preview-35--smarthr-design-system.netlify.app//products/contents/idiomatic-usage/usage/

行頭が「-」のコンテンツなどは、すでにマークダウン変換がされています→ https://deploy-preview-35--smarthr-design-system.netlify.app/products/contents/writing-style/#recrVEn3NYr2AV33o-0
リンクについては、URLを「()」で囲う必要がありそうです。

**テーブルの横スクロール**
https://deploy-preview-35--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/

## キャプチャ

テーブルのスクロール部分↓

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/165259534-568d1465-0897-4ce6-b299-dabe7b09ac24.png" width="350" alt="" > | <img src="https://user-images.githubusercontent.com/7822534/165259682-f2ef41c9-6fe8-4d43-8f64-eb27c6eb621e.png" width="350" alt=""> |


