### PR TITLE
Airtableコンテンツ用のコンポーネントをリファクタリング

### DIFF
--- a/src/components/contents/AppWriting/AppWriting.tsx
+++ b/src/components/contents/AppWriting/AppWriting.tsx
@@ -1,9 +1,8 @@
 import React, { VFC } from 'react'
 import styled from 'styled-components'
 import { graphql, useStaticQuery } from 'gatsby'
-import { Text } from 'smarthr-ui'
+import { TextAnchor } from '../shared/TextAnchor'
 import { FragmentTitle } from '../../article/FragmentTitle/FragmentTitle'
-import reactStringReplace from 'react-string-replace'
 import { marked } from 'marked'
 
 const query = graphql`
@@ -36,57 +35,43 @@ export const AppWriting: VFC = () => {
       recordId: node.data?.record_id,
       order: node.data?.order || Number.MAX_SAFE_INTEGER,
     }))
+    .filter((item) => {
+      return item.name
+    })
     .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
 
-  const getReplaceLinkText = (text: string) => {
-    return (
-      <Text as="p" whiteSpace="pre-wrap">
-        {reactStringReplace(text, /(https?:\/\/\S+)/g, (match: string, strIndex: number) => {
-          return (
-            <a key={strIndex} href={match}>
-              {match}
-            </a>
-          )
-        })}
-      </Text>
-    )
-  }
   return (
     <>
-      {appWritingData
-        .filter((item) => {
-          return item.name
-        })
-        .map(({ name, description, discussion, source, recordId }, index) => {
-          const fragmentId = (suffixId: string) => {
-            return recordId ? `${recordId}-${suffixId}` : ''
-          }
-          return (
-            <Wrapper key={index}>
-              <FragmentTitle tag="h2" id={fragmentId('0')}>
-                {name}
+      {appWritingData.map(({ name, description, discussion, source, recordId }, index) => {
+        const generateFragmentId = (suffixId: string) => {
+          return recordId ? `${recordId}-${suffixId}` : `${index}-${suffixId}`
+        }
+        return (
+          <Wrapper key={index}>
+            <FragmentTitle tag="h2" id={generateFragmentId('0')}>
+              {name}
+            </FragmentTitle>
+            {description && (
+              <FragmentTitle tag="h3" id={generateFragmentId('1')}>
+                説明
               </FragmentTitle>
-              {description && (
-                <FragmentTitle tag="h3" id={fragmentId('1')}>
-                  説明
-                </FragmentTitle>
-              )}
-              {description && <div dangerouslySetInnerHTML={{ __html: description }} />}
-              {discussion && (
-                <FragmentTitle tag="h3" id={fragmentId('2')}>
-                  議事録
-                </FragmentTitle>
-              )}
-              {discussion && getReplaceLinkText(discussion)}
-              {source && (
-                <FragmentTitle tag="h3" id={fragmentId('3')}>
-                  出典
-                </FragmentTitle>
-              )}
-              {source && getReplaceLinkText(source)}
-            </Wrapper>
-          )
-        })}
+            )}
+            {description && <div dangerouslySetInnerHTML={{ __html: description }} />}
+            {discussion && (
+              <FragmentTitle tag="h3" id={generateFragmentId('2')}>
+                議事録
+              </FragmentTitle>
+            )}
+            {discussion && <TextAnchor text={discussion} />}
+            {source && (
+              <FragmentTitle tag="h3" id={generateFragmentId('3')}>
+                出典
+              </FragmentTitle>
+            )}
+            {source && <TextAnchor text={source} />}
+          </Wrapper>
+        )
+      })}
     </>
   )
 }

--- a/src/components/contents/AppWriting/AppWriting.tsx
+++ b/src/components/contents/AppWriting/AppWriting.tsx
@@ -1,7 +1,8 @@
 import React, { VFC } from 'react'
 import styled from 'styled-components'
 import { graphql, useStaticQuery } from 'gatsby'
-import { TextAnchor } from '../shared/TextAnchor'
+import { Text } from 'smarthr-ui'
+import { TextUrlToLink } from '../shared/TextUrlToLink'
 import { FragmentTitle } from '../../article/FragmentTitle/FragmentTitle'
 import { marked } from 'marked'
 
@@ -62,13 +63,21 @@ export const AppWriting: VFC = () => {
                 議事録
               </FragmentTitle>
             )}
-            {discussion && <TextAnchor text={discussion} />}
+            {discussion && (
+              <StyledText as="p">
+                <TextUrlToLink text={discussion} />
+              </StyledText>
+            )}
             {source && (
               <FragmentTitle tag="h3" id={generateFragmentId('3')}>
                 出典
               </FragmentTitle>
             )}
-            {source && <TextAnchor text={source} />}
+            {source && (
+              <StyledText as="p">
+                <TextUrlToLink text={source} />
+              </StyledText>
+            )}
           </Wrapper>
         )
       })}
@@ -77,3 +86,8 @@ export const AppWriting: VFC = () => {
 }
 
 const Wrapper = styled.div``
+
+const StyledText = styled(Text)`
+  white-space: pre-wrap;
+  word-wrap: break-word;
+`

--- a/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
+++ b/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
@@ -1,7 +1,8 @@
 import React, { VFC } from 'react'
 import styled from 'styled-components'
 import { graphql, useStaticQuery } from 'gatsby'
-import { TextAnchor } from '../shared/TextAnchor'
+import { Text } from 'smarthr-ui'
+import { TextUrlToLink } from '../shared/TextUrlToLink'
 import { FragmentTitle } from '../../article/FragmentTitle/FragmentTitle'
 import { marked } from 'marked'
 
@@ -62,13 +63,21 @@ export const BasicConceptTable: VFC = () => {
                 議事録
               </FragmentTitle>
             )}
-            {discussion && <TextAnchor text={discussion} />}
+            {discussion && (
+              <StyledText as="p">
+                <TextUrlToLink text={discussion} />
+              </StyledText>
+            )}
             {source && (
               <FragmentTitle tag="h3" id={generateFragmentId('3')}>
                 出典
               </FragmentTitle>
             )}
-            {source && <TextAnchor text={source} />}
+            {source && (
+              <StyledText as="p">
+                <TextUrlToLink text={source} />
+              </StyledText>
+            )}
           </Wrapper>
         )
       })}
@@ -77,3 +86,7 @@ export const BasicConceptTable: VFC = () => {
 }
 
 const Wrapper = styled.div``
+const StyledText = styled(Text)`
+  white-space: pre-wrap;
+  word-wrap: break-word;
+`

--- a/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
+++ b/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
@@ -1,9 +1,8 @@
 import React, { VFC } from 'react'
 import styled from 'styled-components'
 import { graphql, useStaticQuery } from 'gatsby'
-import { Text } from 'smarthr-ui'
+import { TextAnchor } from '../shared/TextAnchor'
 import { FragmentTitle } from '../../article/FragmentTitle/FragmentTitle'
-import reactStringReplace from 'react-string-replace'
 import { marked } from 'marked'
 
 const query = graphql`
@@ -36,57 +35,43 @@ export const BasicConceptTable: VFC = () => {
       recordId: node.data?.record_id,
       order: node.data?.order || Number.MAX_SAFE_INTEGER,
     }))
+    .filter((item) => {
+      return item.name
+    })
     .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
 
-  const getReplaceLinkText = (text: string) => {
-    return (
-      <Text as="p" whiteSpace="pre-wrap">
-        {reactStringReplace(text, /(https?:\/\/\S+)/g, (match: string, strIndex: number) => {
-          return (
-            <a key={strIndex} href={match}>
-              {match}
-            </a>
-          )
-        })}
-      </Text>
-    )
-  }
   return (
     <>
-      {basicConceptData
-        .filter((item) => {
-          return item.name
-        })
-        .map(({ name, description, discussion, source, recordId }, index) => {
-          const fragmentId = (suffixId: string) => {
-            return recordId ? `${recordId}-${suffixId}` : ''
-          }
-          return (
-            <Wrapper key={index}>
-              <FragmentTitle tag="h2" id={fragmentId('0')}>
-                {name}
+      {basicConceptData.map(({ name, description, discussion, source, recordId }, index) => {
+        const generateFragmentId = (suffixId: string) => {
+          return recordId ? `${recordId}-${suffixId}` : `${index}-${suffixId}`
+        }
+        return (
+          <Wrapper key={index}>
+            <FragmentTitle tag="h2" id={generateFragmentId('0')}>
+              {name}
+            </FragmentTitle>
+            {description && (
+              <FragmentTitle tag="h3" id={generateFragmentId('1')}>
+                説明
               </FragmentTitle>
-              {description && (
-                <FragmentTitle tag="h3" id={fragmentId('1')}>
-                  説明
-                </FragmentTitle>
-              )}
-              {description && <div dangerouslySetInnerHTML={{ __html: description }} />}
-              {discussion && (
-                <FragmentTitle tag="h3" id={fragmentId('2')}>
-                  議事録
-                </FragmentTitle>
-              )}
-              {discussion && getReplaceLinkText(discussion)}
-              {source && (
-                <FragmentTitle tag="h3" id={fragmentId('3')}>
-                  出典
-                </FragmentTitle>
-              )}
-              {source && getReplaceLinkText(source)}
-            </Wrapper>
-          )
-        })}
+            )}
+            {description && <div dangerouslySetInnerHTML={{ __html: description }} />}
+            {discussion && (
+              <FragmentTitle tag="h3" id={generateFragmentId('2')}>
+                議事録
+              </FragmentTitle>
+            )}
+            {discussion && <TextAnchor text={discussion} />}
+            {source && (
+              <FragmentTitle tag="h3" id={generateFragmentId('3')}>
+                出典
+              </FragmentTitle>
+            )}
+            {source && <TextAnchor text={source} />}
+          </Wrapper>
+        )
+      })}
     </>
   )
 }

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -1,8 +1,8 @@
 import React, { VFC } from 'react'
 import styled from 'styled-components'
 import { Link, graphql, useStaticQuery } from 'gatsby'
-import { Body, Cell, Head, Row, Table } from 'smarthr-ui'
-import { TextAnchor } from '../shared/TextAnchor'
+import { Body, Cell, Head, Row, Table, Text } from 'smarthr-ui'
+import { TextUrlToLink } from '../shared/TextUrlToLink'
 import { FragmentTitle } from '../../article/FragmentTitle/FragmentTitle'
 import { marked } from 'marked'
 
@@ -166,13 +166,21 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
                     議事録
                   </FragmentTitle>
                 )}
-                {discussion && <TextAnchor text={discussion} />}
+                {discussion && (
+                  <StyledText as="p">
+                    <TextUrlToLink text={discussion} />
+                  </StyledText>
+                )}
                 {source && (
                   <FragmentTitle tag="h3" id={generateFragmentId('3')}>
                     出典
                   </FragmentTitle>
                 )}
-                {source && <TextAnchor text={source} />}
+                {source && (
+                  <StyledText as="p">
+                    <TextUrlToLink text={source} />
+                  </StyledText>
+                )}
               </Wrapper>
             )
           })}
@@ -198,4 +206,8 @@ const NGCell = styled(Cell)`
 const ReasonCell = styled(Cell)`
   min-width: 22em;
   width: auto;
+`
+const StyledText = styled(Text)`
+  white-space: pre-wrap;
+  word-wrap: break-word;
 `

--- a/src/components/contents/shared/TextAnchor.tsx
+++ b/src/components/contents/shared/TextAnchor.tsx
@@ -1,0 +1,27 @@
+import React, { VFC } from 'react'
+import styled from 'styled-components'
+import { Text } from 'smarthr-ui'
+import reactStringReplace from 'react-string-replace'
+
+type Props = {
+  text: string
+}
+
+export const TextAnchor: VFC<Props> = ({ text }) => {
+  return (
+    <StyledText as="p">
+      {reactStringReplace(text, /(https?:\/\/\S+)/g, (match: string, strIndex: number) => {
+        return (
+          <a key={strIndex} href={match}>
+            {match}
+          </a>
+        )
+      })}
+    </StyledText>
+  )
+}
+
+const StyledText = styled(Text)`
+  white-space: pre-wrap;
+  word-wrap: break-word;
+`

--- a/src/components/contents/shared/TextUrlToLink.tsx
+++ b/src/components/contents/shared/TextUrlToLink.tsx
@@ -1,15 +1,13 @@
 import React, { VFC } from 'react'
-import styled from 'styled-components'
-import { Text } from 'smarthr-ui'
 import reactStringReplace from 'react-string-replace'
 
 type Props = {
   text: string
 }
 
-export const TextAnchor: VFC<Props> = ({ text }) => {
+export const TextUrlToLink: VFC<Props> = ({ text }) => {
   return (
-    <StyledText as="p">
+    <>
       {reactStringReplace(text, /(https?:\/\/\S+)/g, (match: string, strIndex: number) => {
         return (
           <a key={strIndex} href={match}>
@@ -17,11 +15,6 @@ export const TextAnchor: VFC<Props> = ({ text }) => {
           </a>
         )
       })}
-    </StyledText>
+    </>
   )
 }
-
-const StyledText = styled(Text)`
-  white-space: pre-wrap;
-  word-wrap: break-word;
-`


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/937

## やったこと
Airtableのコンテンツを表示するコンポーネント（`/src/components/contents/*`）をリファクタリングしました。

**データをフィルタリングする場所**（https://github.com/kufu/smarthr-design-system/pull/72#discussion_r877831239 ）
→ ソートの手前に移動しました

**recordIdからfragmentIdを生成するところ** （https://github.com/kufu/smarthr-design-system/pull/72#discussion_r877837675 ）
→ `<FragmentTitle>`がstring型を受け取る実装になっているので、`recordId`がない場合はデータの通し番号を使うように書き換えました。また、関数名を動詞に変更しています。

**URLをリンクに変換して表示するところ** （https://github.com/kufu/smarthr-design-system/pull/72#discussion_r877843981 ）
→ 3つのコンポーネントで共通の処理をしていたので、コンポーネントとして独立させました。ひとまず`/src/components/contents/shared/TextAnchor.tsx`というファイルにしましたがどうでしょうか。

## やらなかったこと
型定義については、Airtable関連の型エラーは現在は出なくなっていたため、何もしていません。

## 動作確認
https://deploy-preview-93--smarthr-design-system.netlify.app/products/contents/writing-style/
https://deploy-preview-93--smarthr-design-system.netlify.app/products/contents/app-writing/
https://deploy-preview-93--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/
https://deploy-preview-93--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/usage/

## キャプチャ
見た目の変化はないはずです。
