### PR TITLE
Thコンポーネントのスタイルを修正

### DIFF
--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -46,21 +46,21 @@ export const ComponentPropsTable: VFC<Props> = ({ name, showTitle }) => {
           <Table>
             <thead>
               <tr>
-                <Th>Name</Th>
-                <Th>Required</Th>
-                <Th>Type</Th>
-                <Th>Description</Th>
+                <NameTh>Name</NameTh>
+                <RequiredTh>Required</RequiredTh>
+                <TypeTh>Type</TypeTh>
+                <DescriptionTh>Description</DescriptionTh>
               </tr>
             </thead>
             <tbody>
               {propsData.map((prop, i) => {
                 return (
                   <tr key={i}>
-                    <NameCell>
+                    <NameTd>
                       <strong>{prop.name}</strong>
-                    </NameCell>
-                    <RequiredCell>{prop.required ? 'true' : '-'}</RequiredCell>
-                    <TypeCell>
+                    </NameTd>
+                    <RequiredTd>{prop.required ? 'true' : '-'}</RequiredTd>
+                    <TypeTd>
                       {prop.type.name === 'enum' ? (
                         prop.type.value &&
                         prop.type.value.map((item, y, array) => {
@@ -74,8 +74,8 @@ export const ComponentPropsTable: VFC<Props> = ({ name, showTitle }) => {
                       ) : (
                         <code>{prop.type.name}</code>
                       )}
-                    </TypeCell>
-                    <DescriptionCell>{prop.description}</DescriptionCell>
+                    </TypeTd>
+                    <DescriptionTd>{prop.description}</DescriptionTd>
                   </tr>
                 )
               })}
@@ -96,20 +96,37 @@ const Wrapper = styled.div`
     vertical-align: baseline;
   }
 `
-const NameCell = styled(Td)`
+const NameTh = styled(Th)`
   white-space: nowrap;
 `
-const RequiredCell = styled(Td)`
+const RequiredTh = styled(Th)`
   white-space: nowrap;
 `
-const TypeCell = styled(Td)`
+const TypeTh = styled(Th)`
   min-width: 11em;
   width: 22em;
   & code {
     white-space: nowrap;
   }
 `
-const DescriptionCell = styled(Td)`
+const DescriptionTh = styled(Th)`
+  min-width: 22em;
+  width: auto;
+`
+const NameTd = styled(Td)`
+  white-space: nowrap;
+`
+const RequiredTd = styled(Td)`
+  white-space: nowrap;
+`
+const TypeTd = styled(Td)`
+  min-width: 11em;
+  width: 22em;
+  & code {
+    white-space: nowrap;
+  }
+`
+const DescriptionTd = styled(Td)`
   min-width: 22em;
   width: auto;
 `

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -98,9 +98,9 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
           <Table>
             <thead>
               <tr>
-                <Th>推奨する表記</Th>
-                <Th>NG例</Th>
-                <Th>理由</Th>
+                <RecommendTh>推奨する表記</RecommendTh>
+                <NGTh>NG例</NGTh>
+                <ReasonTh>理由</ReasonTh>
               </tr>
             </thead>
             <tbody>
@@ -114,11 +114,11 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
 
                 return (
                   <tr key={index}>
-                    <RecommendCell>
+                    <RecommendTd>
                       <strong>{prop.okExample}</strong>
-                    </RecommendCell>
-                    <NGCell>{prop.ngExample}</NGCell>
-                    <ReasonCell>
+                    </RecommendTd>
+                    <NGTd>{prop.ngExample}</NGTd>
+                    <ReasonTd>
                       <ul>
                         {matchWritingStyle && (
                           <li>
@@ -135,7 +135,7 @@ export const IdiomaticUsageTable: VFC<Props> = ({ type }) => {
                           </li>
                         )}
                       </ul>
-                    </ReasonCell>
+                    </ReasonTd>
                   </tr>
                 )
               })}
@@ -196,14 +196,25 @@ const Wrapper = styled.div`
     vertical-align: baseline;
   }
 `
-const RecommendCell = styled(Td)`
+const RecommendTh = styled(Th)`
   white-space: nowrap;
 `
-const NGCell = styled(Td)`
+const NGTh = styled(Th)`
   min-width: 11em;
   width: 22em;
 `
-const ReasonCell = styled(Td)`
+const ReasonTh = styled(Th)`
+  min-width: 22em;
+  width: auto;
+`
+const RecommendTd = styled(Td)`
+  white-space: nowrap;
+`
+const NGTd = styled(Td)`
+  min-width: 11em;
+  width: 22em;
+`
+const ReasonTd = styled(Td)`
   min-width: 22em;
   width: auto;
 `


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1006

## やったこと
smarthr-uiの`Th`コンポーネントを使用していて、そこに独自のスタイルをあてる必要がある箇所を修正しました。具体的には、ComponentPropsTableとIdiomaticUsageTableの2つのコンポーネントです。
（`Cell`コンポーネントを`Th`と`Td`に分けた際の対応が不十分でした。）

## 動作確認
https://deploy-preview-180--smarthr-design-system.netlify.app/products/components/button/#h2-5
https://deploy-preview-180--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/ （←こちらは、現状ではthの中身がそれほど長くないので、見た目に変化はありません。）

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/179180796-a2a07211-3516-453f-b4c0-df14b51939d7.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/179180892-b2c3a830-67f7-453b-8c7d-e091da10874f.png" width="350" alt> |
