### PR TITLE
テキストリンクの装飾の基準を最新化する

### DIFF
--- a/content/articles/products/design-tokens/typography.mdx
+++ b/content/articles/products/design-tokens/typography.mdx
@@ -63,7 +63,7 @@ font-family: system-ui, sans-serif;
 
 
 ## 行送り
-テキストスタイルによって使用する[行送り](/products/design-tokens/leading/)が異なります。以下を参照してください。
+テキストスタイルによって使用する[行送り](/products/design-tokens/leading/)が異なります。以下のテキストスタイルを参照してください。
 
 
 ## テキストスタイル
@@ -138,13 +138,13 @@ font-family: system-ui, sans-serif;
 WIP
 
 ### リンク
-テキストリンクは、以下の場合に使います。  
-リンク以外の操作を表す場合は、[Buttonコンポーネント](/products/components/button/)を使用してください。
+テキストリンクは、以下の場合に[TextLinkコンポーネント](/products/components/text-link/)を使用して表します。  
+操作を表す場合は、[Buttonコンポーネント](/products/components/button/)を使用してください。
 
-- 他の画面やヘルプページに遷移させるために、画面の説明文や補助テキストにリンクを設置する場合
-- 一覧コレクションからシングルに遷移させるために、そのインスタンス名にリンクを設置する場合
+- 他の画面やヘルプセンターなどに遷移させるために、画面の説明文や補助テキストにリンクを設置する場合
+- 一覧ビュー（コレクション）から詳細ビュー（シングル）に遷移させるために、そのインスタンス名にリンクを設置する場合（[「よくあるテーブル」の遷移リンクのスタイル](/products/design-patterns/smarthr-table/#h5-0)を参照）
 
-テキストリンクの色は[`TEXT_LINK`](/products/design-tokens/color/#h2-2)を使用し、マウスオーバー時を除いて下線は表示しません。
+[TextLink](/products/components/text-link/)が使えない場合は、テキストの色に[`TEXT_LINK`](/products/design-tokens/color/#h2-2)を使い、基本的に下線を表示します。
 
 新規ウィンドウを開くリンクや、ヘルプセンターのポップアップダイアログを表示するリンクでは、遷移先を事前に認知できるようにアイコンを組み合わせて使います。
 [Iconコンポーネントの使い方](/products/components/icon/#h2-4)を参照してください。

--- a/content/articles/products/design-tokens/typography.mdx
+++ b/content/articles/products/design-tokens/typography.mdx
@@ -144,7 +144,7 @@ WIP
 - 他の画面やヘルプセンターなどに遷移させるために、画面の説明文や補助テキストにリンクを設置する場合
 - 一覧ビュー（コレクション）から詳細ビュー（シングル）に遷移させるために、そのインスタンス名にリンクを設置する場合（[「よくあるテーブル」の遷移リンクのスタイル](/products/design-patterns/smarthr-table/#h5-0)を参照）
 
-[TextLink](/products/components/text-link/)が使えない場合は、テキストの色に[`TEXT_LINK`](/products/design-tokens/color/#h2-2)を使い、基本的に下線を表示します。
+[TextLink](/products/components/text-link/)が使えないときは、テキストに下線を表示し、文字の色は[`TEXT_LINK`](/products/design-tokens/color/#h2-2)にします。
 
 新規ウィンドウを開くリンクや、ヘルプセンターのポップアップダイアログを表示するリンクでは、遷移先を事前に認知できるようにアイコンを組み合わせて使います。
 [Iconコンポーネントの使い方](/products/components/icon/#h2-4)を参照してください。


### PR DESCRIPTION
## 課題・背景

- https://github.com/kufu/smarthr-design-system-issues/issues/1037

## やったこと

- タイポグラフィのリンクの記載内容を最新の基準でアップデートした


## やらなかったこと
- [「よくあるテーブル」の遷移リンクのスタイル](/products/design-patterns/smarthr-table/#h5-0)がアップデートされていないが、別で対応する。

## 動作確認
- Previewでみてね。
  - https://deploy-preview-242--smarthr-design-system.netlify.app/products/design-tokens/typography/#h3-7

## キャプチャ

| Before | After |
| --- | --- |
| <img width="762" alt="image" src="https://user-images.githubusercontent.com/64398878/185554416-d8cfb35a-70af-4079-98c9-351e6de14bac.png"> | <img width="762" alt="image" src="https://user-images.githubusercontent.com/64398878/185554388-74dd96b4-8750-43ad-9c6a-50d08b0da61b.png"> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
