### PR TITLE
smarthr-uiで非推奨となったtable関連のコンポーネントを置き換え

### DIFF
--- a/content/articles/accessibility/policy.mdx
+++ b/content/articles/accessibility/policy.mdx
@@ -4,7 +4,7 @@ description: 'SmartHRのウェブアクセシビリティ方針です。社会�
 order: 1
 ---
 
-import { Table, Body, Head, Row, Cell, Text } from 'smarthr-ui'
+import { Table, Text, Td, Th } from 'smarthr-ui'
 
 ## 社会の非合理をつくりださない
 
@@ -64,41 +64,41 @@ SmartHRは「[社会の非合理を、ハックする。](https://smarthr.co.jp/
 ### SmartHR UIのスケジュール
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>
+  <thead>
+    <tr>
+      <Th>
         時期
-      </Cell>
-      <Cell>
+      </Th>
+      <Th>
         目標
-      </Cell>
-      <Cell>
+      </Th>
+      <Th>
         結果
-      </Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell> <time datatime="2021-06" style="white-space: nowrap">2021年6月</time> </Cell>
-      <Cell> レベルA一部準拠 <div><small>開発中のコンポーネント、または試験開始時点で完成していなかったコンポーネントをのぞく</small></div> </Cell>
-      <Cell> レベルA一部準拠 </Cell>
-    </Row>
-    <Row>
-      <Cell> <time datatime="2021-12" style="white-space: nowrap">2021年12月</time> </Cell>
-      <Cell> レベルA準拠 </Cell>
-      <Cell> レベルA一部準拠 </Cell>
-    </Row>
-    <Row>
-      <Cell> <time datatime="2022-06" style="white-space: nowrap">2022年6月</time> </Cell>
-      <Cell> JIS X 8341-3:2016 レベルAと追加する達成基準に準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Cell>
-      <Cell></Cell>
-    </Row>
-    <Row>
-      <Cell> <time datatime="2022-12" style="white-space: nowrap">2022年12月</time> </Cell>
-      <Cell> JIS X 8341-3:2016 レベルAAに準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Cell>
-      <Cell></Cell>
-    </Row>
-  </Body>
+      </Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td> <time datatime="2021-06" style="white-space: nowrap">2021年6月</time> </Td>
+      <Td> レベルA一部準拠 <div><small>開発中のコンポーネント、または試験開始時点で完成していなかったコンポーネントをのぞく</small></div> </Td>
+      <Td> レベルA一部準拠 </Td>
+    </tr>
+    <tr>
+      <Td> <time datatime="2021-12" style="white-space: nowrap">2021年12月</time> </Td>
+      <Td> レベルA準拠 </Td>
+      <Td> レベルA一部準拠 </Td>
+    </tr>
+    <tr>
+      <Td> <time datatime="2022-06" style="white-space: nowrap">2022年6月</time> </Td>
+      <Td> JIS X 8341-3:2016 レベルAと追加する達成基準に準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
+      <Td></Td>
+    </tr>
+    <tr>
+      <Td> <time datatime="2022-12" style="white-space: nowrap">2022年12月</time> </Td>
+      <Td> JIS X 8341-3:2016 レベルAAに準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
+      <Td></Td>
+    </tr>
+  </tbody>
 </Table>
 
 ### SmartHR 製品の目標とスケジュール
@@ -110,42 +110,42 @@ SmartHRは「[社会の非合理を、ハックする。](https://smarthr.co.jp/
 ## 試験結果
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>試験年月</Cell>
-      <Cell>試験対象</Cell>
-      <Cell>達成した等級</Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell>
+  <thead>
+    <tr>
+      <Th>試験年月</Th>
+      <Th>試験対象</Th>
+      <Th>達成した等級</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>
         <a href="../test/202105/">
           <time datatime="2021-05" style={{ whiteSpace: "no-wrap" }}>2021年5月</time>
         </a>
-      </Cell>
-      <Cell>
+      </Td>
+      <Td>
         SmartHR UIのコンポーネント
         <small>（開発中のコンポーネントを除く）</small>
-      </Cell>
-      <Cell>
+      </Td>
+      <Td>
         レベルA一部準拠
-      </Cell>
-    </Row>
-    <Row>
-      <Cell>
+      </Td>
+    </tr>
+    <tr>
+      <Td>
         <a href="../test/202112/">
           <time datatime="2021-12" style={{ whiteSpace: "no-wrap" }}>2021年12月</time>
         </a>
-      </Cell>
-      <Cell>
+      </Td>
+      <Td>
         SmartHR UIのコンポーネント
-      </Cell>
-      <Cell>
+      </Td>
+      <Td>
         レベルA一部準拠
-      </Cell>
-    </Row>
-  </Body>
+      </Td>
+    </tr>
+  </tbody>
 </Table>
 
 ## 問い合わせ先

--- a/content/articles/accessibility/test/202105/index.mdx
+++ b/content/articles/accessibility/test/202105/index.mdx
@@ -4,7 +4,7 @@ description: '2021年5月に実施したSmartHRのウェブアクセシビリテ
 order: 1
 ---
 
-import { Table, Body, Head, Row, Cell, DefinitionList } from 'smarthr-ui'
+import { Table, Td, Th, DefinitionList } from 'smarthr-ui'
 
 <!-- textlint-disable -->
 
@@ -59,191 +59,191 @@ import { Table, Body, Head, Row, Cell, DefinitionList } from 'smarthr-ui'
 達成基準のリンクは<abbr title="Web Contents Accessibility Guidelines">WCAG</abbr> 2.0解説書へのリンクです。
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>達成基準</Cell>
-      <Cell>等級</Cell>
-      <Cell>適用</Cell>
-      <Cell>結果</Cell>
-    </Row>
-  </Head>
-  <Body>
+  <thead>
+    <tr>
+      <Th>達成基準</Th>
+      <Th>等級</Th>
+      <Th>適用</Th>
+      <Th>結果</Th>
+    </tr>
+  </thead>
+  <tbody>
 
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/text-equiv-all.html">1.1.1 非テキストコンテンツ</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-av-only-alt.html">1.2.1 音声だけ及び映像だけ（収録済み）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-captions.html">1.2.2 キャプション（収録済み）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-audio-desc.html">1.2.3 音声解説又はメディアに対する代替コンテンツ（収録済み）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html">1.3.1 情報及び関係性</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html">1.3.2 意味のある順序</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-understanding.html">1.3.3 感覚的な特徴</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/use-of-color.html">1.4.1 色の使用</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/visual-audio-contrast-dis-audio.html">1.4.2 音声の制御</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/contrast-minimum.html">1.4.3 コントラスト（最低限）</a></Cell>
-    <Cell>AA</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/resize-text.html">1.4.4 テキストのサイズ変更</a></Cell>
-    <Cell>AA</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/images-of-text.html">1.4.5 文字画像</a></Cell>
-    <Cell>AA</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/keyboard.html">2.1.1 キーボード</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/no-keyboard-trap.html">2.1.2 キーボードトラップなし</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/time-limits-required-behaviors.html">2.2.1 タイミング調整可能</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/time-limits-pause.html">2.2.2 一時停止、停止、非表示</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/seizure-does-not-violate.html">2.3.1 3回のせん（閃）光、又はしきい（閾）値以下</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html">2.4.1 ブロックスキップ</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html">2.4.2 ページタイトル</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/focus-order.html">2.4.3 フォーカス順序</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/link-purpose-in-context.html">2.4.4 リンクの目的（コンテキスト内）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/focus-visible.html">2.4.7 フォーカスの可視化</a></Cell>
-    <Cell>AA</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/meaning-doc-lang-id.html">3.1.1 ページの言語</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/on-focus.html">3.2.1 フォーカス時</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/on-input.html">3.2.2 入力時</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/error-identification.html">3.3.1 エラーの特定</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/labels-or-instructions.html">3.3.2 ラベル又は説明</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/parsing.html">4.1.1 構文解析</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/name-role-value.html">4.1.2 名前（name），役割（role）及び値（value）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-  </Body>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/text-equiv-all.html">1.1.1 非テキストコンテンツ</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-av-only-alt.html">1.2.1 音声だけ及び映像だけ（収録済み）</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-captions.html">1.2.2 キャプション（収録済み）</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-audio-desc.html">1.2.3 音声解説又はメディアに対する代替コンテンツ（収録済み）</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html">1.3.1 情報及び関係性</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html">1.3.2 意味のある順序</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-understanding.html">1.3.3 感覚的な特徴</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/use-of-color.html">1.4.1 色の使用</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/visual-audio-contrast-dis-audio.html">1.4.2 音声の制御</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/contrast-minimum.html">1.4.3 コントラスト（最低限）</a></Td>
+    <Td>AA</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/resize-text.html">1.4.4 テキストのサイズ変更</a></Td>
+    <Td>AA</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/images-of-text.html">1.4.5 文字画像</a></Td>
+    <Td>AA</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/keyboard.html">2.1.1 キーボード</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/no-keyboard-trap.html">2.1.2 キーボードトラップなし</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/time-limits-required-behaviors.html">2.2.1 タイミング調整可能</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/time-limits-pause.html">2.2.2 一時停止、停止、非表示</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/seizure-does-not-violate.html">2.3.1 3回のせん（閃）光、又はしきい（閾）値以下</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html">2.4.1 ブロックスキップ</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html">2.4.2 ページタイトル</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/focus-order.html">2.4.3 フォーカス順序</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/link-purpose-in-context.html">2.4.4 リンクの目的（コンテキスト内）</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/focus-visible.html">2.4.7 フォーカスの可視化</a></Td>
+    <Td>AA</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/meaning-doc-lang-id.html">3.1.1 ページの言語</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/on-focus.html">3.2.1 フォーカス時</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/on-input.html">3.2.2 入力時</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/error-identification.html">3.3.1 エラーの特定</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/labels-or-instructions.html">3.3.2 ラベル又は説明</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/parsing.html">4.1.1 構文解析</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/name-role-value.html">4.1.2 名前（name），役割（role）及び値（value）</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+  </tbody>
 </Table>
 
 - 「2.4.2 ページタイトル」および「3.1.1 ページの言語」は、ページが検証対象ではないため該当箇所なしとした。

--- a/content/articles/accessibility/test/202112/index.mdx
+++ b/content/articles/accessibility/test/202112/index.mdx
@@ -4,7 +4,7 @@ description: '2021年12月に実施したSmartHRのウェブアクセシビリ�
 order: 1
 ---
 
-import { Table, Body, Head, Row, Cell, DefinitionList } from 'smarthr-ui'
+import { Table, Td, Th, DefinitionList } from 'smarthr-ui'
 
 ## 試験概要
 
@@ -66,191 +66,191 @@ import { Table, Body, Head, Row, Cell, DefinitionList } from 'smarthr-ui'
 達成基準のリンクは<abbr title="Web Contents Accessibility Guidelines">WCAG</abbr> 2.0解説書へのリンクです。
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>達成基準</Cell>
-      <Cell>等級</Cell>
-      <Cell>適用</Cell>
-      <Cell>結果</Cell>
-    </Row>
-  </Head>
-  <Body>
+  <thead>
+    <tr>
+      <Th>達成基準</Th>
+      <Th>等級</Th>
+      <Th>適用</Th>
+      <Th>結果</Th>
+    </tr>
+  </thead>
+  <tbody>
 
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/text-equiv-all.html">1.1.1 非テキストコンテンツ</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-av-only-alt.html">1.2.1 音声だけ及び映像だけ（収録済み）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-captions.html">1.2.2 キャプション（収録済み）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-audio-desc.html">1.2.3 音声解説又はメディアに対する代替コンテンツ（収録済み）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html">1.3.1 情報及び関係性</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html">1.3.2 意味のある順序</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-understanding.html">1.3.3 感覚的な特徴</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/use-of-color.html">1.4.1 色の使用</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/visual-audio-contrast-dis-audio.html">1.4.2 音声の制御</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/contrast-minimum.html">1.4.3 コントラスト（最低限）</a></Cell>
-    <Cell>AA</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/resize-text.html">1.4.4 テキストのサイズ変更</a></Cell>
-    <Cell>AA</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/images-of-text.html">1.4.5 文字画像</a></Cell>
-    <Cell>AA</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/keyboard.html">2.1.1 キーボード</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/no-keyboard-trap.html">2.1.2 キーボードトラップなし</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/time-limits-required-behaviors.html">2.2.1 タイミング調整可能</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/time-limits-pause.html">2.2.2 一時停止、停止、非表示</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/seizure-does-not-violate.html">2.3.1 3回のせん（閃）光、又はしきい（閾）値以下</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html">2.4.1 ブロックスキップ</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html">2.4.2 ページタイトル</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/focus-order.html">2.4.3 フォーカス順序</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/link-purpose-in-context.html">2.4.4 リンクの目的（コンテキスト内）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/focus-visible.html">2.4.7 フォーカスの可視化</a></Cell>
-    <Cell>AA</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/meaning-doc-lang-id.html">3.1.1 ページの言語</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/on-focus.html">3.2.1 フォーカス時</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/on-input.html">3.2.2 入力時</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/error-identification.html">3.3.1 エラーの特定</a></Cell>
-    <Cell>A</Cell>
-    <Cell>－</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/labels-or-instructions.html">3.3.2 ラベル又は説明</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/parsing.html">4.1.1 構文解析</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>○</Cell>
-</Row>
-<Row>
-    <Cell><a href="https://waic.jp/docs/WCAG21/Understanding/name-role-value.html">4.1.2 名前（name），役割（role）及び値（value）</a></Cell>
-    <Cell>A</Cell>
-    <Cell>○</Cell>
-    <Cell>×</Cell>
-</Row>
-  </Body>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/text-equiv-all.html">1.1.1 非テキストコンテンツ</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-av-only-alt.html">1.2.1 音声だけ及び映像だけ（収録済み）</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-captions.html">1.2.2 キャプション（収録済み）</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/media-equiv-audio-desc.html">1.2.3 音声解説又はメディアに対する代替コンテンツ（収録済み）</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html">1.3.1 情報及び関係性</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html">1.3.2 意味のある順序</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-understanding.html">1.3.3 感覚的な特徴</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/use-of-color.html">1.4.1 色の使用</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/visual-audio-contrast-dis-audio.html">1.4.2 音声の制御</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/contrast-minimum.html">1.4.3 コントラスト（最低限）</a></Td>
+    <Td>AA</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/resize-text.html">1.4.4 テキストのサイズ変更</a></Td>
+    <Td>AA</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/images-of-text.html">1.4.5 文字画像</a></Td>
+    <Td>AA</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/keyboard.html">2.1.1 キーボード</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/no-keyboard-trap.html">2.1.2 キーボードトラップなし</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/time-limits-required-behaviors.html">2.2.1 タイミング調整可能</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/time-limits-pause.html">2.2.2 一時停止、停止、非表示</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/seizure-does-not-violate.html">2.3.1 3回のせん（閃）光、又はしきい（閾）値以下</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html">2.4.1 ブロックスキップ</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html">2.4.2 ページタイトル</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/focus-order.html">2.4.3 フォーカス順序</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/link-purpose-in-context.html">2.4.4 リンクの目的（コンテキスト内）</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/focus-visible.html">2.4.7 フォーカスの可視化</a></Td>
+    <Td>AA</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/meaning-doc-lang-id.html">3.1.1 ページの言語</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/on-focus.html">3.2.1 フォーカス時</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/on-input.html">3.2.2 入力時</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/error-identification.html">3.3.1 エラーの特定</a></Td>
+    <Td>A</Td>
+    <Td>－</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/labels-or-instructions.html">3.3.2 ラベル又は説明</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/parsing.html">4.1.1 構文解析</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>○</Td>
+</tr>
+<tr>
+    <Td><a href="https://waic.jp/docs/WCAG21/Understanding/name-role-value.html">4.1.2 名前（name），役割（role）及び値（value）</a></Td>
+    <Td>A</Td>
+    <Td>○</Td>
+    <Td>×</Td>
+</tr>
+  </tbody>
 </Table>
 
 - 「2.4.2 ページタイトル」および「3.1.1 ページの言語」は、ページが検証対象ではないため該当箇所なしとした。

--- a/content/articles/operational-guideline/page-template/style-template.mdx
+++ b/content/articles/operational-guideline/page-template/style-template.mdx
@@ -4,7 +4,7 @@ description: 'ページの概要はヘッダーに書けます。ページの概
 order: 1
 ---
 
-import { Body, Button, Cell, Cluster, FaPlusCircleIcon, Head, LineUp, Row, Stack, Table, Text } from 'smarthr-ui'
+import { Button, Cluster, FaPlusCircleIcon, LineUp, Stack, Table, Td, Th, Text } from 'smarthr-ui'
 import { ComponentPreview } from '@Components/ComponentPreview'
 import { DoAndDont } from '@Components/DoAndDont'
 import { StaticImage } from '@Components/StaticImage'
@@ -74,29 +74,29 @@ import { StaticImage } from '@Components/StaticImage'
 ### SmartHR UI テーブル
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>thead</Cell>
-      <Cell>thead</Cell>
-      <Cell>thead</Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell>cell</Cell>
-      <Cell>cell</Cell>
-      <Cell>
+  <thead>
+    <tr>
+      <Th>thead</Th>
+      <Th>thead</Th>
+      <Th>thead</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>cell</Td>
+      <Td>cell</Td>
+      <Td>
         <Button variant="primary">Button</Button>
-      </Cell>
-    </Row>
-    <Row>
-      <Cell>cell</Cell>
-      <Cell>cell</Cell>
-      <Cell>
+      </Td>
+    </tr>
+    <tr>
+      <Td>cell</Td>
+      <Td>cell</Td>
+      <Td>
         <Button variant="primary">Button</Button>
-      </Cell>
-    </Row>
-  </Body>
+      </Td>
+    </tr>
+  </tbody>
 </Table>
 
 ## レイアウト

--- a/content/articles/products/components/dialog.mdx
+++ b/content/articles/products/components/dialog.mdx
@@ -8,16 +8,14 @@ order: 16
 import { useEffect, useState } from 'react'
 import {
   ActionDialog,
-  Body,
   Button,
-  Cell,
   CheckBox,
   Dialog,
-  Head,
   MessageDialog,
   ModelessDialog,
-  Row,
   Table,
+  Td,
+  Th
 } from 'smarthr-ui'
 import { ComponentPreview } from '@Components/ComponentPreview'
 import { ComponentStory } from '@Components/ComponentStory'
@@ -150,28 +148,28 @@ export const DynamicModelessDialog = () => {
           <ModelessContent>
             <Stack gap="S">
               <Table>
-                <Head>
-                  <Row>
-                    <Cell>
+                <thead>
+                  <tr>
+                    <Th>
                       <CheckBox />
-                    </Cell>
-                    <Cell>テーブル見出し1</Cell>
-                    <Cell>テーブル見出し2</Cell>
-                    <Cell>テーブル見出し3</Cell>
-                  </Row>
-                </Head>
-                <Body>
+                    </Th>
+                    <Th>テーブル見出し1</Th>
+                    <Th>テーブル見出し2</Th>
+                    <Th>テーブル見出し3</Th>
+                  </tr>
+                </thead>
+                <tbody>
                   {Array.from(Array(10).keys()).map((i) => (
-                    <Row key={i}>
-                      <Cell>
+                    <tr key={i}>
+                      <Td>
                         <CheckBox />
-                      </Cell>
-                      <Cell>データ1-{i}</Cell>
-                      <Cell>データ2-{i}</Cell>
-                      <Cell>データ3-{i}</Cell>
-                    </Row>
+                      </Td>
+                      <Td>データ1-{i}</Td>
+                      <Td>データ2-{i}</Td>
+                      <Td>データ3-{i}</Td>
+                    </tr>
                   ))}
-                </Body>
+                </tbody>
               </Table>
             </Stack>
           </ModelessContent>

--- a/content/articles/products/components/heading.mdx
+++ b/content/articles/products/components/heading.mdx
@@ -5,7 +5,7 @@ smarthr-ui: 'Heading'
 order: 25
 ---
 
-import { Body, Cell, Head, Heading, Row, Stack, Table } from 'smarthr-ui'
+import { Heading, Stack, Table, Td, Th } from 'smarthr-ui'
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 
@@ -40,116 +40,116 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
 画面のタイトルとして、画面ごとに1度しか使えません。
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>タイプ</Cell>
-      <Cell>フォントサイズ</Cell>
-      <Cell>ウェイト</Cell>
-      <Cell>色</Cell>
-      <Cell>サンプル</Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell>screenTitle</Cell>
-      <Cell><a href="/products/design-tokens/typography/">XL</a></Cell>
-      <Cell>normal</Cell>
-      <Cell><a href="/products/design-tokens/color/#h3-2">TEXT_BLACK</a></Cell>
-      <Cell><Heading type="screenTitle" tag="span">社会の非合理を、ハックする</Heading></Cell>
-    </Row>
-  </Body>
+  <thead>
+    <tr>
+      <Th>タイプ</Th>
+      <Th>フォントサイズ</Th>
+      <Th>ウェイト</Th>
+      <Th>色</Th>
+      <Th>サンプル</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>screenTitle</Td>
+      <Td><a href="/products/design-tokens/typography/">XL</a></Td>
+      <Td>normal</Td>
+      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_BLACK</a></Td>
+      <Td><Heading type="screenTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
+    </tr>
+  </tbody>
 </Table>
 
 ### セクションタイトル
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>タイプ</Cell>
-      <Cell>フォントサイズ</Cell>
-      <Cell>ウェイト</Cell>
-      <Cell>色</Cell>
-      <Cell>サンプル</Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell>sectionTitle</Cell>
-      <Cell><a href="/products/design-tokens/typography/">L</a></Cell>
-      <Cell>normal</Cell>
-      <Cell><a href="/products/design-tokens/color/#h3-2">TEXT_BLACK</a></Cell>
-      <Cell><Heading type="sectionTitle" tag="span">社会の非合理を、ハックする</Heading></Cell>
-    </Row>
-  </Body>
+  <thead>
+    <tr>
+      <Th>タイプ</Th>
+      <Th>フォントサイズ</Th>
+      <Th>ウェイト</Th>
+      <Th>色</Th>
+      <Th>サンプル</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>sectionTitle</Td>
+      <Td><a href="/products/design-tokens/typography/">L</a></Td>
+      <Td>normal</Td>
+      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_BLACK</a></Td>
+      <Td><Heading type="sectionTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
+    </tr>
+  </tbody>
 </Table>
 
 ### ブロックタイトル
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>タイプ</Cell>
-      <Cell>フォントサイズ</Cell>
-      <Cell>ウェイト</Cell>
-      <Cell>色</Cell>
-      <Cell>サンプル</Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell>blockTitle</Cell>
-      <Cell><a href="/products/design-tokens/typography/">M</a></Cell>
-      <Cell>bold</Cell>
-      <Cell><a href="/products/design-tokens/color/#h3-2">TEXT_BLACK</a></Cell>
-      <Cell><Heading type="blockTitle" tag="span">社会の非合理を、ハックする</Heading></Cell>
-    </Row>
-  </Body>
+  <thead>
+    <tr>
+      <Th>タイプ</Th>
+      <Th>フォントサイズ</Th>
+      <Th>ウェイト</Th>
+      <Th>色</Th>
+      <Th>サンプル</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>blockTitle</Td>
+      <Td><a href="/products/design-tokens/typography/">M</a></Td>
+      <Td>bold</Td>
+      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_BLACK</a></Td>
+      <Td><Heading type="blockTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
+    </tr>
+  </tbody>
 </Table>
 
 ### サブ・ブロックタイトル
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>タイプ</Cell>
-      <Cell>フォントサイズ</Cell>
-      <Cell>ウェイト</Cell>
-      <Cell>色</Cell>
-      <Cell>サンプル</Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell>subBlockTitle</Cell>
-      <Cell><a href="/products/design-tokens/typography/">M</a></Cell>
-      <Cell>bold</Cell>
-      <Cell><a href="/products/design-tokens/color/#h3-2">TEXT_GREY</a></Cell>
-      <Cell><Heading type="subBlockTitle" tag="span">社会の非合理を、ハックする</Heading></Cell>
-    </Row>
-  </Body>
+  <thead>
+    <tr>
+      <Th>タイプ</Th>
+      <Th>フォントサイズ</Th>
+      <Th>ウェイト</Th>
+      <Th>色</Th>
+      <Th>サンプル</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>subBlockTitle</Td>
+      <Td><a href="/products/design-tokens/typography/">M</a></Td>
+      <Td>bold</Td>
+      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_GREY</a></Td>
+      <Td><Heading type="subBlockTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
+    </tr>
+  </tbody>
 </Table>
 
 ### サブ・サブ・ブロックタイトル
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>タイプ</Cell>
-      <Cell>フォントサイズ</Cell>
-      <Cell>ウェイト</Cell>
-      <Cell>色</Cell>
-      <Cell>サンプル</Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell>subSubBlockTitle</Cell>
-      <Cell><a href="/products/design-tokens/typography/">S</a></Cell>
-      <Cell>bold</Cell>
-      <Cell><a href="/products/design-tokens/color/#h3-2">TEXT_GREY</a></Cell>
-      <Cell><Heading type="subSubBlockTitle" tag="span">社会の非合理を、ハックする</Heading></Cell>
-    </Row>
-  </Body>
+  <thead>
+    <tr>
+      <Th>タイプ</Th>
+      <Th>フォントサイズ</Th>
+      <Th>ウェイト</Th>
+      <Th>色</Th>
+      <Th>サンプル</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>subSubBlockTitle</Td>
+      <Td><a href="/products/design-tokens/typography/">S</a></Td>
+      <Td>bold</Td>
+      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_GREY</a></Td>
+      <Td><Heading type="subSubBlockTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
+    </tr>
+  </tbody>
 </Table>
 
 

--- a/content/articles/products/components/table.mdx
+++ b/content/articles/products/components/table.mdx
@@ -25,13 +25,13 @@ import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 参照には`<label>`を用いても良いですが、識別するためのテキストはオブジェクト詳細へのリンクとなることも多いため `aria-labelledby` を用いるのが良いでしょう。
 
 ```tsx
-<Row key={key}>
+<tr key={key}>
   <CheckBoxCell>
     <CheckBox aria-labelledby={object.id} />
   </CheckBoxCell>
-  <Cell>
+  <Td>
     <a href={`/hoge/${object.id}`} id={object.id}>{name}</a>
-  </Cell>
+  </Td>
   ...
-</Row>
+</tr>
 ```

--- a/content/articles/products/design-tokens/typography.mdx
+++ b/content/articles/products/design-tokens/typography.mdx
@@ -5,7 +5,7 @@ order: 2
 ---
 
 import { createTheme } from 'smarthr-ui'
-import { Table, Body, Head, Row, Cell } from 'smarthr-ui'
+import { Table, Td, Th } from 'smarthr-ui'
 
 
 export const Sampletext = ({size = 'M', children}) => {
@@ -78,25 +78,25 @@ font-family: system-ui, sans-serif;
 サイズ小の積極的な使用は避け、レイアウトの都合上、どうしようもない場合に使います。
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>種類</Cell>
-      <Cell>フォントサイズ</Cell>
-      <Cell>サンプル</Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell>標準</Cell>
-      <Cell>M</Cell>
-      <Cell><Sampletext size={'M'}>社会の非合理を、ハックする。</Sampletext></Cell>
-    </Row>
-    <Row>
-      <Cell>サイズ小</Cell>
-      <Cell>S</Cell>
-      <Cell><Sampletext size={'S'}>社会の非合理を、ハックする。</Sampletext></Cell>
-    </Row>
-  </Body>
+  <thead>
+    <tr>
+      <Th>種類</Th>
+      <Th>フォントサイズ</Th>
+      <Th>サンプル</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>標準</Td>
+      <Td>M</Td>
+      <Td><Sampletext size={'M'}>社会の非合理を、ハックする。</Sampletext></Td>
+    </tr>
+    <tr>
+      <Td>サイズ小</Td>
+      <Td>S</Td>
+      <Td><Sampletext size={'S'}>社会の非合理を、ハックする。</Sampletext></Td>
+    </tr>
+  </tbody>
 </Table>
 
 
@@ -107,25 +107,25 @@ font-family: system-ui, sans-serif;
 サイズ小の積極的な使用は避け、レイアウトの都合上、どうしようもない場合に使います。
 
 <Table>
-  <Head>
-    <Row>
-      <Cell>種類</Cell>
-      <Cell>フォントサイズ</Cell>
-      <Cell>サンプル</Cell>
-    </Row>
-  </Head>
-  <Body>
-    <Row>
-      <Cell>標準</Cell>
-      <Cell>M</Cell>
-      <Cell><Sampletext size={'M'}>社会の非合理を、ハックする。</Sampletext></Cell>
-    </Row>
-    <Row>
-      <Cell>サイズ小</Cell>
-      <Cell>S</Cell>
-      <Cell><Sampletext size={'S'}>社会の非合理を、ハックする。</Sampletext></Cell>
-    </Row>
-  </Body>
+  <thead>
+    <tr>
+      <Th>種類</Th>
+      <Th>フォントサイズ</Th>
+      <Th>サンプル</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>標準</Td>
+      <Td>M</Td>
+      <Td><Sampletext size={'M'}>社会の非合理を、ハックする。</Sampletext></Td>
+    </tr>
+    <tr>
+      <Td>サイズ小</Td>
+      <Td>S</Td>
+      <Td><Sampletext size={'S'}>社会の非合理を、ハックする。</Sampletext></Td>
+    </tr>
+  </tbody>
 </Table>
 
 ### 表

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -1,6 +1,6 @@
 import React, { VFC } from 'react'
 import styled from 'styled-components'
-import { Body, Cell, Head, Row, Table, Text } from 'smarthr-ui'
+import { Table, Td, Text, Th } from 'smarthr-ui'
 import uiProps from '../../../smarthr-ui-props.json'
 import { FragmentTitle } from '../article/FragmentTitle/FragmentTitle'
 
@@ -44,18 +44,18 @@ export const ComponentPropsTable: VFC<Props> = ({ name, showTitle }) => {
       {propsData.length > 0 ? (
         <Wrapper>
           <Table>
-            <Head>
-              <Row>
-                <NameCell>Name</NameCell>
-                <RequiredCell>Required</RequiredCell>
-                <TypeCell>Type</TypeCell>
-                <DescriptionCell>Description</DescriptionCell>
-              </Row>
-            </Head>
-            <Body>
+            <thead>
+              <tr>
+                <Th>Name</Th>
+                <Th>Required</Th>
+                <Th>Type</Th>
+                <Th>Description</Th>
+              </tr>
+            </thead>
+            <tbody>
               {propsData.map((prop, i) => {
                 return (
-                  <Row key={i}>
+                  <tr key={i}>
                     <NameCell>
                       <strong>{prop.name}</strong>
                     </NameCell>
@@ -76,10 +76,10 @@ export const ComponentPropsTable: VFC<Props> = ({ name, showTitle }) => {
                       )}
                     </TypeCell>
                     <DescriptionCell>{prop.description}</DescriptionCell>
-                  </Row>
+                  </tr>
                 )
               })}
-            </Body>
+            </tbody>
           </Table>
         </Wrapper>
       ) : (
@@ -96,20 +96,20 @@ const Wrapper = styled.div`
     vertical-align: baseline;
   }
 `
-const NameCell = styled(Cell)`
+const NameCell = styled(Td)`
   white-space: nowrap;
 `
-const RequiredCell = styled(Cell)`
+const RequiredCell = styled(Td)`
   white-space: nowrap;
 `
-const TypeCell = styled(Cell)`
+const TypeCell = styled(Td)`
   min-width: 11em;
   width: 22em;
   & code {
     white-space: nowrap;
   }
 `
-const DescriptionCell = styled(Cell)`
+const DescriptionCell = styled(Td)`
   min-width: 22em;
   width: auto;
 `

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -1,7 +1,7 @@
 import React, { VFC } from 'react'
 import styled from 'styled-components'
 import { Link, graphql, useStaticQuery } from 'gatsby'
-import { Body, Cell, Head, Row, Table, Text } from 'smarthr-ui'
+import { Table, Td, Text, Th } from 'smarthr-ui'
 import { TextUrlToLink } from '../shared/TextUrlToLink'
 import { FragmentTitle } from '../../article/FragmentTitle/FragmentTitle'
 import { marked } from 'marked'
@@ -96,14 +96,14 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
       {type === 'data' && (
         <Wrapper>
           <Table>
-            <Head>
-              <Row>
-                <RecommendCell>推奨する表記</RecommendCell>
-                <NGCell>NG例</NGCell>
-                <ReasonCell>理由</ReasonCell>
-              </Row>
-            </Head>
-            <Body>
+            <thead>
+              <tr>
+                <Th>推奨する表記</Th>
+                <Th>NG例</Th>
+                <Th>理由</Th>
+              </tr>
+            </thead>
+            <tbody>
               {idiomaticUsageData.map((prop, index) => {
                 const matchReason = idiomaticUsageReason.find((reason) => prop.reason && prop.reason.includes(reason.recordId))
                 const matchWritingStyle = writingStyle.find((style) => style.data && style.data.includes(prop.recordId))
@@ -113,7 +113,7 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
                 // console.log(writingStyle)
 
                 return (
-                  <Row key={index}>
+                  <tr key={index}>
                     <RecommendCell>
                       <strong>{prop.okExample}</strong>
                     </RecommendCell>
@@ -136,10 +136,10 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
                         )}
                       </ul>
                     </ReasonCell>
-                  </Row>
+                  </tr>
                 )
               })}
-            </Body>
+            </tbody>
           </Table>
         </Wrapper>
       )}
@@ -196,14 +196,14 @@ const Wrapper = styled.div`
     vertical-align: baseline;
   }
 `
-const RecommendCell = styled(Cell)`
+const RecommendCell = styled(Td)`
   white-space: nowrap;
 `
-const NGCell = styled(Cell)`
+const NGCell = styled(Td)`
   min-width: 11em;
   width: 22em;
 `
-const ReasonCell = styled(Cell)`
+const ReasonCell = styled(Td)`
   min-width: 22em;
   width: auto;
 `


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/993

## やったこと
smarthr-uiの、`Body`、`Head`、`Row`、`Cell`が使われていた部分を、`tbody`、`thead`、`tr`と`Th`、`Td`に置き換えました。
また、プロダクト＞コンポーネント＞Tableコンポーネントのページのコード例も変更しました。

## 動作確認

https://deploy-preview-177--smarthr-design-system.netlify.app/accessibility/policy/
https://deploy-preview-177--smarthr-design-system.netlify.app/accessibility/test/202105/
https://deploy-preview-177--smarthr-design-system.netlify.app/accessibility/test/202112/
https://deploy-preview-177--smarthr-design-system.netlify.app/operational-guideline/page-template/style-template/
https://deploy-preview-177--smarthr-design-system.netlify.app/products/components/dialog/
https://deploy-preview-177--smarthr-design-system.netlify.app/products/components/heading/
https://deploy-preview-177--smarthr-design-system.netlify.app/products/components/table/
https://deploy-preview-177--smarthr-design-system.netlify.app/products/design-tokens/typography/
https://deploy-preview-177--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/

＋ /products/components/ 以下の各コンポーネントのPropsテーブル


## キャプチャ
見た目の変化はないはずです。
