### PR TITLE
Airtableの`order`順にソートして表示する

### DIFF
--- a/src/__generated__/gatsby-types.ts
+++ b/src/__generated__/gatsby-types.ts
@@ -2979,25 +2979,20 @@ type AirtableSortInput = {
   readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
 };
 
+type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
+
 type IdiomaticUsageTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type IdiomaticUsageTableQuery = { readonly idiomaticUsageData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'label' | 'ng_example' | 'ok_example' | 'expected' | 'reason' | 'record_id'>> } }> }, readonly idiomaticUsageReason: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'data'>> } }> }, readonly writingStyle: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> }, readonly appWriting: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> } };
 
-type AppWritingQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type AppWritingQuery = { readonly appWritingData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
-
 type SearchQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type SearchQuery = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'hierarchy' | 'slug'>> }> } };
-
-type HeadQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type HeadQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'author' | 'ogimage'>> }> };
 
 type FooterQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -3019,9 +3014,30 @@ type FooterQuery = { readonly concept: { readonly nodes: ReadonlyArray<(
       & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> }
     )> } };
 
-type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
+type HeadQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id'>> } }> } };
+type HeadQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'author' | 'ogimage'>> }> };
+
+type ArticleQueryVariables = Exact<{
+  id: Maybe<Scalars['String']>;
+  category: Maybe<Scalars['String']>;
+  depth1Glob: Maybe<Scalars['String']>;
+  depth2Glob: Maybe<Scalars['String']>;
+  depth3Glob: Maybe<Scalars['String']>;
+  depth4Glob: Maybe<Scalars['String']>;
+  airTableName: Maybe<Scalars['String']>;
+}>;
+
+
+type ArticleQuery = { readonly mdx: Maybe<(
+    Pick<Mdx, 'id' | 'body'>
+    & { readonly headings: Maybe<ReadonlyArray<Maybe<Pick<MdxHeadingMdx, 'depth' | 'value'>>>>, readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'description' | 'smarthr_ui'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'hierarchy' | 'slug'>> }
+  )>, readonly parentCategoryAllMdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'slug'>> } }> }, readonly depth1Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly depth2Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly depth3Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly depth4Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly airTable: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
+
+type AppWritingQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type AppWritingQuery = { readonly appWritingData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
 
 }

--- a/src/__generated__/gatsby-types.ts
+++ b/src/__generated__/gatsby-types.ts
@@ -433,10 +433,11 @@ type AirtableData = {
   readonly name: Maybe<Scalars['String']>;
   readonly description: Maybe<Scalars['String']>;
   readonly discussion: Maybe<Scalars['String']>;
+  readonly order: Maybe<Scalars['Int']>;
+  readonly _50_______: Maybe<Scalars['String']>;
   readonly prh: Maybe<Scalars['String']>;
   readonly spec_from: Maybe<Scalars['String']>;
   readonly spec_to: Maybe<Scalars['String']>;
-  readonly order: Maybe<Scalars['Int']>;
   readonly add_next_to_textlint: Maybe<Scalars['Boolean']>;
   readonly basic_reason: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>;
   readonly source: Maybe<Scalars['String']>;
@@ -2755,10 +2756,11 @@ type AirtableDataFilterInput = {
   readonly name: Maybe<StringQueryOperatorInput>;
   readonly description: Maybe<StringQueryOperatorInput>;
   readonly discussion: Maybe<StringQueryOperatorInput>;
+  readonly order: Maybe<IntQueryOperatorInput>;
+  readonly _50_______: Maybe<StringQueryOperatorInput>;
   readonly prh: Maybe<StringQueryOperatorInput>;
   readonly spec_from: Maybe<StringQueryOperatorInput>;
   readonly spec_to: Maybe<StringQueryOperatorInput>;
-  readonly order: Maybe<IntQueryOperatorInput>;
   readonly add_next_to_textlint: Maybe<BooleanQueryOperatorInput>;
   readonly basic_reason: Maybe<StringQueryOperatorInput>;
   readonly source: Maybe<StringQueryOperatorInput>;
@@ -2912,10 +2914,11 @@ type AirtableFieldsEnum =
   | 'data.name'
   | 'data.description'
   | 'data.discussion'
+  | 'data.order'
+  | 'data._50_______'
   | 'data.prh'
   | 'data.spec_from'
   | 'data.spec_to'
-  | 'data.order'
   | 'data.add_next_to_textlint'
   | 'data.basic_reason'
   | 'data.source'
@@ -2979,20 +2982,25 @@ type AirtableSortInput = {
   readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
 };
 
-type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
+type AppWritingTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
+type AppWritingTableQuery = { readonly appWritingData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
 
-type IdiomaticUsageTableQueryVariables = Exact<{ [key: string]: never; }>;
+type HeadQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type IdiomaticUsageTableQuery = { readonly idiomaticUsageData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'label' | 'ng_example' | 'ok_example' | 'expected' | 'reason' | 'record_id'>> } }> }, readonly idiomaticUsageReason: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'data'>> } }> }, readonly writingStyle: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> }, readonly appWriting: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> } };
+type HeadQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'author' | 'ogimage'>> }> };
 
 type SearchQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type SearchQuery = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'hierarchy' | 'slug'>> }> } };
+
+type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
 
 type FooterQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -3014,10 +3022,10 @@ type FooterQuery = { readonly concept: { readonly nodes: ReadonlyArray<(
       & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> }
     )> } };
 
-type HeadQueryVariables = Exact<{ [key: string]: never; }>;
+type IdiomaticUsageTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type HeadQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'author' | 'ogimage'>> }> };
+type IdiomaticUsageTableQuery = { readonly idiomaticUsageData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'label' | 'ng_example' | 'ok_example' | 'expected' | 'reason' | 'record_id'>> } }> }, readonly idiomaticUsageReason: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'data' | 'order'>> } }> }, readonly writingStyle: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> } };
 
 type ArticleQueryVariables = Exact<{
   id: Maybe<Scalars['String']>;
@@ -3034,10 +3042,5 @@ type ArticleQuery = { readonly mdx: Maybe<(
     Pick<Mdx, 'id' | 'body'>
     & { readonly headings: Maybe<ReadonlyArray<Maybe<Pick<MdxHeadingMdx, 'depth' | 'value'>>>>, readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'description' | 'smarthr_ui'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'hierarchy' | 'slug'>> }
   )>, readonly parentCategoryAllMdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'slug'>> } }> }, readonly depth1Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly depth2Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly depth3Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly depth4Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly airTable: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
-
-type AppWritingQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type AppWritingQuery = { readonly appWritingData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
 
 }

--- a/src/components/contents/AppWriting/AppWriting.tsx
+++ b/src/components/contents/AppWriting/AppWriting.tsx
@@ -34,8 +34,9 @@ export const AppWriting: VFC = () => {
       discussion: node.data?.discussion,
       source: node.data?.source,
       recordId: node.data?.record_id,
+      order: node.data?.order,
     }))
-    .reverse()
+    .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
 
   const getReplaceLinkText = (text: string) => {
     return (

--- a/src/components/contents/AppWriting/AppWriting.tsx
+++ b/src/components/contents/AppWriting/AppWriting.tsx
@@ -7,7 +7,7 @@ import reactStringReplace from 'react-string-replace'
 import { marked } from 'marked'
 
 const query = graphql`
-  query AppWriting {
+  query AppWritingTable {
     appWritingData: allAirtable(filter: { table: { eq: "UIテキスト" } }) {
       edges {
         node {
@@ -34,7 +34,7 @@ export const AppWriting: VFC = () => {
       discussion: node.data?.discussion,
       source: node.data?.source,
       recordId: node.data?.record_id,
-      order: node.data?.order,
+      order: node.data?.order || Number.MAX_SAFE_INTEGER,
     }))
     .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
 

--- a/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
+++ b/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
@@ -34,7 +34,7 @@ export const BasicConceptTable: VFC = () => {
       discussion: node.data?.discussion,
       source: node.data?.source,
       recordId: node.data?.record_id,
-      order: node.data?.order,
+      order: node.data?.order || Number.MAX_SAFE_INTEGER,
     }))
     .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
 

--- a/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
+++ b/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
@@ -17,6 +17,7 @@ const query = graphql`
             discussion
             source
             record_id
+            order
           }
         }
       }
@@ -33,8 +34,9 @@ export const BasicConceptTable: VFC = () => {
       discussion: node.data?.discussion,
       source: node.data?.source,
       recordId: node.data?.record_id,
+      order: node.data?.order,
     }))
-    .reverse()
+    .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
 
   const getReplaceLinkText = (text: string) => {
     return (

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -32,22 +32,12 @@ const query = graphql`
             source
             record_id
             data
+            order
           }
         }
       }
     }
     writingStyle: allAirtable(filter: { table: { eq: "基本的な考え方や表記" } }) {
-      edges {
-        node {
-          data {
-            name
-            data
-            record_id
-          }
-        }
-      }
-    }
-    appWriting: allAirtable(filter: { table: { eq: "UIテキスト" } }) {
       edges {
         node {
           data {
@@ -86,8 +76,9 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
       source: node.data?.source,
       recordId: node.data?.record_id,
       data: node.data?.data,
+      order: node.data?.order || Number.MAX_SAFE_INTEGER,
     }))
-    .sort((x, y) => (x.name && y.name ? x.name.localeCompare(y.name, 'ja') : -1))
+    .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
 
   const writingStyle = data.writingStyle.edges
     .map(({ node }) => ({

--- a/src/constants/airtable.ts
+++ b/src/constants/airtable.ts
@@ -30,6 +30,6 @@ export const AIRTABLE_CONTENTS: airtableContents[] = [
     pageTitle: '用字用語：理由',
     pagePath: '/products/contents/idiomatic-usage/usage/',
     tableName: '用字用語：理由',
-    sort: 'CHARACTER',
+    sort: 'AIRTABLE',
   },
 ]

--- a/src/constants/airtable.ts
+++ b/src/constants/airtable.ts
@@ -1,4 +1,4 @@
-type airtableSortType = 'NONE' | 'REVERSE' | 'CHARACTER'
+type airtableSortType = 'NONE' | 'REVERSE' | 'CHARACTER' | 'AIRTABLE'
 
 export type airtableContents = {
   pageTitle: string
@@ -12,13 +12,13 @@ export const AIRTABLE_CONTENTS: airtableContents[] = [
     pageTitle: 'ライティングスタイル',
     pagePath: '/products/contents/writing-style/',
     tableName: '基本的な考え方や表記',
-    sort: 'REVERSE',
+    sort: 'AIRTABLE',
   },
   {
     pageTitle: 'UIテキスト',
     pagePath: '/products/contents/app-writing/',
     tableName: 'UIテキスト',
-    sort: 'REVERSE',
+    sort: 'AIRTABLE',
   },
   {
     pageTitle: '用字用語：一覧',

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -157,6 +157,7 @@ export const query = graphql`
             discussion
             source
             record_id
+            order
           }
         }
       }
@@ -214,6 +215,7 @@ const Article: VFC<Props> = ({ data }) => {
       value: edge.node.data?.name ?? '',
       recordId: edge.node.data?.record_id ?? '',
       name: edge.node.data?.name ?? '',
+      order: edge.node.data?.order ?? Number.MAX_SAFE_INTEGER,
     }
   })
   // Airtableコンテンツは、ページによりソート方法が異なるので、headingの順序もそれに合わせる
@@ -227,6 +229,9 @@ const Article: VFC<Props> = ({ data }) => {
   }
   if (airtableSortType === 'CHARACTER') {
     airTableHeadings.sort((x, y) => (x.name && y.name ? x.name.localeCompare(y.name, 'ja') : -1))
+  }
+  if (airtableSortType === 'AIRTABLE') {
+    airTableHeadings.sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
   }
 
   // Mdxコンテンツのheading


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/933

## やったこと

- Airtableデータから`order`も取得するようにしました。
  - もし`order`が入っていない場合は、最大値をセットして一番後ろになるようにしています。
- AppwritingとBasicConceptTableでは`order`の昇順でコンテンツ・右サイドバーに出力されます。
  - `/src/constants/airtable.ts` に`sort: 'AIRTABLE'`とあるものが対象です。（用字用語はこれまでどおり文字列順でのソートです）

また、GraphQLクエリを編集したため、`typegen`を実行して型定義をも更新しています。
（まだ型のエラーが出ていますが、別途Airtable関連コンポーネントをリファクタリングする際に対応したいです。）

## やらなかったこと
- https://github.com/kufu/smarthr-design-system-issues/issues/937 のリファクタリング
- 型エラーの対応

## 動作確認
https://deploy-preview-84--smarthr-design-system.netlify.app/products/contents/app-writing/
https://deploy-preview-84--smarthr-design-system.netlify.app/products/contents/writing-style/

（以前と変わらず）
https://deploy-preview-84--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/usage/
https://deploy-preview-84--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/170398337-d477dffa-49b5-403e-851f-2be4f7d29f6c.png" width="350" alt=""> | <img src="https://user-images.githubusercontent.com/7822534/170398365-629f625b-8ea7-4a17-9815-af06b3796d80.png" width="350" alt=""> |
