### PR TITLE
コードからストーリー名を抽出する際の正規表現を修正

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -47,8 +47,9 @@ export const ComponentStory: VFC<Props> = ({ name }) => {
   useEffect(() => {
     if (storiesCode === '') return
 
-    // "export const AccordionStyle: Story" のような、Storyをexportするコードから名前を抜き出す
-    const matchStoryNames = storiesCode.matchAll(/export\sconst\s(\S*):\sStory/g)
+    // "export const AccordionStyle: Story" や "export const All = Template.bind({})" のような、Story名をexportするコードから名前を抜き出す
+    // 注意：export { Default as DropdownButton } from ...のようなコードにはマッチしない
+    const matchStoryNames = storiesCode.matchAll(/export\sconst\s(\w*)/g)
     const items1 = [...matchStoryNames].map((result) => {
       // '_'を削除
       const storyName = result[1].replace('_', '')

--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -48,8 +48,11 @@ export const ComponentStory: VFC<Props> = ({ name }) => {
     if (storiesCode === '') return
 
     // "export const AccordionStyle: Story" や "export const All = Template.bind({})" のような、Story名をexportするコードから名前を抜き出す
-    // 注意：export { Default as DropdownButton } from ...のようなコードにはマッチしない
-    const matchStoryNames = storiesCode.matchAll(/export\sconst\s(\w*)/g)
+    // 注意1：export { Default as DropdownButton } from ...のようなコードにはマッチしない
+    // 注意2：ストーリー名に全角文字が入るケースがある（例：Body以外のPortalParent）
+    const matchStoryNames = storiesCode.matchAll(
+      /export\sconst\s([\w\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]*)/g,
+    )
     const items1 = [...matchStoryNames].map((result) => {
       // '_'を削除
       const storyName = result[1].replace('_', '')


### PR DESCRIPTION
## 課題・背景

- https://github.com/kufu/smarthr-design-system/pull/181#issuecomment-1189876160
- https://github.com/kufu/smarthr-design-system-issues/issues/1010

## やったこと

Story名を抽出する正規表現の改修

## やらなかったこと


## 動作確認
- https://deploy-preview-194--smarthr-design-system.netlify.app/products/components/dropdown/

## キャプチャ

|Before|After|
| --- | --- |
| <img width="979" alt="image" src="https://user-images.githubusercontent.com/1369376/180108788-dd8dc960-cbe3-4bc2-aa98-0c2587679025.png"> | <img width="979" alt="image" src="https://user-images.githubusercontent.com/1369376/180108848-6e39e930-f6ff-44de-b3ba-fb48a127f24e.png"> |
