### PR TITLE
MDXコンテンツ用のスタイルを調整

### DIFF
--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -545,8 +545,8 @@ const MDXStyledWrapper = styled.div`
     line-height: 2.12;
     margin-block: 20px 0;
 
-    ul:first-child,
-    ol:first-child {
+    ul,
+    ol {
       margin-block-start: 0;
     }
   }

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -544,6 +544,11 @@ const MDXStyledWrapper = styled.div`
     font-size: ${CSS_FONT_SIZE.PX_16};
     line-height: 2.12;
     margin-block: 20px 0;
+
+    ul:first-child,
+    ol:first-child {
+      margin-block-start: 0;
+    }
   }
 
   /* 表組み */
@@ -556,6 +561,14 @@ const MDXStyledWrapper = styled.div`
       vertical-align: middle;
       font-size: ${CSS_FONT_SIZE.PX_14};
       background-color: ${CSS_COLOR.DIVIDER};
+    }
+
+    td {
+      p:first-child,
+      ul:first-child,
+      ol:first-child {
+        margin-block-start: 0;
+      }
     }
   }
 


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1026

## やったこと
`src/templates/article.tsx`内にMDXコンテンツ全体に適用されるCSSが定義されていますが、`td`の中の`p`や入れ子になった`ul`の子要素などに意図しない上マージンが効いているケースがあったため、CSSを修正しました。

具体的には、`td`内の`p`、`ul`、`ol`の先頭の要素（`:first-child`）と、入れ子になった`ul`または`ol`の子の先頭の要素について、`margin-block-start: 0;`を追加しました。

## 動作確認
https://deploy-preview-241--smarthr-design-system.netlify.app/products/design-tokens/typography/#h3-3
https://deploy-preview-241--smarthr-design-system.netlify.app/products/design-patterns/table-bulk-action/#h2-0
https://deploy-preview-241--smarthr-design-system.netlify.app/products/contents/help-center/#h3-3
https://deploy-preview-241--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/184818223-c59d0f1f-7c54-40ae-9b58-464747e77705.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/184818160-fd801d18-065c-4e8a-b3d7-fda413728833.png" width="350" alt> |
| <img src="https://user-images.githubusercontent.com/7822534/184818528-ba901e5f-eb92-43e5-8936-da7cd36a37e6.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/184818470-fc95037e-1d2f-4c48-9fcf-3f30fec072fc.png" width="350" alt> |
| <img src="https://user-images.githubusercontent.com/7822534/184818939-d95a6588-38f4-40dd-9338-3b04272ecb25.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/184818807-d87381d7-18e0-4e53-a5a6-7190655a98f1.png" width="350" alt> |