### PR TITLE
左ナビゲーションに子ページの開閉機能を追加

### DIFF
--- a/src/__generated__/gatsby-types.ts
+++ b/src/__generated__/gatsby-types.ts
@@ -2987,6 +2987,16 @@ type AppWritingTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 type AppWritingTableQuery = { readonly appWritingData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
 
+type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
+
+type IdiomaticUsageTableQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type IdiomaticUsageTableQuery = { readonly idiomaticUsageData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'label' | 'ng_example' | 'ok_example' | 'expected' | 'reason' | 'record_id'>> } }> }, readonly idiomaticUsageReason: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'data' | 'order'>> } }> }, readonly writingStyle: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> } };
+
 type HeadQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -2996,11 +3006,6 @@ type SearchQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type SearchQuery = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'hierarchy' | 'slug'>> }> } };
-
-type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
 
 type FooterQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -3022,18 +3027,9 @@ type FooterQuery = { readonly concept: { readonly nodes: ReadonlyArray<(
       & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> }
     )> } };
 
-type IdiomaticUsageTableQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type IdiomaticUsageTableQuery = { readonly idiomaticUsageData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'label' | 'ng_example' | 'ok_example' | 'expected' | 'reason' | 'record_id'>> } }> }, readonly idiomaticUsageReason: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'data' | 'order'>> } }> }, readonly writingStyle: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> } };
-
 type ArticleQueryVariables = Exact<{
   id: Maybe<Scalars['String']>;
   category: Maybe<Scalars['String']>;
-  depth1Glob: Maybe<Scalars['String']>;
-  depth2Glob: Maybe<Scalars['String']>;
-  depth3Glob: Maybe<Scalars['String']>;
-  depth4Glob: Maybe<Scalars['String']>;
   airTableName: Maybe<Scalars['String']>;
 }>;
 
@@ -3041,6 +3037,6 @@ type ArticleQueryVariables = Exact<{
 type ArticleQuery = { readonly mdx: Maybe<(
     Pick<Mdx, 'id' | 'body'>
     & { readonly headings: Maybe<ReadonlyArray<Maybe<Pick<MdxHeadingMdx, 'depth' | 'value'>>>>, readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'description' | 'smarthr_ui'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'hierarchy' | 'slug'>> }
-  )>, readonly parentCategoryAllMdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'slug'>> } }> }, readonly depth1Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly depth2Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly depth3Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly depth4Mdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> }, readonly airTable: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
+  )>, readonly parentCategoryAllMdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'slug'>> } }> }, readonly airTable: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
 
 }

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -183,6 +183,9 @@ const Nav = styled.nav`
     }
     &:hover {
       background-color: ${CSS_COLOR.DIVIDER};
+      + button {
+        background-color: ${CSS_COLOR.LIGHT_GREY_1};
+      }
     }
 
     &:focus-visible {

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -42,8 +42,8 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
     savePosition(newPosition)
   }
 
-  const onClickCaret = (e: React.MouseEvent<HTMLButtonElement>): void => {
-    const clicked = e.currentTarget
+  const onClickCaret = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    const clicked = event.currentTarget
     const isOpen = clicked.getAttribute('aria-expanded') === 'true'
     const targetId = clicked.getAttribute('aria-controls')
     const targetUl = document.querySelector(`#${targetId}`)
@@ -79,7 +79,11 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
                         aria-expanded={path.includes(depth2Item.link)}
                         onClick={onClickCaret}
                       >
-                        <FaChevronDownIcon color="TEXT_GREY" size={14} />
+                        <FaChevronDownIcon
+                          color="TEXT_GREY"
+                          size={14}
+                          visuallyHiddenText={path.includes(depth2Item.link) ? '閉じる' : '開く'}
+                        />
                       </CaretButton>
                     )}
                   </Depth2Item>
@@ -99,7 +103,11 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
                                 aria-expanded={path.includes(depth3Item.link)}
                                 onClick={onClickCaret}
                               >
-                                <FaChevronDownIcon color="TEXT_GREY" size={14} />
+                                <FaChevronDownIcon
+                                  color="TEXT_GREY"
+                                  size={14}
+                                  visuallyHiddenText={path.includes(depth3Item.link) ? '閉じる' : '開く'}
+                                />
                               </CaretButton>
                             )}
                           </Depth3Item>
@@ -216,13 +224,24 @@ const Depth4Item = styled.div`
   line-height: 1.2;
 `
 const CaretButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
-  top: 50%;
-  right: 0.5rem;
-  transform: translateY(-50%);
+  width: 2rem;
+  height: 100%;
+  top: 0;
+  right: 0;
   border: 0;
   background: none;
-  &[aria-expanded='true'] {
-    transform: rotate(180deg) translateY(50%);
+  cursor: pointer;
+  &:hover {
+    background-color: ${CSS_COLOR.LIGHT_GREY_1};
+  }
+  > span {
+    top: 0; /* -1pxだとフォーカスリングがずれて見えるため */
+  }
+  &[aria-expanded='true'] > .smarthr-ui-Icon {
+    transform: rotate(180deg);
   }
 `

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -235,7 +235,8 @@ const CaretButton = styled.button`
   border: 0;
   background: none;
   cursor: pointer;
-  &:hover {
+  &:hover,
+  &:focus-visible {
     background-color: ${CSS_COLOR.LIGHT_GREY_1};
   }
   > span {

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -188,7 +188,7 @@ const Nav = styled.nav`
     }
   }
 
-  & li:hover > div {
+  & div:hover {
     > a {
       background-color: ${CSS_COLOR.DIVIDER};
     }

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -79,11 +79,7 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
                         aria-expanded={path.includes(depth2Item.link)}
                         onClick={onClickCaret}
                       >
-                        <FaChevronDownIcon
-                          color="TEXT_GREY"
-                          size={14}
-                          visuallyHiddenText={path.includes(depth2Item.link) ? '閉じる' : '開く'}
-                        />
+                        <FaChevronDownIcon size={14} visuallyHiddenText={path.includes(depth2Item.link) ? '閉じる' : '開く'} />
                       </CaretButton>
                     )}
                   </Depth2Item>
@@ -104,7 +100,6 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
                                 onClick={onClickCaret}
                               >
                                 <FaChevronDownIcon
-                                  color="TEXT_GREY"
                                   size={14}
                                   visuallyHiddenText={path.includes(depth3Item.link) ? '閉じる' : '開く'}
                                 />
@@ -180,16 +175,33 @@ const Nav = styled.nav`
     &[aria-current='true']:hover {
       background-color: ${CSS_COLOR.DARK_GREY_1};
       color: ${CSS_COLOR.WHITE};
+      + button {
+        color: ${CSS_COLOR.WHITE};
+      }
     }
     &:hover {
       background-color: ${CSS_COLOR.DIVIDER};
-      + button {
-        background-color: ${CSS_COLOR.LIGHT_GREY_1};
-      }
     }
 
     &:focus-visible {
       outline-offset: -1px;
+    }
+  }
+
+  & li:hover > div {
+    > a {
+      background-color: ${CSS_COLOR.DIVIDER};
+    }
+    > a[aria-current='true'] {
+      background-color: ${CSS_COLOR.DARK_GREY_1};
+      color: ${CSS_COLOR.WHITE};
+      + button {
+        background-color: ${CSS_COLOR.DARK_GREY_1};
+        color: ${CSS_COLOR.WHITE};
+        &:hover {
+          background-color: ${CSS_COLOR.TEXT_GREY};
+        }
+      }
     }
   }
 `
@@ -237,14 +249,17 @@ const CaretButton = styled.button`
   right: 0;
   border: 0;
   background: none;
+  color: ${CSS_COLOR.TEXT_GREY};
   cursor: pointer;
-  &:hover,
-  &:focus-visible {
+
+  &:hover {
     background-color: ${CSS_COLOR.LIGHT_GREY_1};
   }
+
   > span {
     top: 0; /* -1pxだとフォーカスリングがずれて見えるため */
   }
+
   &[aria-expanded='true'] > .smarthr-ui-Icon {
     transform: rotate(180deg);
   }

--- a/src/gatsby-node/index.ts
+++ b/src/gatsby-node/index.ts
@@ -65,11 +65,6 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions, graphql,
   allMdx.edges.forEach(({ node }) => {
     const slug = node.fields?.slug
     const component = path.resolve(`./src/templates/article.tsx`)
-    const fileNameArray = node.fields?.hierarchy?.split('/') ?? ''
-    const depth1Glob = `${fileNameArray[0]}`
-    const depth2Glob = `${fileNameArray[0]}/*`
-    const depth3Glob = `${fileNameArray[0]}/${fileNameArray[1]}/*`
-    const depth4Glob = `${fileNameArray[0]}/${fileNameArray[1]}/${fileNameArray[2]}/*`
 
     const targetAirtable = AIRTABLE_CONTENTS.filter((item: airtableContents) => {
       return item.pagePath === slug
@@ -82,10 +77,6 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions, graphql,
         context: {
           id: node.id,
           category: node.fields?.category,
-          depth1Glob,
-          depth2Glob,
-          depth3Glob,
-          depth4Glob,
           airTableName: targetAirtable[0]?.tableName || '',
         },
       })


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/898

## やったこと
コンテンツページ左カラムのナビゲーションメニューを更新しました。
- 表示中以外のページの子・孫ページのデータも取得しておき、ナビゲーションに追加しました。
- 子ページが存在する場合は、右端にキャレットを表示します。
- クリックすると、子ページのリストが開閉します。

実装としては、`aria-controls` `aria-expanded` `aria-hidden` 属性をJSで切り替え、さらにCSSで表示の制御をしています。

## 動作確認
例 https://deploy-preview-86--smarthr-design-system.netlify.app/products/contents/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/170618584-d9be6f00-d139-46cf-803d-7cf83abd05db.png" width="350" alt=""> | <img src="https://user-images.githubusercontent.com/7822534/170618645-0d453878-4e63-43b1-ad5d-ea1024ca5bb1.png" width="350" alt=""> |
