### PR TITLE
英単語が改行途中で折り返されてしまうのを防ぐ

### DIFF
--- a/src/components/shared/GlobalStyle/GlobalStyle.tsx
+++ b/src/components/shared/GlobalStyle/GlobalStyle.tsx
@@ -15,7 +15,6 @@ export const GlobalStyle = createGlobalStyle`
     font-family: Yu Gothic Medium, 游ゴシック Medium, YuGothic, 游ゴシック体, sans-serif;
     line-height: ${defaultLeading.RELAXED};
     color: ${defaultColor.TEXT_BLACK};
-    word-break: break-all;
   }
 
   /* stylelint-disable */
@@ -27,6 +26,7 @@ export const GlobalStyle = createGlobalStyle`
   a {
     color: ${defaultColor.TEXT_LINK};
     text-decoration: underline;
+    overflow-wrap: break-word;
   }
 
   table {


### PR DESCRIPTION
## 課題・背景

Global Style に `word-break: break-all;` が指定されているので、改行位置によっては英単語が途中で折り返されてしまう。

```
具体的には「JIS X 8341-3:2016 高齢者・障害者等配慮設計指針－情報通信における
機器、ソフトウェア及びサービス－第3部：ウェブコンテンツ」、に加えて「Web C
ontent Accessibility Guidelines 2.1」に対応することを目標としています。
```

<img width="643" alt="折り返されているスクショ。ContentのCの次に改行が入っている。" src="https://user-images.githubusercontent.com/6724665/176619462-c477d3ff-6fd3-48e6-83fb-e73c9a8afe87.png">

## やったこと

- グローバルスタイルから `word-break: break-all;` を削除
- リンク文字列まんまなリンクが折り返されないので、 `<a>` に `overflow-wrap: break-word` を指定。

## やらなかったこと
- 

## 動作確認
- word-break: break-all が無いと崩れるところがあればご指摘を…

## キャプチャ

|Before|After|
| --- | --- |
| <img width="643" alt="折り返されているスクショ。ContentのCの次に改行が入っている。" src="https://user-images.githubusercontent.com/6724665/176619462-c477d3ff-6fd3-48e6-83fb-e73c9a8afe87.png"> | <img width="637" alt="Screen Shot 2022-06-30 at 16 35 25" src="https://user-images.githubusercontent.com/6724665/176620054-cf6413d5-4924-4faf-bc9e-c38e188acf34.png"> |

Content が始まる前で折り返されるようになります。