### PR TITLE
コンポーネントのページのiframeのリサイズUIを改善

### DIFF
--- a/src/components/ComponentStory/ResizableContainer.tsx
+++ b/src/components/ComponentStory/ResizableContainer.tsx
@@ -43,6 +43,12 @@ export const ResizableContainer: VFC<Props> = ({ defaultWidth, defaultHeight, ch
       document.removeEventListener('pointermove', handlePointerMove, false)
       document.removeEventListener('pointerup', handlePointerUp, false)
     }
+
+    // コンテナ幅 - 20pxまで近づいていたらコンテナと同じ幅に吸着させる
+    if (container.current === null || boxSizeRef.current.width === null) return
+    if (container.current.offsetWidth - boxSizeRef.current.width < 20) {
+      setBoxSize({ width: container.current.offsetWidth, height: boxSizeRef.current.height })
+    }
   }
 
   const handlePointerMove = (event: PointerEvent) => {

--- a/src/components/ComponentStory/ResizableContainer.tsx
+++ b/src/components/ComponentStory/ResizableContainer.tsx
@@ -107,7 +107,9 @@ export const ResizableContainer: VFC<Props> = ({ defaultWidth, defaultHeight, ch
   )
 }
 
-const Container = styled.div``
+const Container = styled.div`
+  user-select: none;
+`
 
 const ResizeArea = styled.div`
   position: relative;


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1016

## やったこと
プロダクト>コンポーネント以下の各コンポーネントページで、
- iframeをラップしている`div`に`user-select: none;`のCSSを追加しました
- 横幅のドラッグ時に、幅100%に近づいたら（<20px）自動的に100%に吸着するようにしました

## 動作確認
https://deploy-preview-208--smarthr-design-system.netlify.app/products/components/accordion-panel/