### PR TITLE
Storybookに別画面で開くリンクを追加、ヘッダーを追加

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -12,6 +12,7 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  layout: 'fullscreen',
 }
 
 const theme = createTheme()

--- a/content/articles/products/design-patterns/DesignPatternCodeBlock.tsx
+++ b/content/articles/products/design-patterns/DesignPatternCodeBlock.tsx
@@ -1,5 +1,5 @@
 import React, { VFC } from 'react'
-import { CodeBlock } from '../../../../src/components/article/CodeBlock'
+import { CodeBlock } from '@Components/article/CodeBlock'
 import * as Components from './components'
 
 type Props = {

--- a/content/articles/products/design-patterns/select-company-account/SelectCompanyAccount.stories.tsx
+++ b/content/articles/products/design-patterns/select-company-account/SelectCompanyAccount.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { Header } from 'smarthr-ui'
+
 import { ComponentMeta } from '@storybook/react'
 import { SelectCompanyAccount as StoryComponent } from './SelectCompanyAccount'
 
@@ -10,4 +12,14 @@ export const SelectCompanyAccount = () => {
 export default {
   title: 'SelectCompanyAccount',
   component: SelectCompanyAccount,
+  decorators: [
+    (Story) => (
+      <>
+        <Header />
+        <div style={{ padding: '1rem' }}>
+          <Story />
+        </div>
+      </>
+    ),
+  ],
 } as ComponentMeta<typeof SelectCompanyAccount>

--- a/src/components/ComponentPreview/WrapperBase.tsx
+++ b/src/components/ComponentPreview/WrapperBase.tsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components'
 
 export const WrapperBase = styled.div(
   ({ theme: { border, color, space } }) => css`
-    margin-block-start: ${space(1)};
+    margin-block-start: ${space(0.5)};
     border: ${border.shorthand};
     background-color: ${color.WHITE};
     font-family: system-ui, sans-serif;

--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -1,6 +1,6 @@
 import React, { VFC, useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { Loader, TabBar, TabItem } from 'smarthr-ui'
+import { Loader, TabBar, TabItem, TextLink } from 'smarthr-ui'
 
 import { SHRUI_GITHUB_RAW, SHRUI_STORYBOOK_IFRAME } from '@Constants/application'
 import { CSS_COLOR } from '@Constants/style'
@@ -134,19 +134,26 @@ export const ComponentStory: VFC<Props> = ({ name }) => {
         })}
       </Tab>
       {currentIFrame !== '' && (
-        <ResizableContainer defaultWidth="100%" defaultHeight="300px">
-          <StoryLoader className={isIFrameLoaded ? '' : '-show'} />
-          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-          <StoryIframe
-            title={
-              storyItems.find((item) => {
-                return item.name === currentIFrame
-              })?.label || ''
-            }
-            src={`${SHRUI_STORYBOOK_IFRAME}?id=${getStoryName(name, currentIFrame)}`}
-            onLoad={() => setIsIFrameLoaded(true)}
-          />
-        </ResizableContainer>
+        <>
+          <LinkWrapper>
+            <TextLink href={`${SHRUI_STORYBOOK_IFRAME}?id=${getStoryName(name, currentIFrame)}&viewMode=story`} target="_blank">
+              別画面で開く
+            </TextLink>
+          </LinkWrapper>
+          <ResizableContainer defaultWidth="100%" defaultHeight="300px">
+            <StoryLoader className={isIFrameLoaded ? '' : '-show'} />
+            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+            <StoryIframe
+              title={
+                storyItems.find((item) => {
+                  return item.name === currentIFrame
+                })?.label || ''
+              }
+              src={`${SHRUI_STORYBOOK_IFRAME}?id=${getStoryName(name, currentIFrame)}`}
+              onLoad={() => setIsIFrameLoaded(true)}
+            />
+          </ResizableContainer>
+        </>
       )}
       <CodeWrapper>
         <StoryLoader className={isCodeLoaded ? '' : '-show'} />
@@ -160,6 +167,12 @@ const Tab = styled(TabBar)`
   margin-block: 48px 0;
   flex-wrap: wrap;
   gap: 4px 0;
+`
+
+const LinkWrapper = styled.div`
+  margin-block: 16px 0;
+  font-size: 0.8rem;
+  text-align: right;
 `
 
 const StoryIframe = styled.iframe`

--- a/src/components/ComponentStory/ResizableContainer.tsx
+++ b/src/components/ComponentStory/ResizableContainer.tsx
@@ -112,7 +112,7 @@ const Container = styled.div``
 const ResizeArea = styled.div`
   position: relative;
   max-width: 100%;
-  margin-block: 16px 0;
+  margin-block: 8px 0;
   padding: 0 16px 16px 0;
   border: solid 1px ${CSS_COLOR.LIGHT_GREY_1};
   border-bottom: 0;

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -8,6 +8,7 @@ import { LiveEditor, LiveError, LivePreview, LiveProvider, LiveProviderProps } f
 import ts, { transpile } from 'typescript'
 import { ComponentPreview } from '../../ComponentPreview'
 import * as ui from 'smarthr-ui'
+import { SDS_STORYBOOK_IFRAME } from '@Constants/application'
 import { CSS_COLOR } from '@Constants/style'
 import { CopyButton } from './CopyButton'
 import { Gap, SeparateGap } from 'smarthr-ui/lib/components/Layout/type'
@@ -59,10 +60,17 @@ export const CodeBlock: VFC<Props> = ({
 
   // Storybookとのコード共通化のため、childrenで渡ってくるコードには`render()`が含まれていない。LivePreviewでコンポーネントのレンダリングが必要な場合には、末尾に追加する。
   const code = renderingComponent ? `${children.trim()}\nrender(<${renderingComponent} />)` : children.trim()
-
+  const TextLink = ui.TextLink
   if (editable) {
     return (
       <Wrapper>
+        {renderingComponent && (
+          <LinkWrapper>
+            <TextLink href={`${SDS_STORYBOOK_IFRAME}?id=${renderingComponent.toLowerCase()}&viewMode=story`} target="_blank">
+              別画面で開く
+            </TextLink>
+          </LinkWrapper>
+        )}
         <ThemeProvider theme={smarthrTheme}>
           <LiveProvider
             code={code}
@@ -116,6 +124,11 @@ export const CodeBlock: VFC<Props> = ({
 
 const Wrapper = styled.div`
   margin-block: 16px 0;
+`
+
+const LinkWrapper = styled.div`
+  font-size: 0.8rem;
+  text-align: right;
 `
 
 const PreContainer = styled.pre`

--- a/src/constants/application.ts
+++ b/src/constants/application.ts
@@ -8,3 +8,5 @@ import packageInfo from 'smarthr-ui/package.json'
 
 export const SHRUI_GITHUB_RAW = `https://raw.githubusercontent.com/kufu/smarthr-ui/v${packageInfo.version}`
 export const SHRUI_STORYBOOK_IFRAME = 'https://smarthr-ui.netlify.app/iframe.html'
+
+export const SDS_STORYBOOK_IFRAME = `https://62992322cdff0a004aaf9263-zpcbasolhc.chromatic.com/iframe.html`


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/974

## やったこと
iframeで埋め込んでいるsmarthr-uiのStorybook、ライブプレビューを実装しているデザインパターンのStorybookの両方に、別画面で開くリンクテキストを追加しました。
また、デザインパターンのStorybookにヘッダーを追加しました。

ヘッダーはStorybookのdecoratorで追加して見ました。ひとまずグローバルなdecorator（`/.storybook/preview.js`）には追加せず、コンポーネントのほう（`SelectCompanyAccount.stories.tsx`）に入れました。また、`body`に`padding`がついていたのですが、ヘッダーの周囲に余白がないほうがいいかと考えて`fullscreen`に変更しています。

## 動作確認

https://deploy-preview-152--smarthr-design-system.netlify.app/products/components/accordion-panel/
https://deploy-preview-152--smarthr-design-system.netlify.app/products/design-patterns/select-company-account/
（↑こちらの別画面で開く、のリンク先はmainブランチのStorybookなのでヘッダーはないです。）

https://62992322cdff0a004aaf9263-yqiexbohnn.chromatic.com/?path=/story/selectcompanyaccount--select-company-account
（↑このPRのChromaticのプレビューはこちら）

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/176076600-0acb27ce-a00b-41df-b799-6910d1916f98.png" width="350" alt=""> | <img src="https://user-images.githubusercontent.com/7822534/176076742-e2c4be8d-ad45-42e1-b20d-d2f3e699df5a.png" width="350" alt=""> |

