### PR TITLE
GitHub ActionsでのChromaticビルドを追加

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,23 @@
+name: Deploy to Chromatic
+
+on:
+  push:
+    branches-ignore:
+      - 'renovate/*'
+
+jobs:
+  chromatic-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-engines
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        # Options required to the GitHub Chromatic Action
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitZeroOnChanges: true # Option to prevent the workflow from failing


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/927

## やったこと
GitHub ActionsからChromaticのビルドが自動実行されるように`.github/workflows/chromatic.yml`を追加しました。

- 基本的には[Chromaticのドキュメント](https://www.chromatic.com/docs/github-actions)にある推奨設定を採用しました
  - yarnのインストールコマンドはNetlifyのものと同じにしています（`yarn install --frozen-lockfile --ignore-engines`）
  - `renovate/*`ブランチは除外しています
  - `actions/checkout`は最新のv3にしています（Chromaticのドキュメントにはv1、v2の例しかありませんが、そうするとrenovateがv3を提案してくると思われるので）

## 動作確認
[Actions -> chromatic.yml](https://github.com/kufu/smarthr-design-system/actions/workflows/chromatic.yml)やChromaticのダッシュボードで確認できます。

## キャプチャ
Webページの挙動や見た目に影響はないはずです。