### PR TITLE
「次へ」ナビゲーションの改良、関連する不具合の修正

### DIFF
--- a/src/components/index/Faq/FaqItem.tsx
+++ b/src/components/index/Faq/FaqItem.tsx
@@ -1,7 +1,8 @@
 import React, { VFC } from 'react'
-import { Link } from 'gatsby'
 import styled from 'styled-components'
-import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
+import { CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
+
+import { RoundedBoxLink } from '@Components/shared/RoundedBoxLink'
 
 type FaqJsonObject = {
   question: string
@@ -21,12 +22,7 @@ export const FaqItem: VFC<Props> = ({ data }) => {
     <Wrapper>
       <QuestionText>{data.question}</QuestionText>
       <AnswerText>{data.answer}</AnswerText>
-      <DetailLink to={data.path}>
-        <p>もっと詳しく</p>
-        <StyledText>
-          <span>{data.linkLabel}</span>
-        </StyledText>
-      </DetailLink>
+      <RoundedBoxLink path={data.path} label="もっと詳しく" title={data.linkLabel} />
     </Wrapper>
   )
 }
@@ -47,62 +43,7 @@ const QuestionText = styled.h3`
 `
 
 const AnswerText = styled.p`
-  margin: 8px 0 0;
+  margin: 8px 0 24px;
   font-size: ${CSS_FONT_SIZE.PX_16};
   line-height: 1.75;
-`
-
-const DetailLink = styled(Link)`
-  display: block;
-  margin: 24px 0 0;
-  padding: 24px;
-  border: solid 1px ${CSS_COLOR.LIGHT_GREY_1};
-  border-radius: 12px;
-  font-size: ${CSS_FONT_SIZE.PX_14};
-  font-weight: bold;
-  line-height: 1.4;
-  text-decoration: none;
-  transition: background-color 1.5s cubic-bezier(0, 0.7, 0, 1);
-  > p {
-    margin: 0 0 8px;
-    letter-spacing: 0.1rem;
-    color: ${CSS_COLOR.TEXT_BLACK};
-  }
-  &:hover {
-    transition: background-color 0.2s;
-    background-color: ${CSS_COLOR.LIGHT_GREY_2};
-    border-color: ${CSS_COLOR.TEXT_GREY};
-  }
-`
-
-const StyledText = styled.div`
-  display: block;
-  color: ${CSS_COLOR.MAIN_DARKEN};
-  > span {
-    display: inline-block;
-    position: relative;
-    padding-right: 1.8em;
-    border-bottom: solid 1px currentColor;
-    ${DetailLink}:hover & {
-      border-bottom-color: transparent;
-    }
-    &::after {
-      content: '';
-      display: block;
-      position: absolute;
-      width: 0.8em;
-      height: 0.8em;
-      top: 50%;
-      right: 0;
-      transform: translateY(-50%);
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE1Ljg3MiA3LjMzNzAzTDAgMC42MDMwMjdWMi4wODUwM0wxNC4yNiA4LjAxMzAzTDAgMTMuOTE1VjE1LjM5N0wxNS44NzIgOC42NjMwM1Y3LjMzNzAzWiIgZmlsbD0iIzAwNjVBOSIvPgo8L3N2Zz4K');
-      background-size: contain;
-      background-repeat: no-repeat;
-      transition: transform 1.5s cubic-bezier(0, 0.7, 0, 1);
-      ${DetailLink}:hover & {
-        transition: transform 0.2s;
-        transform: translateY(-50%) translateX(4px);
-      }
-    }
-  }
 `

--- a/src/components/shared/RoundedBoxLink/RoundedBoxLink.tsx
+++ b/src/components/shared/RoundedBoxLink/RoundedBoxLink.tsx
@@ -1,0 +1,77 @@
+import React, { VFC } from 'react'
+import { Link } from 'gatsby'
+import styled from 'styled-components'
+import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
+
+type Props = {
+  path: string
+  label: string
+  title: string
+  align?: 'left' | 'center' | 'right'
+  caretPosition?: 'left' | 'right'
+}
+
+export const RoundedBoxLink: VFC<Props> = ({ path, label, title, align = 'left', caretPosition = 'right' }) => {
+  return (
+    <BoxLink to={path} align={align} caret={caretPosition}>
+      <p className="labelText">{label}</p>
+      <div className="linkText">
+        <span>{title}</span>
+      </div>
+    </BoxLink>
+  )
+}
+
+const BoxLink = styled(Link)<{ align: 'left' | 'center' | 'right'; caret: 'left' | 'right' }>`
+  display: block;
+  padding: 24px;
+  border: solid 1px ${CSS_COLOR.LIGHT_GREY_1};
+  border-radius: 12px;
+  font-size: ${CSS_FONT_SIZE.PX_14};
+  font-weight: bold;
+  line-height: 1.4;
+  text-decoration: none;
+  text-align: ${({ align }) => align};
+  transition: background-color 1.5s cubic-bezier(0, 0.7, 0, 1);
+  > .labelText {
+    margin: 0 0 8px;
+    letter-spacing: 0.1rem;
+    color: ${CSS_COLOR.TEXT_BLACK};
+  }
+  .linkText {
+    display: inline-block;
+    color: ${CSS_COLOR.MAIN_DARKEN};
+    position: relative;
+    padding-left: ${({ caret }) => (caret === 'left' ? '1.8em' : 0)};
+    padding-right: ${({ caret }) => (caret === 'left' ? 0 : '1.8em')};
+    border-bottom: solid 1px currentColor;
+    &::after {
+      content: '';
+      display: block;
+      position: absolute;
+      width: 0.8em;
+      height: 0.8em;
+      top: 50%;
+      right: ${({ caret }) => (caret === 'left' ? 'auto' : 0)};
+      left: ${({ caret }) => (caret === 'left' ? 0 : 'auto')};
+      transform: ${({ caret }) => (caret === 'left' ? 'translateY(-50%) rotate(180deg)' : 'translateY(-50%)')};
+      background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE1Ljg3MiA3LjMzNzAzTDAgMC42MDMwMjdWMi4wODUwM0wxNC4yNiA4LjAxMzAzTDAgMTMuOTE1VjE1LjM5N0wxNS44NzIgOC42NjMwM1Y3LjMzNzAzWiIgZmlsbD0iIzAwNjVBOSIvPgo8L3N2Zz4K');
+      background-size: contain;
+      background-repeat: no-repeat;
+      transition: transform 1.5s cubic-bezier(0, 0.7, 0, 1);
+    }
+  }
+  &:hover {
+    transition: background-color 0.2s;
+    background-color: ${CSS_COLOR.LIGHT_GREY_2};
+    border-color: ${CSS_COLOR.TEXT_GREY};
+    .linkText {
+      border-bottom-color: transparent;
+      &::after {
+        transition: transform 0.2s;
+        transform: ${({ caret }) =>
+          caret === 'left' ? 'translateY(-50%) rotate(180deg) translateX(4px)' : 'translateY(-50%) translateX(4px)'};
+      }
+    }
+  }
+`

--- a/src/components/shared/RoundedBoxLink/index.tsx
+++ b/src/components/shared/RoundedBoxLink/index.tsx
@@ -1,0 +1,1 @@
+export { RoundedBoxLink } from './RoundedBoxLink'

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -12,11 +12,11 @@ import { FragmentTitle } from '@Components/article/FragmentTitle/FragmentTitle'
 import { INDEXED_DEPTH } from '@Constants/application'
 import { GlobalStyle } from '@Components/shared/GlobalStyle/GlobalStyle'
 import { Header } from '@Components/shared/Header/Header'
+import { RoundedBoxLink } from '@Components/shared/RoundedBoxLink'
 import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import { Private } from '@Components/shared/Private'
 import { SmartHRUIMetaInfo } from '@Components/SmartHRUIMetaInfo'
 import { Footer } from '@Components/shared/Footer/Footer'
-import { FloatingTextLink } from '@Components/shared/FloatingTextLink'
 
 import { AIRTABLE_CONTENTS } from '@Constants/airtable'
 import type { airtableContents } from '@Constants/airtable'
@@ -184,7 +184,7 @@ const Article: VFC<Props> = ({ data }) => {
   const headingList = [...airTableHeadings, ...mdxHeadings]
 
   //
-  // サイドバー、「次へ」コンポーネントのための配列作成
+  // サイドバー、「前へ」「次へ」コンポーネントのための配列作成
   //
 
   // 1. Maybe型を排除して
@@ -266,7 +266,7 @@ const Article: VFC<Props> = ({ data }) => {
   }
 
   //
-  // 次のページのindexを準備
+  // 前・次のページのindexを準備
   //
   const currentPageIndex = sidebarItems.findIndex(({ link }) => {
     // hierarchyはfrontmatterで定義されている値ではなく、
@@ -274,7 +274,8 @@ const Article: VFC<Props> = ({ data }) => {
     return link === `/${fields!.hierarchy!}/`
   })
 
-  // 同カテゴリ最後のページの場合はnullになる
+  // 同カテゴリ最初or最後のページの場合はnullになる
+  const prevPageIndex: number | null = currentPageIndex <= 0 ? null : currentPageIndex - 1
   const nextPageIndex: number | null = currentPageIndex === sidebarItems.length - 1 ? null : currentPageIndex + 1
 
   return (
@@ -305,12 +306,31 @@ const Article: VFC<Props> = ({ data }) => {
               </MDXProvider>
             </MDXStyledWrapper>
 
-            {/* 次へ表示 */}
-            {nextPageIndex !== null && (
-              <FloatingTextLinkOuter>
-                <FloatingTextLink path={sidebarItems[nextPageIndex].link}>次へ</FloatingTextLink>
-              </FloatingTextLinkOuter>
-            )}
+            {/* 前へ・次へ表示 */}
+            <MainArticleNav>
+              {prevPageIndex !== null && (
+                <PrevArticleLink>
+                  <RoundedBoxLink
+                    path={sidebarItems[prevPageIndex].link}
+                    label="前へ"
+                    title={sidebarItems[prevPageIndex].title}
+                    align="left"
+                    caretPosition="left"
+                  />
+                </PrevArticleLink>
+              )}
+              {nextPageIndex !== null && (
+                <NextArticleLink>
+                  <RoundedBoxLink
+                    path={sidebarItems[nextPageIndex].link}
+                    label="次へ"
+                    title={sidebarItems[nextPageIndex].title}
+                    align="right"
+                    caretPosition="right"
+                  />
+                </NextArticleLink>
+              )}
+            </MainArticleNav>
           </MainArticle>
         </Main>
 
@@ -421,6 +441,29 @@ const MainArticleTitle = styled.div`
   }
 `
 
+const MainArticleNav = styled.ul`
+  list-style: none;
+  margin-block: 5rem;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template: 'left right' 1fr/50%;
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+    grid-template:
+      'left' 1fr
+      'right' 1fr
+      /100%;
+  }
+`
+
+const PrevArticleLink = styled.li`
+  grid-area: left;
+`
+
+const NextArticleLink = styled.li`
+  grid-area: right;
+`
+
 /* MarkDownで書き出されるコンテンツ用のスタイル */
 const MDXStyledWrapper = styled.div`
   /* 画像 */
@@ -509,8 +552,4 @@ const MDXStyledWrapper = styled.div`
     width: 100%;
     max-width: 100%;
   }
-`
-const FloatingTextLinkOuter = styled.div`
-  margin-top: 120px;
-  text-align: right;
 `

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -225,13 +225,13 @@ const Article: VFC<Props> = ({ data }) => {
   depth2Items.sort(({ order: a }, { order: b }) => {
     return a - b
   })
-  depth3Items.sort(({ order: a }, { order: b }) => {
-    return a - b
+  depth3Items.sort((a, b) => {
+    // プロダクト/コンポーネントは名前の順でソートする
+    if (a.link.includes('/products/components/') && b.link.includes('/products/components/')) {
+      return a.title < b.title ? -1 : a.title > b.title ? 1 : 0
+    }
+    return a.order - b.order
   })
-  if (slug.includes('/products/components')) {
-    // プロダクト/コンポーネントは名前の順
-    depth3Items.sort(({ title: a }, { title: b }) => (a < b ? -1 : a > b ? 1 : 0))
-  }
   depth4Items.sort(({ order: a }, { order: b }) => {
     return a - b
   })

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -447,7 +447,7 @@ const MainArticleNav = styled.ul`
   padding: 0;
   display: grid;
   gap: 1rem;
-  grid-template: 'left right' 1fr/50%;
+  grid-template: 'left right' 1fr/1fr 1fr;
   @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     grid-template:
       'left' 1fr


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/952

## やったこと
各記事ページ下部の「次へ」ナビゲーションを改良しました。
- ページタイトルの追加
- UIをトップ＞よくある質問と同じに（コンポーネントも共通化しました→ `/src/components/shared/RoundedBoxLink`)
  - コンポーネント名にもっと良さそうなものがあれば変えたいです
- 「前へ」も追加

また、ページの並び順について、プロダクト→コンポーネント 以下のページのみ、frontmatterの`order`ではなくページタイトル（＝コンポーネントの名前）順にするのが正しいかと思いますが、プロダクト→コンポーネント以外のページでは`order`順になってしまっていたため、修正しました。（左サイドバーの開閉メニューを実装した際に考慮が漏れていました。）

## 動作確認
https://deploy-preview-123--smarthr-design-system.netlify.app/concept/about/
https://deploy-preview-123--smarthr-design-system.netlify.app/products/contents/

## キャプチャ
**ナビゲーション**
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/173738357-bc6d4e9e-7c40-4881-946c-c290ec2f0b3b.png" alt="" width="350"> | <img src="https://user-images.githubusercontent.com/7822534/173738398-c8687532-5272-4edf-8864-bc37cbba59e1.png" width="350" alt=""> |

**コンポーネントの並び順修正**
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/173738978-631e7a24-1ee1-4876-bb5e-8f3278aebb4a.png" width="350" alt=""> | <img src="https://user-images.githubusercontent.com/7822534/173738939-0936b03f-5ca3-4ba8-8fe5-13092dd9abb6.png" width="350" alt=""> |
