### PR TITLE
Gotchaの画像まわりの余白が出ないよう調整

### DIFF
--- a/src/components/index/Gotcha.tsx
+++ b/src/components/index/Gotcha.tsx
@@ -155,31 +155,49 @@ const Wrapper = styled.div`
 const Heading = styled.div`
   position: relative;
   width: 100%;
-  height: calc((100vw - 160px) / 1272 * 352);
-  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
-    height: calc((100vw - 32px) / 1272 * 352);
-  }
-  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
-    height: calc(100vw / 1272 * 352);
+  aspect-ratio: 1272 / 352;
+  @supports not (aspect-ratio: 1272 / 352) {
+    height: calc((100vw - 160px) / 1272 * 352);
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+      height: calc((100vw - 32px) / 1272 * 352);
+    }
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+      height: calc(100vw / 1272 * 352);
+    }
   }
 `
 
 const ImageContainer = styled.div`
+  position: relative;
   width: 100%;
   height: 100%;
-  border: solid 1px ${CSS_COLOR.SMARTHR_BLUE};
   border-radius: 4px;
   background-color: ${CSS_COLOR.SMARTHR_BLUE};
   overflow: hidden;
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: solid 1px ${CSS_COLOR.SMARTHR_BLUE};
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
   @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
-    border-left: 0;
-    border-right: 0;
     border-radius: 0;
+    &::after {
+      border-radius: 0;
+      border-left: none;
+      border-right: none;
+    }
   }
   img {
     width: 100%;
     height: 100%;
-    object-fit: contain;
+    object-fit: cover;
     transform: translateY(-100%);
   }
   &.runAnimation {
@@ -214,7 +232,7 @@ const GotchaButton = styled.button`
   height: 36px;
   padding: 0;
   position: absolute;
-  bottom: -6px;
+  bottom: -4px;
   left: 40px;
   font-weight: bold;
 
@@ -356,6 +374,7 @@ const Label = styled.p`
   right: 40px;
   top: 100%;
   margin: 0;
+  margin-top: -2px;
   color: ${CSS_COLOR.TEXT_GREY};
   font-weight: bold;
   font-size: ${CSS_FONT_SIZE.PX_12};


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/978

## やったこと
- `vw`を使って`height`を計算せず、`aspect-ratio`プロパティを使うように変更しました。
  - `aspect-ratio`をサポートしていない環境（主にSafari14以前）用には、`@supports not(...)`ルールで以前と同じ`height`の計算をするようにフォールバックしています。

また、そもそも上下のボーダーが太く見えていたのは、正確にはボーダーと画像の隙間から背景色（同じ水色）が見えていることが原因なのですが、上記の対応をしても画像が拡大・縮小される都合上、若干の余白が出てしまうポイント（画面幅）があるようでした。そこで、
- 画像に`object-fit: contain;`を指定していたが、`cover`に変更（画像の縦横比が表示エリアと異なる場合に画像が切れないようにという意図だったが、全て表示エリアに合わせたサイズになっているようなので。）
- 画像の周りに1pxのボーダーをつけていたが、`::after`疑似要素を利用して画像の上に1pxのボーダーを重ねる方法に変更　→ 1px未満の余白であればボーダーの下に隠れる

としてみました。Figmaでは画像に対して`inset`でボーダーが指定されていたので、それに近い表示にもなったかと思います。


## 動作確認
https://deploy-preview-141--smarthr-design-system.netlify.app/

## キャプチャ

**aspect-ratioに変更Before/After**
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/175224460-c095da15-4f64-48be-af5d-b6b98574c74d.png" alt="" width="350"> | <img src="https://user-images.githubusercontent.com/7822534/175224484-9f431b1b-a976-4107-9cc3-ccfec4d47214.png" width="350" alt=""> |

**さらにボーダーを画像の上に重ねるBefore/After**
スクリーンショットを拡大したものです。
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/175224952-7d94f5d0-cc44-4fe5-8254-4be2fb040bfe.png" alt="" width="350"> | <img src="https://user-images.githubusercontent.com/7822534/175225288-5dd52ca6-5034-419f-bf76-5476982e6159.png" width="350" alt=""> |