### PR TITLE
プロダクトの色をSmartHR UIの最新に追従する

### DIFF
--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -34,7 +34,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 <ColorPalettesWrapper>
   <ColorPalette hexCode="#e01e5a" colorName="DANGER" description="エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）" />
-  <ColorPalette hexCode="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせる" />
+  <ColorPalette hexCode="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う" />
 </ColorPalettesWrapper>
 
 
@@ -45,7 +45,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 強調などの文字スタイルは、[タイポグラフィ](/products/design-tokens/typography/)を参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221f" colorName="TEXT_BLACK" description="基本的な文字の色" />
+  <ColorPalette hexCode="#23221e" colorName="TEXT_BLACK" description="基本的な文字の色" />
   <ColorPalette hexCode="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
   <ColorPalette hexCode="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
   <ColorPalette hexCode="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
@@ -66,8 +66,8 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
   <ColorPalette hexCode="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
   <ColorPalette hexCode="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
   <ColorPalette hexCode="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
-  <ColorPalette hexCode="#00000026" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
-  <ColorPalette hexCode="#0000007f" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
+  <ColorPalette hexCode="#23221e26" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
+  <ColorPalette hexCode="#23221e80" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
   <ColorPalette hexCode="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
 </ColorPalettesWrapper>
 
@@ -100,10 +100,10 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
   <ColorPalette hexCode="#ef475b" colorName="旧" description="" />
 </ColorPalettesWrapper>
 
-#### WARNING
+#### WARNING（WARNING_YELLOW）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ff8800" colorName="新 ※変更なし" description="" />
+  <ColorPalette hexCode="#ffcc17" colorName="新" description="" />
   <ColorPalette hexCode="#ff8800" colorName="旧" description="" />
 </ColorPalettesWrapper>
 
@@ -111,7 +111,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### TEXT_BLACK
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221f" colorName="新" description="" />
+  <ColorPalette hexCode="#23221e" colorName="新" description="" />
   <ColorPalette hexCode="#333333" colorName="旧" description="" />
 </ColorPalettesWrapper>
 
@@ -185,14 +185,14 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### OVERLAY
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#00000026" colorName="新 ※変更なし" description="" />
+  <ColorPalette hexCode="#23221e26" colorName="新" description="" />
   <ColorPalette hexCode="#00000026" colorName="旧" description="" />
 </ColorPalettesWrapper>
 
 #### SCRIM
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0000007f" colorName="新 ※変更なし" description="" />
+  <ColorPalette hexCode="#23221e80" colorName="新" description="" />
   <ColorPalette hexCode="#0000007f" colorName="旧" description="" />
 </ColorPalettesWrapper>
 


### PR DESCRIPTION
## 課題・背景

- https://github.com/kufu/smarthr-design-system-issues/issues/984
- SmartHR UIの色のアップデートに追従
  - https://github.com/kufu/smarthr-ui/pull/2447

## やったこと

- 色のアップデート
  - `TEXT_BLACK`
  - `SCRIM`
  - `OVERLAY`
- 色の新旧比較表を更新

## やらなかったこと
- `SCRIM`と`OVERLAY`のrgba表示に透明度が反映されていない問題は別途

## 動作確認
- ファイルでの確認で十分だよ。

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
