### PR TITLE
SCRIMとOVERLAYのカラーコードを修正

### DIFF
--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -66,8 +66,8 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
   <ColorPalette hexCode="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
   <ColorPalette hexCode="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
   <ColorPalette hexCode="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
-  <ColorPalette hexCode="#23221e26" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
-  <ColorPalette hexCode="#23221e80" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
+  <ColorPalette hexCode="#03030226" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
+  <ColorPalette hexCode="#03030280" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
   <ColorPalette hexCode="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
 </ColorPalettesWrapper>
 
@@ -185,14 +185,14 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### OVERLAY
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221e26" colorName="新" description="" />
+  <ColorPalette hexCode="#03030226" colorName="新" description="" />
   <ColorPalette hexCode="#00000026" colorName="旧" description="" />
 </ColorPalettesWrapper>
 
 #### SCRIM
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221e80" colorName="新" description="" />
+  <ColorPalette hexCode="#03030280" colorName="新" description="" />
   <ColorPalette hexCode="#0000007f" colorName="旧" description="" />
 </ColorPalettesWrapper>
 


### PR DESCRIPTION
## 課題・背景

- #190 でカラーコードを変更しましたが、誤っていたため修正します。
  - https://github.com/kufu/smarthr-ui/blob/master/src/themes/createColor.ts#L32

## やったこと

- `SCRIM`と`OVERLAY`のカラーコードを修正しました。

<!--
- 〇〇に追記
- 〇〇ページを追加

## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認

- ファイルでの確認で十分だよ。


## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
