### PR TITLE
ヘッダーメニューの余白を調整

### DIFF
--- a/src/components/shared/Header/Header.tsx
+++ b/src/components/shared/Header/Header.tsx
@@ -200,7 +200,7 @@ const StyledNav = styled(Cluster).attrs({ gap: { row: 0.75, column: 0.5 }, justi
     list-style: none;
     margin: 0;
     padding: 0;
-    gap: 8px;
+    gap: 6px;
     @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
       display: none;
     }
@@ -255,6 +255,10 @@ const StyledLink = styled(LinkComponent)`
   font-weight: bold;
   line-height: 1;
   color: ${defaultColor.TEXT_BLACK};
+
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_1}) {
+    padding-inline: 6px;
+  }
 
   &:hover {
     color: ${CSS_COLOR.NAV_ACTIVE};


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/999

## やったこと
画面幅が768px〜1114pxの時の、ヘッダーメニューの各アイテムの左右の余白を縮めました。
また、スクロールバーを表示した状態＋画面幅が1441px〜1448pxの場合、ヘッダーが2列になってしまうことも確認したので、こちらも調整しました（1406px〜1440pxは1列で収まるので、一瞬だけ2列になるような状態でした）。

## 動作確認
https://deploy-preview-189--smarthr-design-system.netlify.app/

## キャプチャ
画面幅800pxでの比較
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/179671818-e6f8fc08-b934-4023-8edf-072b79b84e66.png" alt="" width="350"> | <img src="https://user-images.githubusercontent.com/7822534/179671969-584a3713-ac76-4073-9bf0-c4d12acd06ac.png" alt="" width="350"> |

画面幅1445pxでの比較
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/179675181-5ad6a758-c0fd-4c61-a919-39d1eadc1f49.png" alt="" width="350"> | <img src="https://user-images.githubusercontent.com/7822534/179675238-656d58d0-fe92-4bb8-b098-b29b09123d06.png" alt="" width="350"> |