### PR TITLE
検索結果に表示するカテゴリーのラベルを更新

### DIFF
--- a/src/components/search/Search/HitComponent.tsx
+++ b/src/components/search/Search/HitComponent.tsx
@@ -3,19 +3,23 @@ import { Link as LinkComponent } from 'gatsby'
 import styled from 'styled-components'
 
 interface Categories {
-  about: string
-  foundations: string
+  concept: string
+  foundation: string
+  basics: string
   products: string
-  marketing: string
-  employees: string
+  accessibility: string
+  communication: string
+  'operational-guideline': string
 }
 
 const categories = {
-  about: '概要',
-  foundations: '基本原則',
+  concept: 'コンセプト',
+  foundation: '基本原則',
+  basics: '基本要素',
   products: 'プロダクト',
-  marketing: 'マーケティング',
-  employees: '従業員向け',
+  accessibility: 'アクセシビリティ',
+  communication: 'コミュニケーション',
+  'operational-guideline': '運用ガイドライン',
 } as Categories
 
 export const HitComponent: FC = (props: any) => {

--- a/src/components/search/Search/HitComponent.tsx
+++ b/src/components/search/Search/HitComponent.tsx
@@ -28,7 +28,7 @@ export const HitComponent: FC = (props: any) => {
   return (
     <Wrapper>
       <LinkComponent to={`/${props.hit.path}`}>
-        {props.hit.title}&nbsp;|&nbsp;{categories[categoryKey]}
+        {props.hit.title}&nbsp;{categories[categoryKey] ? `|${'\u00A0'}${categories[categoryKey]}` : ''}
       </LinkComponent>
       {props.hit.description && <StyledParagraph>{props.hit.description}</StyledParagraph>}
     </Wrapper>


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1019

## やったこと
祖先カテゴリー（基本要素やプロダクトなどの第二階層）の定義が`src/components/search/Search/HitComponent.tsx`に書かれていましたが、リニューアル前のカテゴリー定義のままで、「プロダクト」以外表示されなくなっていたので修正しました。

## やらなかったこと
「|」の表示自体は変えていないです。カテゴリーが出るようになったので、末尾が「|」で終わるケースは、ダウンロードや利用規約などの一部のページのみです。
そういう場合は末尾の「|」を出さないようにしたほうが良いでしょうか？

## 動作確認
https://deploy-preview-215--smarthr-design-system.netlify.app/search/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/182752427-d82916ed-5739-46bb-a701-80eff639bb2b.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/182752386-4ad08264-5860-41c6-b677-a202bd69c3cf.png" width="350" alt> |
