### PR TITLE
開発コンソールに出ていたReactの警告に対処

### DIFF
--- a/content/articles/products/components/dialog.mdx
+++ b/content/articles/products/components/dialog.mdx
@@ -69,7 +69,7 @@ export const DynamicActionDialog = () => {
           onPressEscape={() => setIsOpen(false)}
           onClickAction={()=> {setIsOpen(false)}}
         >
-          <div style={{'box-sizing': 'border-box', 'width': '480px', 'padding': '24px'}}>
+          <div style={{'boxSizing': 'border-box', 'width': '480px', 'padding': '24px'}}>
             本文が入ります。
           </div>
         </ActionDialog>
@@ -100,7 +100,7 @@ export const DynamicMessageDialog = () => {
         <MessageDialog
           isOpen={isOpen}
           title="メッセージダイアログタイトル"
-          description={<p style={{'box-sizing': 'border-box', 'width': '432px', 'margin': '0', 'padding': '24px 0'}}>本文が入ります。</p>}
+          description={<p style={{'boxSizing': 'border-box', 'width': '432px', 'margin': '0', 'padding': '24px 0'}}>本文が入ります。</p>}
           closeText="閉じる"
           onClickClose={() => setIsOpen(false)}
           onPressEscape={() => setIsOpen(false)}

--- a/content/articles/products/contents/error-messages-guide.mdx
+++ b/content/articles/products/contents/error-messages-guide.mdx
@@ -95,5 +95,5 @@ order: 5
 
 
 #### ライティングパターン
-<iframe class="airtable-embed" src="https://airtable.com/embed/shrJesWWfaW3G0B02?backgroundColor=teal&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+<iframe class="airtable-embed" src="https://airtable.com/embed/shrJesWWfaW3G0B02?backgroundColor=teal&viewControls=on" frameborder="0" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
 

--- a/content/articles/products/design-patterns/delete-dialog.mdx
+++ b/content/articles/products/design-patterns/delete-dialog.mdx
@@ -45,7 +45,7 @@ export const DynamicActionDialog = () => {
           onClickClose={()=> {setIsOpen(false)}}
           onClickAction={()=> {setIsOpen(false)}}
         >
-          <div style={{'box-sizing': 'border-box', 'width': '640px', 'padding': '24px'}}>
+          <div style={{'boxSizing': 'border-box', 'width': '640px', 'padding': '24px'}}>
             <p style={{'margin': 0}}>
             {'【{オブジェクトのインスタンス名}】を削除します。'}<br />
             {'{関連するオブジェクト名など}に登録されているデータも削除されます。'}<br />
@@ -103,7 +103,7 @@ export const DynamicActionDialog = () => {
 
 
 ## ライティングパターン
-<iframe className="airtable-embed" src="https://airtable.com/embed/shr4uUQHE55YM8F1W?backgroundColor=teal&viewControls=on" frameBorder="0" onmousewheel="" width="100%" height="400px" style="background: transparent; border: 1px solid #ccc;"></iframe>
+<iframe className="airtable-embed" src="https://airtable.com/embed/shr4uUQHE55YM8F1W?backgroundColor=teal&viewControls=on" frameBorder="0" width="100%" height="400px" style="background: transparent; border: 1px solid #ccc;"></iframe>
 
 
 ## 類似する種類
@@ -130,7 +130,7 @@ export const DynamicCancelActionDialog = () => {
           onClickClose={()=> {setIsOpen(false)}}
           onClickAction={()=> {setIsOpen(false)}}
         >
-          <div style={{'box-sizing': 'border-box', 'width': '480px', 'padding': '24px'}}>
+          <div style={{'boxSizing': 'border-box', 'width': '480px', 'padding': '24px'}}>
             {'{操作名}を取り消します。'}<br />
             {'「取り消し」を押すと変更内容が破棄されます。'}
           </div>

--- a/content/articles/products/design-patterns/help-link.mdx
+++ b/content/articles/products/design-patterns/help-link.mdx
@@ -45,7 +45,7 @@ order: 13
     - リンクの目的が判断できれば構いません。リンクテキストとリンク先のページタイトルは完全一致でなくても構いません。(※1.)
 
 ## ライティングパターン
-<iframe class="airtable-embed" src="https://airtable.com/embed/shr0uo6clqu2YkINO?backgroundColor=teal&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+<iframe class="airtable-embed" src="https://airtable.com/embed/shr0uo6clqu2YkINO?backgroundColor=teal&viewControls=on" frameborder="0" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
 
 
 

--- a/content/articles/products/design-patterns/help-link.mdx
+++ b/content/articles/products/design-patterns/help-link.mdx
@@ -4,6 +4,8 @@ description: 'アプリケーションからヘルプセンターの各ヘルプ
 order: 13
 ---
 
+import { FaExternalLinkAltIcon, FaQuestionCircleIcon } from 'smarthr-ui'
+
 アプリケーションからヘルプセンターの各ヘルプページへのテキストリンクを定義しています。
 
 ## 基本的な考え方


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/968

## やったこと
- Airtableで出力されるiframeのコードに含まれている（と思われる）`onmousewheel`を削除
- React要素のstyle属性では、`box-sizing`ではなく`boxSizing`と記述するように変更

もう1点、[ヘルプページへの動線](https://smarthr.design/products/design-patterns/help-link/) ページで、`visuallyHiddenText`という属性はない、という警告が出ていましたが、smarthr-uiのアイコン要素に指定されている属性で、そもそもアイコンが`import`されていないのが原因のようでした。
`import`を追加すると警告は消え、アイコンも表示されるようになりました。

## 動作確認
見た目は変わっていないはずのページ例：
https://deploy-preview-109--smarthr-design-system.netlify.app/products/design-patterns/delete-dialog/

アイコンの`import`を追加したページ
https://deploy-preview-109--smarthr-design-system.netlify.app/products/design-patterns/help-link/#h3-2

## キャプチャ

アイコンの表示が意図したものになっているでしょうか？

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/172331132-61173fbe-c88e-446f-afde-935239c5a4e4.png" width="350" alt=""> | <img src="https://user-images.githubusercontent.com/7822534/172331268-92e4157b-3421-439a-8b30-907fefaf529d.png" width="350" alt=""> |

