### PR TITLE
ESCキー押下でデモのダイアログを閉じるように修正

### DIFF
--- a/content/articles/products/components/dialog.mdx
+++ b/content/articles/products/components/dialog.mdx
@@ -66,6 +66,7 @@ export const DynamicActionDialog = () => {
           actionText="実行"
           actionTheme="primary"
           onClickClose={()=> {setIsOpen(false)}}
+          onPressEscape={() => setIsOpen(false)}
           onClickAction={()=> {setIsOpen(false)}}
         >
           <div style={{'box-sizing': 'border-box', 'width': '480px', 'padding': '24px'}}>
@@ -102,6 +103,7 @@ export const DynamicMessageDialog = () => {
           description={<p style={{'box-sizing': 'border-box', 'width': '432px', 'margin': '0', 'padding': '24px 0'}}>本文が入ります。</p>}
           closeText="閉じる"
           onClickClose={() => setIsOpen(false)}
+          onPressEscape={() => setIsOpen(false)}
           id="dialog-message"
         />
       </>


### PR DESCRIPTION
## 課題・背景

ダイアログの実装方法を検討中、ガイドラインの「ESCキー押下でダイアログを閉じる」にデモが準拠していないことに気付いたので、修正しました。
https://kufuinc.slack.com/archives/C02NUAT7P0X/p1652322660794599?thread_ts=1652319019.097679&cid=C02NUAT7P0X

## やったこと

- ActionDialogとMessageDialogのプロパティにonPressEscapeを追加しました。

## やらなかったこと

- ModelessDialogは元々onPressEscapeプロパティが指定されていたので、修正していません。

## 動作確認

- Previewで確認をお願いします。
