### PR TITLE
lintの警告、TypeScriptの型エラーに対処

### DIFF
--- a/src/components/ComponentPreview/ComponentPreview.tsx
+++ b/src/components/ComponentPreview/ComponentPreview.tsx
@@ -37,7 +37,7 @@ export const ComponentPreview = ({
         return <NoLayoutWrapper>{children}</NoLayoutWrapper>
       }
     }
-  }, [layout])
+  }, [layout, align, children, gap])
 
 const Wrapper = styled(WrapperBase)(
   ({ theme: { space } }) => css`

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -9,10 +9,27 @@ type Props = {
   showTitle?: boolean
 }
 
+interface UIPropValue {
+  value: string
+  description?: string
+  fullComment?: string
+  tags?: { [key: string]: string }
+}
+
+interface UIProps {
+  name: string
+  required: boolean
+  description: string
+  defaultValue: { [key: string]: string } | null
+  declarations: Array<{ fileName: string; name: string }>
+  type: { name: string; raw?: string; value?: UIPropValue[] }
+}
+
 export const ComponentPropsTable: VFC<Props> = ({ name, showTitle }) => {
   const data = uiProps.filter((uiProp) => {
     return uiProp.displayName === name
   })[0]
+  const propsData: UIProps[] = data ? data.props : []
   const fragmentId = (propsName: string) => {
     return `props-${propsName.replace(' ', '-')}`
   }
@@ -24,7 +41,7 @@ export const ComponentPropsTable: VFC<Props> = ({ name, showTitle }) => {
         </FragmentTitle>
       )}
 
-      {data && data.props.length > 0 ? (
+      {propsData.length > 0 ? (
         <Wrapper>
           <Table>
             <Head>
@@ -36,7 +53,7 @@ export const ComponentPropsTable: VFC<Props> = ({ name, showTitle }) => {
               </Row>
             </Head>
             <Body>
-              {data.props.map((prop, i) => {
+              {propsData.map((prop, i) => {
                 return (
                   <Row key={i}>
                     <NameCell>

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -71,10 +71,12 @@ export const CodeBlock: VFC<Props> = ({
             }
           >
             <ComponentPreview gap={gap} align={align} layout={layout}>
+              {/* @ts-ignore -- LivePreviewの型定義が正しくないようなので、エラーを無視。https://github.com/FormidableLabs/react-live/pull/304 */}
               <LivePreview Component={React.Fragment} />
             </ComponentPreview>
             <StyledLiveEditorContainer>
               <CopyButton text={code} />
+              {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
               <LiveEditor padding={0} />
             </StyledLiveEditorContainer>
             <LiveError />


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/951

## やったこと
ESLintでの警告、TypeScriptのエラーが出ている部分を修正、または調査の上無視するよう設定しました。

- `src/components/ComponentPreview/ComponentPreview.tsx`にて、`useMemo`の依存配列がESLintの`react-hooks/exhaustive-deps`ルールに引っ掛かっていたので、修正しました。
- `src/components/ComponentPropsTable/ComponentPropsTable.tsx`で`smarthr-ui-props.json`を読み込みますが、このJSON由来のpropsオブジェクトに型が定義されていなかったため、追加しました。
- `src/components/article/CodeBlock/CodeBlock.tsx`で、[react-live](https://github.com/FormidableLabs/react-live)のコンポーネントのpropsについて2つ型エラーが出ていますが、これはreact-live側の型定義に問題があるようで、PRも出ていたので（マージはされていませんでしたが）、その旨コメントを追加してエラーは無視するようにしました。

## やらなかったこと
- `node_modules`以下のコードに由来するTSエラーについては何もしていません。
- `src/components/article/CodeBlock/CodeBlock.tsx`で、styled-componentsの`<ThemeProvider />`に渡すpropsでも型エラーが出ていますが、これは[src/templates/Theme.tsx](https://github.com/kufu/smarthr-design-system/blob/main/src/templates/Theme.tsx)で`space`というキーの値が追加されているためで、ここにTODOコメントがありましたので、特に対応はしていません。

## 動作確認
- `ComponentPreview.tsx` https://deploy-preview-108--smarthr-design-system.netlify.app/products/design-patterns/delete-dialog/
- `ComponentPropsTable.tsx` https://deploy-preview-108--smarthr-design-system.netlify.app/products/components/accordion-panel/#h2-0
- `CodeBlock.tsx` -> Live preview https://deploy-preview-108--smarthr-design-system.netlify.app/products/components/button/


## キャプチャ
見た目や挙動に影響はないはずです。
