### PR TITLE
コンポーネントページにsmarthr-ui関連の情報が表示されなくなっていたので修正

### DIFF
--- a/src/__generated__/gatsby-types.ts
+++ b/src/__generated__/gatsby-types.ts
@@ -2985,15 +2985,15 @@ type AirtableSortInput = {
   readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
 };
 
-type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id'>> } }> } };
-
 type IdiomaticUsageTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type IdiomaticUsageTableQuery = { readonly idiomaticUsageData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'label' | 'ng_example' | 'ok_example' | 'expected' | 'reason' | 'record_id'>> } }> }, readonly idiomaticUsageReason: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'data'>> } }> }, readonly writingStyle: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> } };
+
+type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id'>> } }> } };
 
 type HeadQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/src/gatsby-node/index.ts
+++ b/src/gatsby-node/index.ts
@@ -105,6 +105,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       order: Int
     }
   `
+  // MdxFrontmatterには`smarthr-ui`もあるが、型定義（`smarthr_ui: String`）を追加すると値が取得できない現象が起こるため、未定義。
 
   createTypes(typeDefs)
 }

--- a/src/gatsby-node/index.ts
+++ b/src/gatsby-node/index.ts
@@ -103,7 +103,6 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       title: String!
       description: String!
       order: Int
-      smarthr_ui: String
     }
   `
 


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/893 に関連して、#34 でmdxのfrontmatterに対するGraphQLクエリの型定義を追加したが、その後コンポーネントページ冒頭のリンクが表示されなくなっていました。

## やったこと
型定義があると、GraphQLからfrontmatterの`smarthr-ui`（クエリ内では `smarthr_ui`）を取得しても`null`になってしまうようなので、いったん定義を削除しました。

## 動作確認
https://deploy-preview-38--smarthr-design-system.netlify.app/products/components/accordion-panel/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/165695037-d8afcc24-1e47-49da-8e0f-aded5d0ff5ec.png" width="350" alt=""> | <img src="https://user-images.githubusercontent.com/7822534/165695125-7257f205-3eaa-4e1d-bcab-33ecbf7c3f4d.png" width="350"  alt=""> |
