### PR TITLE
Tdコンポーネント内のデザイントークンをcodeタグで表記

### DIFF
--- a/content/articles/products/components/heading.mdx
+++ b/content/articles/products/components/heading.mdx
@@ -52,9 +52,9 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
   <tbody>
     <tr>
       <Td>screenTitle</Td>
-      <Td><a href="/products/design-tokens/typography/">XL</a></Td>
+      <Td><a href="/products/design-tokens/typography/"><code>XL</code></a></Td>
       <Td>normal</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_BLACK</a></Td>
+      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_BLACK</code></a></Td>
       <Td><Heading type="screenTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
     </tr>
   </tbody>
@@ -75,9 +75,9 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
   <tbody>
     <tr>
       <Td>sectionTitle</Td>
-      <Td><a href="/products/design-tokens/typography/">L</a></Td>
+      <Td><a href="/products/design-tokens/typography/"><code>L</code></a></Td>
       <Td>normal</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_BLACK</a></Td>
+      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_BLACK</code></a></Td>
       <Td><Heading type="sectionTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
     </tr>
   </tbody>
@@ -98,9 +98,9 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
   <tbody>
     <tr>
       <Td>blockTitle</Td>
-      <Td><a href="/products/design-tokens/typography/">M</a></Td>
+      <Td><a href="/products/design-tokens/typography/"><code>M</code></a></Td>
       <Td>bold</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_BLACK</a></Td>
+      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_BLACK</code></a></Td>
       <Td><Heading type="blockTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
     </tr>
   </tbody>
@@ -121,9 +121,9 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
   <tbody>
     <tr>
       <Td>subBlockTitle</Td>
-      <Td><a href="/products/design-tokens/typography/">M</a></Td>
+      <Td><a href="/products/design-tokens/typography/"><code>M</code></a></Td>
       <Td>bold</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_GREY</a></Td>
+      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_GREY</code></a></Td>
       <Td><Heading type="subBlockTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
     </tr>
   </tbody>
@@ -144,9 +144,9 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
   <tbody>
     <tr>
       <Td>subSubBlockTitle</Td>
-      <Td><a href="/products/design-tokens/typography/">S</a></Td>
+      <Td><a href="/products/design-tokens/typography/"><code>S</code></a></Td>
       <Td>bold</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2">TEXT_GREY</a></Td>
+      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_GREY</code></a></Td>
       <Td><Heading type="subSubBlockTitle" tag="span">社会の非合理を、ハックする</Heading></Td>
     </tr>
   </tbody>

--- a/content/articles/products/design-tokens/leading.mdx
+++ b/content/articles/products/design-tokens/leading.mdx
@@ -11,8 +11,8 @@ CSSでは`line-height`を指しています。
 
 | トークン名  | 値 | 使用例 |
 | :--- | :--- | :--- |
-| `NONE`    | 1    | [ラベルテキスト](/products/design-tokens/typography/#h3-4)、[Heading](/products/components/heading/) |
-| `TIGHT`   | 1.25 | |
+| `NONE`    | 1    | [ラベルテキスト](/products/design-tokens/typography/#h3-4) |
+| `TIGHT`   | 1.25 | [Dialogのタイトル](/products/components/dialog/)、[Heading](/products/components/heading/)、[NotificationBar](/products/components/notification-bar/) |
 | `NORMAL`  | 1.5  | [段落テキスト](/products/design-tokens/typography/#h3-3) |
 | `RELAXED` | 1.75 | |
 

--- a/content/articles/products/design-tokens/typography.mdx
+++ b/content/articles/products/design-tokens/typography.mdx
@@ -88,12 +88,12 @@ font-family: system-ui, sans-serif;
   <tbody>
     <tr>
       <Td>標準</Td>
-      <Td>M</Td>
+      <Td><code>M</code></Td>
       <Td><Sampletext size={'M'}>社会の非合理を、ハックする。</Sampletext></Td>
     </tr>
     <tr>
       <Td>サイズ小</Td>
-      <Td>S</Td>
+      <Td><code>S</code></Td>
       <Td><Sampletext size={'S'}>社会の非合理を、ハックする。</Sampletext></Td>
     </tr>
   </tbody>
@@ -117,12 +117,12 @@ font-family: system-ui, sans-serif;
   <tbody>
     <tr>
       <Td>標準</Td>
-      <Td>M</Td>
+      <Td><code>M</code></Td>
       <Td><Sampletext size={'M'}>社会の非合理を、ハックする。</Sampletext></Td>
     </tr>
     <tr>
       <Td>サイズ小</Td>
-      <Td>S</Td>
+      <Td><code>S</code></Td>
       <Td><Sampletext size={'S'}>社会の非合理を、ハックする。</Sampletext></Td>
     </tr>
   </tbody>


### PR DESCRIPTION
## 課題・背景

- #214 で対応いただいたため、対象コンテンツに反映しました。

## やったこと

- Tdコンポーネントの中でデザイントークンを表記している部分を`<code>`で括りました。
- ついでに、行送りの使用状況が変わっていたので追従しました。

<!--
- 〇〇に追記
- 〇〇ページを追加

## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認
- Previewでみてね。

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
