### PR TITLE
目次を表示するコンポーネントを追加

### DIFF
--- a/content/articles/products/contents/index.mdx
+++ b/content/articles/products/contents/index.mdx
@@ -8,7 +8,7 @@ import { PageIndex } from '@Components/article/PageIndex'
 
 UIテキストに限らず、**「ユーザーがSmartHRというプロダクトを利用する際に助けとなる言葉をデザインする」**ためのツールを提供します。
 
-<PageIndex path="/products/contents/" excludes={['app-writing']}>
+<PageIndex path="/products/contents/" excludes={['app-writing']} heading="h3">
   <Description name="writing-principles">
     index.mdxに書いたDescription{'\n'}
     改行、**太字**

--- a/content/articles/products/contents/index.mdx
+++ b/content/articles/products/contents/index.mdx
@@ -11,7 +11,12 @@ UIテキストに限らず、**「ユーザーがSmartHRというプロダクト
 
 <PageIndex path="/products/contents/" excludes={['app-writing']}>
   <Description name="writing-principles">
-    index.mdxに書いたDescription
+    index.mdxに書いたDescription{'\n'}
+    改行、**太字**
+    [リンクテキスト](/products/contents/idiomatic-usage/data/)
+  </Description>
+  <Description name="error-messages-guide">
+    改行のないテキスト。[リンク](/products/contents/idiomatic-usage/data/)
   </Description>
 </PageIndex>
 

--- a/content/articles/products/contents/index.mdx
+++ b/content/articles/products/contents/index.mdx
@@ -8,37 +8,29 @@ import { PageIndex } from '@Components/article/PageIndex'
 
 UIテキストに限らず、**「ユーザーがSmartHRというプロダクトを利用する際に助けとなる言葉をデザインする」**ためのツールを提供します。
 
-<PageIndex path="/products/contents/" excludes={['app-writing']} heading="h3">
+<PageIndex path="/products/contents/" excludes={[]} heading="h2">
   <Description name="writing-principles">
-    index.mdxに書いたDescription{'\n'}
-    改行、**太字**
-    [リンクテキスト](/products/contents/idiomatic-usage/data/)
+    ライティングガイドラインの位置づけについてまとめています。
+  </Description>
+  <Description name="writing-style">
+    言葉をデザインするときの判断基準や表記ルールをトピックごとに記載しています。
+  </Description>
+  <Description name="idiomatic-usage">
+    文章を書くときに用いる字（平仮名、カタカナ、漢字、英数字）と用いる語（単語、熟語）について、推奨する表記とNG例、その理由を定義しています。
+  </Description>
+  <Description name="app-writing">
+    アプリケーション上の表現で迷ったときの判断基準や、推奨する表記を記載しています。
   </Description>
   <Description name="error-messages-guide">
-    改行のないテキスト。[リンク](/products/contents/idiomatic-usage/data/)
+    エラーメッセージについての考え方とライティングパターンを記載しています。
+  </Description>
+  <Description name="releasenotes-guide">
+    リリースノートの目的と書くときの考え方を記載しています。
+  </Description>
+  <Description name="help-center">
+    ヘルプセンターの目的と各種ヘルプページの表記ルールを記載しています。
   </Description>
 </PageIndex>
-
-## ライティングガイドライン
-ライティングガイドラインの位置づけについてまとめています。
-
-### [ライティングスタイル](/products/contents/writing-style/)
-言葉をデザインするときの判断基準や表記ルールをトピックごとに記載しています。
-
-### [用字用語](/products/contents/idiomatic-usage/data/)
-文章を書くときに用いる字（平仮名、カタカナ、漢字、英数字）と用いる語（単語、熟語）について、推奨する表記とNG例、その理由を定義しています。
-
-#### [UIテキスト](/products/contents/app-writing/)
-アプリケーション上の表現で迷ったときの判断基準や、推奨する表記を記載しています。
-
-#### [エラーメッセージ](/products/contents/error-message/)
-エラーメッセージについての考え方とライティングパターンを記載しています。
-
-### [リリースノートガイドライン](/products/contents/releasenotes-guide/)
-リリースノートの目的と書くときの考え方を記載しています。
-
-### [ヘルプセンターガイドライン](/products/contents/help-center/index/)
-ヘルプセンターの目的と各種ヘルプページの表記ルールを記載しています。
 
 ## フィードバック先
 記載内容に気になる点がある場合は、社内Slack`#design_system相談`チャンネル、または、お近くのUXライターまでお願いします。

--- a/content/articles/products/contents/index.mdx
+++ b/content/articles/products/contents/index.mdx
@@ -3,8 +3,17 @@ title: 'コンテンツ'
 description: 'UIテキストに限らず、「ユーザーがSmartHRというプロダクトを利用する際に助けとなる言葉をデザインする」ためのツールを提供します。'
 order: 5
 ---
+
+import { PageIndex } from '@Components/article/PageIndex'
+
 <!-- textlint-disable -->
 UIテキストに限らず、**「ユーザーがSmartHRというプロダクトを利用する際に助けとなる言葉をデザインする」**ためのツールを提供します。
+
+<PageIndex path="/products/contents/" excludes={['app-writing']}>
+  <Description name="writing-principles">
+    index.mdxに書いたDescription
+  </Description>
+</PageIndex>
 
 ## ライティングガイドライン
 ライティングガイドラインの位置づけについてまとめています。

--- a/content/articles/products/contents/index.mdx
+++ b/content/articles/products/contents/index.mdx
@@ -6,7 +6,6 @@ order: 5
 
 import { PageIndex } from '@Components/article/PageIndex'
 
-<!-- textlint-disable -->
 UIテキストに限らず、**「ユーザーがSmartHRというプロダクトを利用する際に助けとなる言葉をデザインする」**ためのツールを提供します。
 
 <PageIndex path="/products/contents/" excludes={['app-writing']}>
@@ -36,11 +35,10 @@ UIテキストに限らず、**「ユーザーがSmartHRというプロダクト
 エラーメッセージについての考え方とライティングパターンを記載しています。
 
 ### [リリースノートガイドライン](/products/contents/releasenotes-guide/)
-リリースノートの目的と書く時の考え方を記載しています。
+リリースノートの目的と書くときの考え方を記載しています。
 
 ### [ヘルプセンターガイドライン](/products/contents/help-center/index/)
 ヘルプセンターの目的と各種ヘルプページの表記ルールを記載しています。
 
 ## フィードバック先
-記載内容に気になる点がある場合は 社内Slack`#design_system相談`チャンネル、または、お近くのUXライターまでお願いします。
-<!-- textlint-enable -->
+記載内容に気になる点がある場合は、社内Slack`#design_system相談`チャンネル、または、お近くのUXライターまでお願いします。

--- a/src/__generated__/gatsby-types.ts
+++ b/src/__generated__/gatsby-types.ts
@@ -259,6 +259,7 @@ type Site = Node & {
   readonly pathPrefix: Maybe<Scalars['String']>;
   readonly jsxRuntime: Maybe<Scalars['String']>;
   readonly trailingSlash: Maybe<Scalars['String']>;
+  readonly graphqlTypegen: Maybe<Scalars['Boolean']>;
   readonly id: Scalars['ID'];
   readonly parent: Maybe<Node>;
   readonly children: ReadonlyArray<Node>;
@@ -347,6 +348,8 @@ type MdxFrontmatter = {
   readonly description: Scalars['String'];
   readonly order: Maybe<Scalars['Int']>;
   readonly smarthr_ui: Maybe<Scalars['String']>;
+  readonly author: Maybe<Scalars['String']>;
+  readonly date: Maybe<Scalars['String']>;
 };
 
 type MdxHeadingMdx = {
@@ -443,6 +446,7 @@ type AirtableData = {
   readonly source: Maybe<Scalars['String']>;
   readonly slack: Maybe<Scalars['Boolean']>;
   readonly data: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>;
+  readonly assign: Maybe<Scalars['String']>;
 };
 
 type Query = {
@@ -573,6 +577,7 @@ type Query_siteArgs = {
   pathPrefix: Maybe<StringQueryOperatorInput>;
   jsxRuntime: Maybe<StringQueryOperatorInput>;
   trailingSlash: Maybe<StringQueryOperatorInput>;
+  graphqlTypegen: Maybe<BooleanQueryOperatorInput>;
   id: Maybe<StringQueryOperatorInput>;
   parent: Maybe<NodeFilterInput>;
   children: Maybe<NodeFilterListInput>;
@@ -795,6 +800,8 @@ type MdxFrontmatterFilterInput = {
   readonly description: Maybe<StringQueryOperatorInput>;
   readonly order: Maybe<IntQueryOperatorInput>;
   readonly smarthr_ui: Maybe<StringQueryOperatorInput>;
+  readonly author: Maybe<StringQueryOperatorInput>;
+  readonly date: Maybe<StringQueryOperatorInput>;
 };
 
 type MdxHeadingMdxFilterListInput = {
@@ -953,6 +960,8 @@ type FileFieldsEnum =
   | 'childrenMdx.frontmatter.description'
   | 'childrenMdx.frontmatter.order'
   | 'childrenMdx.frontmatter.smarthr_ui'
+  | 'childrenMdx.frontmatter.author'
+  | 'childrenMdx.frontmatter.date'
   | 'childrenMdx.slug'
   | 'childrenMdx.body'
   | 'childrenMdx.excerpt'
@@ -1013,6 +1022,8 @@ type FileFieldsEnum =
   | 'childMdx.frontmatter.description'
   | 'childMdx.frontmatter.order'
   | 'childMdx.frontmatter.smarthr_ui'
+  | 'childMdx.frontmatter.author'
+  | 'childMdx.frontmatter.date'
   | 'childMdx.slug'
   | 'childMdx.body'
   | 'childMdx.excerpt'
@@ -1559,6 +1570,7 @@ type SiteFieldsEnum =
   | 'pathPrefix'
   | 'jsxRuntime'
   | 'trailingSlash'
+  | 'graphqlTypegen'
   | 'id'
   | 'parent.id'
   | 'parent.parent.id'
@@ -1694,6 +1706,7 @@ type SiteFilterInput = {
   readonly pathPrefix: Maybe<StringQueryOperatorInput>;
   readonly jsxRuntime: Maybe<StringQueryOperatorInput>;
   readonly trailingSlash: Maybe<StringQueryOperatorInput>;
+  readonly graphqlTypegen: Maybe<BooleanQueryOperatorInput>;
   readonly id: Maybe<StringQueryOperatorInput>;
   readonly parent: Maybe<NodeFilterInput>;
   readonly children: Maybe<NodeFilterListInput>;
@@ -2595,6 +2608,8 @@ type MdxFieldsEnum =
   | 'frontmatter.description'
   | 'frontmatter.order'
   | 'frontmatter.smarthr_ui'
+  | 'frontmatter.author'
+  | 'frontmatter.date'
   | 'slug'
   | 'body'
   | 'excerpt'
@@ -2766,6 +2781,7 @@ type AirtableDataFilterInput = {
   readonly source: Maybe<StringQueryOperatorInput>;
   readonly slack: Maybe<BooleanQueryOperatorInput>;
   readonly data: Maybe<StringQueryOperatorInput>;
+  readonly assign: Maybe<StringQueryOperatorInput>;
 };
 
 type AirtableConnection = {
@@ -2923,7 +2939,8 @@ type AirtableFieldsEnum =
   | 'data.basic_reason'
   | 'data.source'
   | 'data.slack'
-  | 'data.data';
+  | 'data.data'
+  | 'data.assign';
 
 type AirtableGroupConnection = {
   readonly totalCount: Scalars['Int'];
@@ -2982,30 +2999,20 @@ type AirtableSortInput = {
   readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
 };
 
-type AppWritingTableQueryVariables = Exact<{ [key: string]: never; }>;
+type PageListQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type AppWritingTableQuery = { readonly appWritingData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
-
-type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
-
-type IdiomaticUsageTableQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type IdiomaticUsageTableQuery = { readonly idiomaticUsageData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'label' | 'ng_example' | 'ok_example' | 'expected' | 'reason' | 'record_id'>> } }> }, readonly idiomaticUsageReason: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'data' | 'order'>> } }> }, readonly writingStyle: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> } };
-
-type HeadQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type HeadQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'author' | 'ogimage'>> }> };
+type PageListQuery = { readonly childPageAllMdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'description' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> } }> } };
 
 type SearchQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type SearchQuery = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'hierarchy' | 'slug'>> }> } };
+
+type BasicConceptTableQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type BasicConceptTableQuery = { readonly basicConceptData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
 
 type FooterQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -3027,6 +3034,11 @@ type FooterQuery = { readonly concept: { readonly nodes: ReadonlyArray<(
       & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> }
     )> } };
 
+type IdiomaticUsageTableQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type IdiomaticUsageTableQuery = { readonly idiomaticUsageData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'label' | 'ng_example' | 'ok_example' | 'expected' | 'reason' | 'record_id'>> } }> }, readonly idiomaticUsageReason: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'data' | 'order'>> } }> }, readonly writingStyle: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'data' | 'record_id'>> } }> } };
+
 type ArticleQueryVariables = Exact<{
   id: Maybe<Scalars['String']>;
   category: Maybe<Scalars['String']>;
@@ -3038,5 +3050,15 @@ type ArticleQuery = { readonly mdx: Maybe<(
     Pick<Mdx, 'id' | 'body'>
     & { readonly headings: Maybe<ReadonlyArray<Maybe<Pick<MdxHeadingMdx, 'depth' | 'value'>>>>, readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'description' | 'smarthr_ui'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'hierarchy' | 'slug'>> }
   )>, readonly parentCategoryAllMdx: { readonly edges: ReadonlyArray<{ readonly node: { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title' | 'order'>>, readonly fields: Maybe<Pick<MdxFields, 'category' | 'slug'>> } }> }, readonly airTable: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
+
+type HeadQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type HeadQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'author' | 'ogimage'>> }> };
+
+type AppWritingTableQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type AppWritingTableQuery = { readonly appWritingData: { readonly edges: ReadonlyArray<{ readonly node: { readonly data: Maybe<Pick<AirtableData, 'name' | 'description' | 'discussion' | 'source' | 'record_id' | 'order'>> } }> } };
 
 }

--- a/src/components/article/PageIndex/PageIndex.tsx
+++ b/src/components/article/PageIndex/PageIndex.tsx
@@ -7,6 +7,7 @@ import { CSS_FONT_SIZE } from '@Constants/style'
 type Props = {
   children: React.ReactNode
   path: string
+  heading?: 'h2' | 'h3'
   excludes?: string[]
 }
 
@@ -29,7 +30,7 @@ const query = graphql`
   }
 `
 
-export const PageIndex: VFC<Props> = ({ path, excludes, children }) => {
+export const PageIndex: VFC<Props> = ({ path, excludes, heading = 'h2', children }) => {
   const currentDepth = path.split('/').length
   const data = useStaticQuery<GatsbyTypes.PageListQuery>(query)
   const pageData = data.childPageAllMdx.edges
@@ -73,7 +74,7 @@ export const PageIndex: VFC<Props> = ({ path, excludes, children }) => {
           const itemName = item.pathList[item.pathList.length - 2]
           return (
             <React.Fragment key={idx}>
-              <PageTitle>
+              <PageTitle as={heading}>
                 <Link to={item.slug}>{item.title}</Link>
               </PageTitle>
               {injectedDescriptions[itemName] ? (

--- a/src/components/article/PageIndex/PageIndex.tsx
+++ b/src/components/article/PageIndex/PageIndex.tsx
@@ -1,0 +1,100 @@
+import { Link, graphql, useStaticQuery } from 'gatsby'
+import React, { VFC } from 'react'
+import styled from 'styled-components'
+import { CSS_FONT_SIZE } from '@Constants/style'
+
+type Props = {
+  children: React.ReactNode
+  path: string
+  excludes?: string[]
+}
+
+const query = graphql`
+  query PageList {
+    childPageAllMdx: allMdx {
+      edges {
+        node {
+          frontmatter {
+            title
+            description
+            order
+          }
+          fields {
+            slug
+          }
+        }
+      }
+    }
+  }
+`
+
+export const PageIndex: VFC<Props> = ({ path, excludes, children }) => {
+  const currentDepth = path.split('/').length
+  const data = useStaticQuery<GatsbyTypes.PageListQuery>(query)
+  const pageData = data.childPageAllMdx.edges
+    .map(({ node }) => {
+      const slug = node.fields?.slug || ''
+      const pathList = slug.split('/')
+      return {
+        title: node.frontmatter?.title || '',
+        description: node.frontmatter?.description || '',
+        order: node.frontmatter?.order || Number.MAX_SAFE_INTEGER,
+        slug: slug,
+        pathList: pathList,
+      }
+    })
+    .filter((item) => {
+      //子ページではない場合は除外
+      if (!item.slug.match(`^${path}`) || item.pathList.length !== currentDepth + 1) return false
+      //propsで指定された除外リストに入っていた場合も除外
+      if (excludes?.includes(item.pathList[item.pathList.length - 2])) return false
+      return true
+    })
+    .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
+
+  const injectedDescriptions: { [key: string]: string } = {}
+  React.Children.toArray(children)
+    .filter((child: any) => {
+      return child.props?.mdxType === 'Description'
+    })
+    .forEach((child: any) => {
+      injectedDescriptions[child.props?.name] = child.props.children
+    })
+
+  return (
+    <Wrapper>
+      <PageList>
+        {pageData.map((item, idx: number) => {
+          const itemName = item.pathList[item.pathList.length - 2]
+          return (
+            <li key={idx}>
+              <PageTitle>
+                <Link to={item.slug}>{item.title}</Link>
+              </PageTitle>
+              <PageDescription>{injectedDescriptions[itemName] || item.description}</PageDescription>
+            </li>
+          )
+        })}
+      </PageList>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+  margin-block: 4rem;
+`
+
+const PageList = styled.ul`
+  padding: 0;
+  list-style: none;
+  > li {
+    margin-bottom: 2rem;
+  }
+`
+
+const PageTitle = styled.div`
+  font-size: ${CSS_FONT_SIZE.PX_20};
+  font-weight: bold;
+`
+
+const PageDescription = styled.div``

--- a/src/components/article/PageIndex/PageIndex.tsx
+++ b/src/components/article/PageIndex/PageIndex.tsx
@@ -80,7 +80,9 @@ export const PageIndex: VFC<Props> = ({ path, excludes, heading = 'h2', children
               {injectedDescriptions[itemName] ? (
                 <PageDescription dangerouslySetInnerHTML={{ __html: injectedDescriptions[itemName] }} />
               ) : (
-                <PageDescription>{item.description}</PageDescription>
+                <PageDescription>
+                  <p>{item.description}</p>
+                </PageDescription>
               )}
             </React.Fragment>
           )

--- a/src/components/article/PageIndex/PageIndex.tsx
+++ b/src/components/article/PageIndex/PageIndex.tsx
@@ -72,7 +72,7 @@ export const PageIndex: VFC<Props> = ({ path, excludes, children }) => {
         {pageData.map((item, idx: number) => {
           const itemName = item.pathList[item.pathList.length - 2]
           return (
-            <li key={idx}>
+            <React.Fragment key={idx}>
               <PageTitle>
                 <Link to={item.slug}>{item.title}</Link>
               </PageTitle>
@@ -81,7 +81,7 @@ export const PageIndex: VFC<Props> = ({ path, excludes, children }) => {
               ) : (
                 <PageDescription>{item.description}</PageDescription>
               )}
-            </li>
+            </React.Fragment>
           )
         })}
       </PageList>
@@ -93,7 +93,7 @@ const Wrapper = styled.div`
   margin-block: 4rem;
 `
 
-const PageList = styled.ul`
+const PageList = styled.div`
   padding: 0;
   list-style: none;
   > li {
@@ -101,9 +101,18 @@ const PageList = styled.ul`
   }
 `
 
-const PageTitle = styled.div`
+const PageTitle = styled.h2`
   font-size: ${CSS_FONT_SIZE.PX_20};
   font-weight: bold;
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
 `
 
 const PageDescription = styled.div``

--- a/src/components/article/PageIndex/index.ts
+++ b/src/components/article/PageIndex/index.ts
@@ -1,0 +1,1 @@
+export { PageIndex } from './PageIndex'


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/969

## やったこと
- 指定されたパス（slug）の子ページのインデックス（リンク＋Description）を表示するコンポーネントを追加しました
  - コンポーネント本体→ `/src/components/article/PageIndex/PageIndex.tsx`
  - 試しにコンポーネントを配置したページ→ `/content/articles/products/contents/index.mdx`

### 仕様  
- `path` propsに`/products/contents/`のように指定すると、その子ページの一覧を表示します
  - 表示順やページ名は各ページのfrontmatterから取得します
- `excludes` propsに指定されたページは除外します
- `<Description />`タグで指定された文字列があればそれを、なければfrontmatterのdescriptionを表示します
  - `<Description />`タグ内の文字列は、マークダウンとして変換します。改行を入れたい場合は`{'\n'}`を入力します。（コード内の改行では反映されません。）
 
### TextLintについて
また、`/content/articles/products/contents/index.mdx`では、コメントによってTextLintが無効になっていたようですが、今回の`<Description />`タグなどが引っかかることはなさそうだったので、再度有効にしてみました。2点テキストを修正しましたが問題なさそうでしょうか？
```
リリースノートの目的と書く時 -> リリースノートの目的と書くとき
気になる点がある場合は 社内Slack -> 気になる点がある場合は、社内Slack
```

## やらなかったこと
- 子ページのみで、孫ページ以下は表示しません
- 現在のページ（https://smarthr.design/products/contents/ ）では、「UIテキスト」「エラーメッセージ」の2つは`h4`になっていて文字が小さいですが、今回の実装では文字サイズは全て同じになっています。（サイズ指定が必要であればpropsを追加するなどの対応を考えたいです。）

## 動作確認
https://deploy-preview-115--smarthr-design-system.netlify.app/products/contents/

## キャプチャ
![image](https://user-images.githubusercontent.com/7822534/173292971-ac48e01d-9596-48da-9be1-8f734662457a.png)


