### PR TITLE
サイドバーの第4階層の開閉を修正

### DIFF
--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -95,7 +95,7 @@ export const Sidebar: FC<Props> = ({ path, nestedSidebarItems }) => {
                             </Link>
                             {depth3Item.children.length > 0 && (
                               <CaretButton
-                                aria-controls={`Depth4Items__${depth3Index}`}
+                                aria-controls={`Depth4Items__${depth2Index}__${depth3Index}`}
                                 aria-expanded={path.includes(depth3Item.link)}
                                 onClick={onClickCaret}
                               >
@@ -109,7 +109,7 @@ export const Sidebar: FC<Props> = ({ path, nestedSidebarItems }) => {
 
                           {/* 第4階層 */}
                           {depth3Item.children.length > 0 && (
-                            <ul id={`Depth4Items__${depth3Index}`} aria-hidden={!path.includes(depth3Item.link)}>
+                            <ul id={`Depth4Items__${depth2Index}__${depth3Index}`} aria-hidden={!path.includes(depth3Item.link)}>
                               {depth3Item.children.map((depth4Item) => (
                                 <li key={depth4Item.link}>
                                   <Depth4Item>


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1054

## やったこと
第4階層が複数出てくる想定になっていなかったため、コードを修正しました。

開閉ボタンと開閉対象の要素を紐づけるために、配列のindexをベースにidを振っていますが、第4階層は4-1、4-2のようなidでは重複の可能性があるので、4-1-1、4-1-2…のようなidに変更しました。

## 動作確認
https://deploy-preview-276--smarthr-design-system.netlify.app/products/design-process/usability-test/
