### PR TITLE
DialogのPropsテーブルを追加

### DIFF
--- a/content/articles/products/components/dialog.mdx
+++ b/content/articles/products/components/dialog.mdx
@@ -280,6 +280,8 @@ export const DynamicModelessDialog = () => {
 
 ## Props
 
+<ComponentPropsTable name="Dialog" showTitle />
+
 <ComponentPropsTable name="ActionDialog" showTitle />
 
 <ComponentPropsTable name="MessageDialog" showTitle />


### PR DESCRIPTION
## 課題・背景

- コンポーネントのDialogのPropsに「Dialog」がなかったので追加した。

## やったこと

- 👆のとおり。

<!--
- 〇〇に追記
- 〇〇ページを追加

## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認

- ファイルでの確認で十分だよ。

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
