### PR TITLE
子ページのリンクリストを表示するページで、PageIndexコンポーネントを使用するように変更

### DIFF
--- a/content/articles/operational-guideline/page-template/index.mdx
+++ b/content/articles/operational-guideline/page-template/index.mdx
@@ -4,11 +4,16 @@ description: ''
 order: 3
 ---
 
-## [スタイルテンプレート](/operational-guideline/page-template/style-template/)
-ページ（mdxファイル）のスタイル見本です。
+import { PageIndex } from '@Components/article/PageIndex'
 
-## [コンポーネントのテンプレート](/operational-guideline/page-template/component-template/)
-[プロダクトのコンポーネント](/products/components/)カテゴリのページを書く際のテンプレートです。
-
-## [デザインパターンのテンプレート](/operational-guideline/page-template/design-patterns-template/)
-[プロダクトのデザインパターン](/products/design-patterns/)カテゴリのページを書く際のテンプレートです。
+<PageIndex path="/operational-guideline/page-template/" excludes={[]} heading="h2">
+  <Description name="style-template">
+    ページ（mdxファイル）のスタイル見本です。
+  </Description>
+  <Description name="component-template">
+    [プロダクトのコンポーネント](/products/components/)カテゴリのページを書く際のテンプレートです。
+  </Description>
+  <Description name="design-patterns-template">
+    [プロダクトのデザインパターン](/products/design-patterns/)カテゴリのページを書く際のテンプレートです。
+  </Description>
+</PageIndex>

--- a/content/articles/products/design-process/index.mdx
+++ b/content/articles/products/design-process/index.mdx
@@ -4,12 +4,16 @@ description: ''
 order: 8
 ---
 
-## [デザインデータ（Figma）の作り方](/products/design-process/design-guide/)
-Figmaによるデザインデータ作成時のルールなどをまとめました。
+import { PageIndex } from '@Components/article/PageIndex'
 
-## [デザインレビューの手引](/products/design-process/review/)
-UIデザイン、デザインモックに対してのレビュー方法についてまとめた手引です。
-<!-- textlint-disable -->
-## [ユーザビリティテストの手引](/products/design-process/usability-test/)
-ユーザビリティテストを実施するうえで利用する資料をまとめています。
-<!-- textlint-disable -->
+<PageIndex path="/products/design-process/" excludes={[]} heading="h2">
+  <Description name="design-guide">
+    Figmaによるデザインデータ作成時のルールなどをまとめました。
+  </Description>
+  <Description name="review">
+    UIデザイン、デザインモックに対してのレビュー方法についてまとめた手引です。
+  </Description>
+  <Description name="usability-test">
+    ユーザビリティテストを実施するうえで利用する資料をまとめています。
+  </Description>
+</PageIndex>


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/997

## やったこと
.mdxファイル内で、子ページのリンク一覧を表示している箇所がありましたが、見出しの中にリンクを置くとビルド後に`a`タグが入れ子になるという事情があるため、PageIndexコンポーネントに置き換えました。

## 動作確認
https://deploy-preview-178--smarthr-design-system.netlify.app/products/design-process/
https://deploy-preview-178--smarthr-design-system.netlify.app/operational-guideline/page-template/

アンカーリンクではなく、子ページへのリンクになるため、
- ホバー時にアンカーリンクのアイコンが出ない
- 右サイドバーに見出しリストが表示されない

の2点は変わりますが、それ以外の見た目の変化はありません。
