### PR TITLE
お問合せ先を最新化

### DIFF
--- a/content/articles/contact.mdx
+++ b/content/articles/contact.mdx
@@ -14,9 +14,16 @@ SmartHR Design Systemに関して気づいたことがありましたら、い�
 以下のコンテンツは、別の方法でもお問い合わせ・フィードバックできます。
 
 #### 基本要素
-- [ロゴ・モーションロゴのお問い合わせ](/basics/logos/#h2-3)
-- [イラストレーションについてのお問い合わせ](/basics/illustration/#h2-0)
+- [ロゴ・モーションロゴ・サウンドロゴのお問い合わせ](/basics/logos/#h2-3)
+- [イラストレーションのフィードバック](/basics/illustration/#h2-3)
+- [印刷ガイドラインのフィードバック](/basics/colors/printguideline/#h2-3)
 
-#### プロダクト
+#### アクセシビリティ
 - [アクセシビリティ方針のお問い合わせ](/accessibility/policy/#h2-5)
 
+#### プロダクト
+- [ユーザビリティテストの手引のフィードバック](/products/design-process/usability-test/#h2-3)
+
+#### コミュニケーション
+- [ジングルムービーのフィードバック](/communication/photography/jingle-movie/#h2-3)
+- [画面キャプチャのフィードバック](/communication/capture/#h2-3)


### PR DESCRIPTION
## 課題・背景
- お問合せ先が最新になっていませんでした。
https://github.com/kufu/smarthr-design-system-issues/issues/1021
  - 全体のお問合せ先とは別のお問合せ先が用意されていても、リンクが貼られていない
  - リンクを踏んでも、お問合せ先の見出しに遷移しない


## やったこと
- お問合せ先を最新にする
  - 全体のお問合せ先と別でお問合せ先・フィードバック先も用意している場合、リンクを貼る

## やらなかったこと
- お問合せ先自体が正しいかの確認

## 動作確認
- Previewでみてね。

## キャプチャ
|Before|After|
| --- | --- |
| <img width="1188" alt="お問合せ先・フィードバック先のbefore" src="https://user-images.githubusercontent.com/101125529/183009370-aa585b15-3c05-4798-8591-a6fb80e196ca.png"> | <img width="901" alt="お問合せ先・フィードバック先のafter" src="https://user-images.githubusercontent.com/101125529/183009383-2d93d8c8-3eaf-472f-a12c-8952cea10e64.png"> |