### PR TITLE
第4階層のコンポーネントの並び順、サイドバーの開閉メニューを修正

### DIFF
--- a/content/articles/products/components/dropdown/dropdown-button.mdx
+++ b/content/articles/products/components/dropdown/dropdown-button.mdx
@@ -2,7 +2,6 @@
 title: 'DropdownButton'
 description: ''
 smarthr-ui: 'Dropdown/DropdownButton'
-order: 1
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/dropdown/filter-dropdown.mdx
+++ b/content/articles/products/components/dropdown/filter-dropdown.mdx
@@ -2,7 +2,6 @@
 title: 'FilterDropdown'
 description: ''
 smarthr-ui: 'Dropdown/FilterDropdown'
-order: 2
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/layout/cluster.mdx
+++ b/content/articles/products/components/layout/cluster.mdx
@@ -2,7 +2,6 @@
 title: 'Cluster'
 description: ''
 smarthr-ui: 'Layout/Cluster'
-order: 1
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/layout/line-up.mdx
+++ b/content/articles/products/components/layout/line-up.mdx
@@ -2,7 +2,6 @@
 title: 'LineUp（非推奨）'
 description: ''
 smarthr-ui: 'Layout/LineUp'
-order: 2
 ---
 import { CompactInformationPanel } from 'smarthr-ui'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/layout/reel.mdx
+++ b/content/articles/products/components/layout/reel.mdx
@@ -2,7 +2,6 @@
 title: 'Reel'
 description: ''
 smarthr-ui: 'Layout/Reel'
-order: 3
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/layout/sidebar.mdx
+++ b/content/articles/products/components/layout/sidebar.mdx
@@ -2,7 +2,6 @@
 title: 'Sidebar'
 description: ''
 smarthr-ui: 'Layout/Sidebar'
-order: 4
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/layout/stack.mdx
+++ b/content/articles/products/components/layout/stack.mdx
@@ -2,7 +2,6 @@
 title: 'Stack'
 description: ''
 smarthr-ui: 'Layout/Stack'
-order: 4
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -67,7 +67,7 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
           {/* 第2階層 */}
           {depth1Item.children.length > 0 && (
             <ul>
-              {depth1Item.children.map((depth2Item) => (
+              {depth1Item.children.map((depth2Item, depth2Index) => (
                 <li key={depth2Item.link}>
                   <Depth2Item>
                     <Link to={depth2Item.link} aria-current={path === depth2Item.link}>
@@ -75,7 +75,7 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
                     </Link>
                     {depth2Item.children.length > 0 && (
                       <CaretButton
-                        aria-controls={`Depth3Items__${depth2Item.order}`}
+                        aria-controls={`Depth3Items__${depth2Index}`}
                         aria-expanded={path.includes(depth2Item.link)}
                         onClick={onClickCaret}
                       >
@@ -86,8 +86,8 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
 
                   {/* 第3階層 */}
                   {depth2Item.children.length > 0 && (
-                    <ul id={`Depth3Items__${depth2Item.order}`} aria-hidden={!path.includes(depth2Item.link)}>
-                      {depth2Item.children.map((depth3Item) => (
+                    <ul id={`Depth3Items__${depth2Index}`} aria-hidden={!path.includes(depth2Item.link)}>
+                      {depth2Item.children.map((depth3Item, depth3Index) => (
                         <li key={depth3Item.link}>
                           <Depth3Item>
                             <Link to={depth3Item.link} aria-current={path === depth3Item.link}>
@@ -95,7 +95,7 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
                             </Link>
                             {depth3Item.children.length > 0 && (
                               <CaretButton
-                                aria-controls={`Depth4Items__${depth3Item.order}`}
+                                aria-controls={`Depth4Items__${depth3Index}`}
                                 aria-expanded={path.includes(depth3Item.link)}
                                 onClick={onClickCaret}
                               >
@@ -109,7 +109,7 @@ export const Sidebar: VFC<Props> = ({ path, nestedSidebarItems }) => {
 
                           {/* 第4階層 */}
                           {depth3Item.children.length > 0 && (
-                            <ul id={`Depth4Items__${depth3Item.order}`} aria-hidden={!path.includes(depth3Item.link)}>
+                            <ul id={`Depth4Items__${depth3Index}`} aria-hidden={!path.includes(depth3Item.link)}>
                               {depth3Item.children.map((depth4Item) => (
                                 <li key={depth4Item.link}>
                                   <Depth4Item>

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -193,6 +193,7 @@ const Article: VFC<Props> = ({ data }) => {
   const depth3Items: SidebarItem[] = []
   const depth3ComponentItems: SidebarItem[] = []
   const depth4Items: SidebarItem[] = []
+  const depth4ComponentItems: SidebarItem[] = []
 
   parentCategory.edges.forEach(({ node }) => {
     const link = node.fields?.slug ?? ''
@@ -219,7 +220,11 @@ const Article: VFC<Props> = ({ data }) => {
       }
     }
     if (item.depth === 4) {
-      depth4Items.push(item)
+      if (item.link.includes('/products/components/')) {
+        depth4ComponentItems.push(item)
+      } else {
+        depth4Items.push(item)
+      }
     }
   })
 
@@ -236,6 +241,10 @@ const Article: VFC<Props> = ({ data }) => {
   })
   depth3Items.sort(({ order: a }, { order: b }) => {
     return a - b
+  })
+  // /products/components/*/以下のコンポーネントページは名前の順でソートするので、別途並べ替える
+  depth4ComponentItems.sort(({ title: a }, { title: b }) => {
+    return a < b ? -1 : a > b ? 1 : 0
   })
   depth4Items.sort(({ order: a }, { order: b }) => {
     return a - b
@@ -260,7 +269,7 @@ const Article: VFC<Props> = ({ data }) => {
         sidebarItems.push(depth3Item)
         depth2Item.children.push(depth3Item)
 
-        for (const depth4Item of depth4Items) {
+        for (const depth4Item of [...depth4Items, ...depth4ComponentItems]) {
           if (!depth4Item.link.includes(depth3Item.link)) continue
 
           sidebarItems.push(depth4Item)


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system/pull/181　→やらなかったこと

## やったこと
- `/products/components/`以下のコンポーネントが、2階層になる（＝第4階層ができる）ケースが出てきたので、その場合も自動的にアルファベット順に並ぶように調整しました。
  - frontmatterの`order`は無視されるため、削除しています。
- frontmatterの`order`がない場合に、サイドバーの開閉メニューがうまく動作しない不具合があったため、修正しました。
  - `order`の代わりに実際のページの並び順のindexをidにして、開閉ボタンと対象の子メニューを識別するようにしました。

## 動作確認


## キャプチャ
![image](https://user-images.githubusercontent.com/7822534/179925397-236c517c-dc3d-4a38-a188-62c921bf5207.png)

