### PR TITLE
デザインパターンのコード例をStoryにする・プレビュー領域のサイズを可変にする

### DIFF
--- a/content/articles/products/design-patterns/components/index.ts
+++ b/content/articles/products/design-patterns/components/index.ts
@@ -1,3 +1,4 @@
 import SelectCompanyAccount from '!!raw-loader!../select-company-account/SelectCompanyAccount'
+import UpwardNavigation from '!!raw-loader!../upward-navigation/UpwardNavigation'
 
-export { SelectCompanyAccount }
+export { SelectCompanyAccount, UpwardNavigation }

--- a/content/articles/products/design-patterns/upward-navigation/UpwardNavigation.stories.tsx
+++ b/content/articles/products/design-patterns/upward-navigation/UpwardNavigation.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { Header } from 'smarthr-ui'
+
+import { ComponentMeta } from '@storybook/react'
+import { UpwardNavigation as StoryComponent } from './UpwardNavigation'
+
+export const UpwardNavigation = () => {
+  return <StoryComponent />
+}
+
+export default {
+  title: 'UpwardNavigation',
+  component: UpwardNavigation,
+  decorators: [
+    (Story) => (
+      <>
+        <Header />
+        <div style={{ padding: '1rem' }}>
+          <Story />
+        </div>
+      </>
+    ),
+  ],
+} as ComponentMeta<typeof UpwardNavigation>

--- a/content/articles/products/design-patterns/upward-navigation/UpwardNavigation.tsx
+++ b/content/articles/products/design-patterns/upward-navigation/UpwardNavigation.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { FaArrowLeftIcon, Heading, Stack, Text, TextLink } from 'smarthr-ui'
+import styled, { css } from 'styled-components'
+
+export const UpwardNavigation = () => (
+  <Wrapper>
+    <UpwardLink>
+      <TextLink href="#" prefix={<FaArrowLeftIcon />}>
+        分析レポートに戻る
+      </TextLink>
+    </UpwardLink>
+    <Stack>
+      <Heading>分析対象の従業員項目</Heading>
+      <Text as="p">
+        一部の数値データにおいて、クロス集計する際の集計単位を変更できます例えば「年齢」を「60」以上をまとめる、「20」以下をまとめる、「10」単位でまとめるのように設定すると、以下のように出力されます。
+      </Text>
+    </Stack>
+  </Wrapper>
+)
+
+const Wrapper = styled(Stack).attrs({ gap: 1.5 })`
+  ${({ theme: { space } }) => css`
+    padding-block: ${space(2)};
+  `}
+`
+const UpwardLink = styled.div`
+  ${({ theme: { leading, space } }) => css`
+    /* アイコン(1)とその間隔（0.25）分をずらしている */
+    transform: translateX(${space(-1.25)});
+    /* Stack の margin を上書くために詳細度を上げる
+     * https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity */
+    &&& {
+      /* UpwardLink がない場合にレイアウトが崩れないように negative margin で制御 */
+      margin-block-start: ${space(-1)};
+    }
+    line-height: ${leading.NONE};
+
+    @media (max-width: 480px) {
+      transform: revert;
+    }
+  `}
+`

--- a/content/articles/products/design-patterns/upward-navigation/index.mdx
+++ b/content/articles/products/design-patterns/upward-navigation/index.mdx
@@ -5,6 +5,7 @@ order: 5
 ---
 
 import { FaArrowLeftIcon } from 'smarthr-ui'
+import { DesignPatternCodeBlock } from '../DesignPatternCodeBlock'
 
 一階層上のコンテンツに誘導する役割を持ち、コンテンツ間の階層構造を認知させるためのナビゲーションです。
 
@@ -16,7 +17,7 @@ import { FaArrowLeftIcon } from 'smarthr-ui'
 1. リンクテキスト
 2. アイコンで伝える。
 
-![上に戻るリンクの構成の紐付け図](./images/navigation/upward-navigation-overview.png)
+![上に戻るリンクの構成の紐付け図](../images/navigation/upward-navigation-overview.png)
 
 
 ### 1. リンクテキスト
@@ -39,46 +40,7 @@ import { FaArrowLeftIcon } from 'smarthr-ui'
 上に戻るリンクのレイアウトは次の通りです。  
 ※ヘッダーとの間隔は[余白](#h3-2)を参照してください。
 
-```tsx editable codeBlock withStyled layout=product
-const SomePage = () => (
-  <Wrapper>
-    <UpwardLink>
-      <TextLink href="#h2-1" prefix={<FaArrowLeftIcon />}>分析レポートに戻る</TextLink>
-    </UpwardLink>
-    <Stack>
-      <Heading>分析対象の従業員項目</Heading>
-      <Text as="p">一部の数値データにおいて、クロス集計する際の集計単位を変更できます例えば「年齢」を「60」以上をまとめる、「20」以下をまとめる、「10」単位でまとめるのように設定すると、以下のように出力されます。</Text>
-    </Stack>
-  </Wrapper>
-)
-
-const Wrapper = styled(Stack).attrs({ gap: 1.5 })`
-  ${({ theme: { space } }) => css`
-    padding-block: ${space(2)};
-  `}
-`
-const UpwardLink = styled.div`
-  ${({ theme: { leading, space } }) => css`
-    /* アイコン(1)とその間隔（0.25）分をずらしている */
-    transform: translateX(${space(-1.25)});
-    /* Stack の margin を上書くために詳細度を上げる
-     * https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity */
-    &&& {
-      /* UpwardLink がない場合にレイアウトが崩れないように negative margin で制御 */
-      margin-block-start: ${space(-1)};
-    }
-    line-height: ${leading.NONE};
-
-    @media (max-width: 480px) {
-      transform: revert;
-    }
-  `}
-`
-
-render (
-  <SomePage />
-)
-```
+<DesignPatternCodeBlock componentName="UpwardNavigation" />
 
 
 ### 余白
@@ -103,10 +65,10 @@ render (
 #### 例外1. メインコンテンツにサイドナビゲーションが隣接する場合
 [基本機能の共通設定](/products/design-patterns-core-features/main-admin/)のように、メインコンテンツにサイドナビゲーションが隣接する場合は、<FaArrowLeftIcon visuallyHiddenText="左矢印" /> アイコンをメインコンテンツの左端に合わせて配置します。
 
-![スクリーンショット:見出しや本文といったメインコンテンツの左端とアイコンの左端が揃っている](./images/navigation/upward-navigation-withsidenav.png)
+![スクリーンショット:見出しや本文といったメインコンテンツの左端とアイコンの左端が揃っている](../images/navigation/upward-navigation-withsidenav.png)
 
 #### 例外2. モバイルでの表示
 モバイル（スマートフォンや画面幅が狭い場合）では、<FaArrowLeftIcon visuallyHiddenText="左矢印" /> アイコンをメインコンテンツの左端に合わせて配置します。
 （参考：[メディアクエリ](/products/design-tokens/media-query/)）
 
-![画面幅が狭い場合のスクリーンショット:見出しや本文といったメインコンテンツの左端とアイコンの左端が揃っている](./images/navigation/upward-navigation-mobile.png)
+![画面幅が狭い場合のスクリーンショット:見出しや本文といったメインコンテンツの左端とアイコンの左端が揃っている](../images/navigation/upward-navigation-mobile.png)

--- a/src/components/ComponentPreview/ProductWrapper.tsx
+++ b/src/components/ComponentPreview/ProductWrapper.tsx
@@ -1,19 +1,21 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
 import { Header } from 'smarthr-ui'
-
+import { ResizableContainer } from '../ComponentStory/ResizableContainer'
 import { WrapperBase } from './WrapperBase'
 
 export const ProductWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <Wrapper>
-    <Header logoHref="#" />
-    <Body>{children}</Body>
+    <ResizableContainer defaultWidth="100%" defaultHeight="300px">
+      <Header logoHref="#" />
+      <Body>{children}</Body>
+    </ResizableContainer>
   </Wrapper>
 )
 
 const Wrapper = styled(WrapperBase)(
-  ({ theme: { color, leading } }) => css`
-    background-color: ${color.BACKGROUND};
+  ({ theme: { leading } }) => css`
+    border-width: 0 0 1px; /* CodeBlockには上ボーダーがないので、下のみボーダーをつける */
 
     /* FIXME: @scope が来たら書き直したい! */
 


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1013

## やったこと
1. Upward navigationのコード例・プレビュー部分をコンポーネントの埋め込みから独立したStoryに変更しました
2. デザインパターンのStoryをプレビューしている部分（`layout='product'`で呼び出される`CodeBlock`コンポーネント）に、ドラッグで幅・高さを変更できる機能を追加しました。
   - `products/components/`以下の、smarthr-uiのStoryを表示している部分と同様に、`ResizableContainer`コンポーネントでラップしています。 

## 動作確認
https://deploy-preview-229--smarthr-design-system.netlify.app/products/design-patterns/upward-navigation/#h2-1
https://deploy-preview-229--smarthr-design-system.netlify.app/products/design-patterns/select-company-account/#h2-2
https://62992322cdff0a004aaf9263-frmsevrgym.chromatic.com/?path=/story/upwardnavigation--upward-navigation

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/183355443-665a16ab-6e39-4106-882c-f7a752da6222.png" alt width="350"> | <img src="https://user-images.githubusercontent.com/7822534/183355473-1ae829c0-d307-480c-b0d1-caa5ab11969f.png" alt width="350"> |
| <img src="https://user-images.githubusercontent.com/7822534/183355629-94a1ae57-09b1-4afe-9a56-3e9dd674f0a1.png" alt width="350"> | <img src="https://user-images.githubusercontent.com/7822534/183355655-1ab54019-9c1c-4012-9bf0-e079d35927ca.png" alt width="350"> |