### PR TITLE
Storybookのiframeリサイズ機能をJSベースのものに置き換え

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -6,6 +6,8 @@ import { SHRUI_GITHUB_RAW, SHRUI_STORYBOOK_IFRAME } from '@Constants/application
 import { CSS_COLOR } from '@Constants/style'
 import { CodeBlock } from '../article/CodeBlock'
 
+import { ResizableContainer } from './ResizableContainer'
+
 type Props = {
   name: string
 }
@@ -132,10 +134,10 @@ export const ComponentStory: VFC<Props> = ({ name }) => {
         })}
       </Tab>
       {currentIFrame !== '' && (
-        <IFrameWrapper>
+        <ResizableContainer defaultWidth="100%" defaultHeight="300px">
           <StoryLoader className={isIFrameLoaded ? '' : '-show'} />
           {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-          <iframe
+          <StoryIframe
             title={
               storyItems.find((item) => {
                 return item.name === currentIFrame
@@ -143,8 +145,8 @@ export const ComponentStory: VFC<Props> = ({ name }) => {
             }
             src={`${SHRUI_STORYBOOK_IFRAME}?id=${getStoryName(name, currentIFrame)}`}
             onLoad={() => setIsIFrameLoaded(true)}
-          ></iframe>
-        </IFrameWrapper>
+          />
+        </ResizableContainer>
       )}
       <CodeWrapper>
         <StoryLoader className={isCodeLoaded ? '' : '-show'} />
@@ -160,22 +162,10 @@ const Tab = styled(TabBar)`
   gap: 4px 0;
 `
 
-const IFrameWrapper = styled.div`
-  position: relative;
+const StoryIframe = styled.iframe`
   width: 100%;
-  height: 300px;
-  margin-block: 16px 0;
-  padding-bottom: 10px; /* Safariで右下のリサイズUIがスクロールバーで隠れてしまうため、下部を空けておく */
-  border: solid 1px ${CSS_COLOR.LIGHT_GREY_1};
-  border-bottom: 0;
-  resize: vertical;
-  box-sizing: border-box;
-  overflow: hidden;
-  > iframe {
-    width: 100%;
-    height: 100%;
-    border: 0;
-  }
+  height: 100%;
+  border: 0;
 `
 
 const StoryLoader = styled(Loader)`

--- a/src/components/ComponentStory/ResizableContainer.tsx
+++ b/src/components/ComponentStory/ResizableContainer.tsx
@@ -1,0 +1,154 @@
+import React, { VFC, useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
+import { FaGripLinesIcon, FaGripLinesVerticalIcon } from 'smarthr-ui'
+
+import { CSS_COLOR } from '@Constants/style'
+
+type Props = {
+  defaultWidth?: string
+  defaultHeight?: string
+  children: React.ReactNode
+}
+
+export const ResizableContainer: VFC<Props> = ({ defaultWidth, defaultHeight, children }) => {
+  const [pointerPosition, setPointerPosition] = useState<{ x: number | null; y: number | null }>({ x: null, y: null })
+  const pointerPositionRef = useRef<{ x: number | null; y: number | null }>({ x: null, y: null })
+  pointerPositionRef.current = pointerPosition
+
+  const [boxSize, setBoxSize] = useState<{ width: number | null; height: number | null }>({ width: null, height: null })
+  const boxSizeRef = useRef<{ width: number | null; height: number | null }>({ width: null, height: null })
+  boxSizeRef.current = boxSize
+
+  const container = useRef<HTMLDivElement>(null)
+
+  const handleVerticalPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    setPointerPosition({ x: event.clientX, y: null })
+    if (typeof window !== undefined) {
+      document.addEventListener('pointermove', handlePointerMove, false)
+      document.addEventListener('pointerup', handlePointerUp, false)
+    }
+  }
+
+  const handleHorizontalPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    setPointerPosition({ x: null, y: event.clientY })
+    if (typeof window !== undefined) {
+      document.addEventListener('pointermove', handlePointerMove, false)
+      document.addEventListener('pointerup', handlePointerUp, false)
+    }
+  }
+
+  const handlePointerUp = () => {
+    setPointerPosition({ x: null, y: null })
+    if (typeof window !== undefined) {
+      document.removeEventListener('pointermove', handlePointerMove, false)
+      document.removeEventListener('pointerup', handlePointerUp, false)
+    }
+  }
+
+  const handlePointerMove = (event: PointerEvent) => {
+    if (container.current === null) return
+    //幅変更の場合
+    if (pointerPositionRef.current.x !== null) {
+      const containerWidth = container.current.offsetWidth
+      const newWidth = (boxSizeRef.current.width || containerWidth) - (pointerPositionRef.current.x - event.clientX)
+      if (containerWidth < newWidth) return
+      setPointerPosition({ x: event.clientX, y: null })
+      setBoxSize({ width: newWidth, height: boxSizeRef.current.height })
+    }
+
+    //高さ変更の場合
+    if (pointerPositionRef.current.y !== null) {
+      const containerHeight = container.current.offsetHeight
+      const newHeight = (boxSizeRef.current.height || containerHeight) - (pointerPositionRef.current.y - event.clientY)
+      setPointerPosition({ x: null, y: event.clientY })
+      setBoxSize({ width: boxSizeRef.current.width, height: newHeight })
+    }
+  }
+
+  const handleWindowResize = () => {
+    if (container.current === null || boxSizeRef.current.width === null) return
+
+    //中身の横幅がコンテナより長くなった場合は、デフォルトに戻す
+    if (boxSizeRef.current.width !== null && container.current.offsetWidth < boxSizeRef.current.width) {
+      setBoxSize({ width: null, height: boxSizeRef.current.height })
+    }
+  }
+
+  useEffect(() => {
+    if (typeof window !== undefined) {
+      window.addEventListener('resize', handleWindowResize)
+    }
+
+    return () => {
+      window.removeEventListener('resize', handleWindowResize)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <Container ref={container}>
+      <ResizeArea
+        style={{
+          width: boxSize.width === null ? defaultWidth || '100%' : `${boxSize.width}px`,
+          height: boxSize.height === null ? defaultHeight || '300px' : `${boxSize.height}px`,
+        }}
+        // ドラッグ中かどうかのフラグ。中身のiframeに`pointer-events: none`を追加しないとマウスイベントが取れなくなるため。
+        data-resizing={pointerPosition.x || pointerPosition.y ? 'true' : 'false'}
+      >
+        {children}
+        <VerticalResizeHandler onPointerDown={handleVerticalPointerDown}>
+          <FaGripLinesVerticalIcon visuallyHiddenText="ドラッグして幅を変更" />
+        </VerticalResizeHandler>
+        <HorizontalResizeHandler onPointerDown={handleHorizontalPointerDown}>
+          <FaGripLinesIcon visuallyHiddenText="ドラッグして高さを変更" />
+        </HorizontalResizeHandler>
+      </ResizeArea>
+    </Container>
+  )
+}
+
+const Container = styled.div``
+
+const ResizeArea = styled.div`
+  position: relative;
+  max-width: 100%;
+  margin-block: 16px 0;
+  padding: 0 16px 16px 0;
+  border: solid 1px ${CSS_COLOR.LIGHT_GREY_1};
+  border-bottom: 0;
+  box-sizing: border-box;
+  overflow: hidden;
+  &[data-resizing='true'] {
+    iframe {
+      pointer-events: none;
+    }
+  }
+`
+
+const VerticalResizeHandler = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  width: 16px;
+  height: 100%;
+  top: 0;
+  right: 0;
+  background: ${CSS_COLOR.LIGHT_GREY_1};
+  color: ${CSS_COLOR.TEXT_GREY};
+  cursor: col-resize;
+`
+
+const HorizontalResizeHandler = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+  height: 16px;
+  bottom: 0;
+  left: 0;
+  background: ${CSS_COLOR.LIGHT_GREY_1};
+  color: ${CSS_COLOR.TEXT_GREY};
+  cursor: row-resize;
+`


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/973

## やったこと
今までは、高さのみ簡易的にCSSの`resize`でリサイズできるようにしてありましたが、JSベースのUIに置き換えて幅もリサイズできるようになりました。

JSのコードがそれなりの量になるので、リサイズ機能の部分を新たにコンポーネントにしています（`/src/components/ComponentStory/ResizableContainer.tsx`）。

## やらなかったこと
現状、スマートフォンサイズの場合もそのまま同じUIが出てきますが、ある程度幅が狭くなったら非表示にするなどしたほうがいいでしょうか？
一応、iPhoneでもリサイズできることは確認していますが、高さのほうはページ自体のスクロール動作と重なるため、あまり実用的ではなさそうです（何か調整すればもう少し使いやすくできるかもしれませんが）。

## 動作確認
https://deploy-preview-124--smarthr-design-system.netlify.app/products/components/accordion-panel/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/174230421-6d1d04c6-416a-4ad3-bd8a-e2dca1883127.png" width="350" alt=""> | <img src="https://user-images.githubusercontent.com/7822534/174230400-20e29200-301e-41aa-b213-0e38b996a473.png" width="350" alt=""> |