### PR TITLE
テキストの折り返しが必要な部分のCSSを調整

### DIFF
--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -63,8 +63,11 @@ const Thumbnail = styled.div<{
 const Informations = styled.div``
 const ColorName = styled.div`
   font-weight: bold;
+  word-break: break-all;
 `
-const ColorCode = styled.div``
+const ColorCode = styled.div`
+  word-break: break-all;
+`
 const ColorContrast: VFC<{ fgColor: string; bgColor: string }> = ({ fgColor, bgColor }) => {
   const contrastRatio = Math.round(Color(convertHexToRGBA(fgColor)).contrast(Color(convertHexToRGBA(bgColor))) * 100) / 100
   const score = contrastRatio >= 7 ? 'AAA' : contrastRatio >= 4.5 ? 'AA' : contrastRatio >= 3 ? 'AA+' : 'Fail'
@@ -72,4 +75,6 @@ const ColorContrast: VFC<{ fgColor: string; bgColor: string }> = ({ fgColor, bgC
   return <p>{`${contrastRatio} (${score})`}</p>
 }
 
-const Description = styled.p``
+const Description = styled.p`
+  word-break: break-all;
+`

--- a/src/components/shared/GlobalStyle/GlobalStyle.tsx
+++ b/src/components/shared/GlobalStyle/GlobalStyle.tsx
@@ -41,5 +41,6 @@ export const GlobalStyle = createGlobalStyle`
   table td {
     box-sizing: border-box;
     padding: 0.5rem 1rem;
+    word-break: break-all;
   }
 `


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/992

## やったこと
ColorPaletteコンポーネント、グローバルCSSのテーブルセル（`th`、`td`）に`word-break: break-all;`を追加しました。

- ColorPalette：PC表示では4カラムでの表示になっていて幅が狭いので、文字列部分に`word-break: break-all;`を追加しました。
- テーブルセル：URLが入る場合などにテーブルが中央カラムからはみ出しているケースがあったため、グローバルCSSの`th, td`に`word-break: break-all;`を追加しました。

## やらなかったこと
以前はグローバルCSSに`word-break: break-all;`があったこともあり、テーブルについては一律に指定してしまいましたが、例えば`th > a, td > a`にする、個別に指定する、などでも良いかもしれません。

## 動作確認
https://deploy-preview-170--smarthr-design-system.netlify.app/products/design-tokens/color/#h2-3
https://deploy-preview-170--smarthr-design-system.netlify.app/downloads/#h2-1

## キャプチャ
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/177289301-aa0ec218-f569-4b85-989f-154ba2fc6b44.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/177289780-7ea3542e-0da7-423a-9ee8-2792301c11b9.png" width="350" alt> |
| <img src="https://user-images.githubusercontent.com/7822534/177289154-3fe20a03-238e-4907-91d6-f2ebe55d7f90.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/177289099-fe93ed61-fc20-47c6-a4c0-85ece6ad7c65.png" width="350" alt> |