### PR TITLE
フッターメニューにアクセシビリティを追加

### DIFF
--- a/src/__generated__/gatsby-types.ts
+++ b/src/__generated__/gatsby-types.ts
@@ -3026,6 +3026,9 @@ type FooterQuery = { readonly concept: { readonly nodes: ReadonlyArray<(
     )> }, readonly basics: { readonly nodes: ReadonlyArray<(
       Pick<Mdx, 'id'>
       & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> }
+    )> },readonly accessibility: { readonly nodes: ReadonlyArray<(
+      Pick<Mdx, 'id'>
+      & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> }
     )> }, readonly products: { readonly nodes: ReadonlyArray<(
       Pick<Mdx, 'id'>
       & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>>, readonly fields: Maybe<Pick<MdxFields, 'slug'>> }

--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -51,6 +51,20 @@ const query = graphql`
         }
       }
     }
+    accessibility: allMdx(
+      filter: { fields: { category: { eq: "accessibility" }, hierarchy: { glob: "*/*" } } }
+      sort: { fields: frontmatter___order }
+    ) {
+      nodes {
+        id
+        frontmatter {
+          title
+        }
+        fields {
+          slug
+        }
+      }
+    }
     products: allMdx(
       filter: { fields: { category: { eq: "products" }, hierarchy: { glob: "*/*" } } }
       sort: { fields: frontmatter___order }
@@ -86,6 +100,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
     concept: { nodes: concept },
     foundation: { nodes: foundation },
     basics: { nodes: basics },
+    accessibility: { nodes: accessibility },
     products: { nodes: products },
     communication: { nodes: communication },
   } = useStaticQuery<GatsbyTypes.FooterQuery>(query)
@@ -115,8 +130,6 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
                 })}
               </StyledUl>
             )}
-          </div>
-          <div>
             <StyledH3>
               <Link to="/foundation/">基本原則</Link>
               {foundation.length > 0 && (
@@ -133,12 +146,30 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
                 </StyledUl>
               )}
             </StyledH3>
+          </div>
+          <div>
             <StyledH3>
               <Link to="/basics/">基本要素</Link>
             </StyledH3>
             {basics.length > 0 && (
               <StyledUl>
                 {basics.map(({ fields, frontmatter }) => {
+                  if (fields?.slug === undefined) return null
+                  if (frontmatter?.title === undefined) return null
+                  return (
+                    <li key={fields.slug}>
+                      <Link to={fields.slug}>{frontmatter.title}</Link>
+                    </li>
+                  )
+                })}
+              </StyledUl>
+            )}
+            <StyledH3>
+              <Link to="/products/">アクセシビリティ</Link>
+            </StyledH3>
+            {accessibility.length > 0 && (
+              <StyledUl>
+                {accessibility.map(({ fields, frontmatter }) => {
                   if (fields?.slug === undefined) return null
                   if (frontmatter?.title === undefined) return null
                   return (
@@ -330,7 +361,7 @@ const StyledH3 = styled.h3`
 `
 
 const StyledUl = styled.ul`
-  margin: 0;
+  margin: 0 0 16px;
   padding: 0;
   list-style: none;
   color: ${CSS_COLOR.TEXT_BLACK};

--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -272,7 +272,7 @@ const LayoutContainer = styled.div<{ isArticlePage: boolean }>`
     'col1 . col2' auto
     'col1 . col2' auto
     'copy   copy copy' auto
-    / auto minmax(40px, 1fr) auto;
+    / auto minmax(80px, 1fr) auto;
   align-items: start;
   max-width: 1192px;
   ${({ isArticlePage }) =>
@@ -287,13 +287,13 @@ const LayoutContainer = styled.div<{ isArticlePage: boolean }>`
           padding-top: 72px;
         `}
 
-  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_1}) {
     grid-template:
       'col1 . col2' auto
       'col1 . col2' auto
       'col1 . col2' auto
       'copy   copy copy' auto
-      / auto 40px 1fr;
+      / auto 80px 1fr;
     padding-top: 32px;
   }
 
@@ -330,7 +330,7 @@ const Col2Container = styled.div`
   grid-template-columns: repeat(4, 1fr);
   gap: 40px;
 
-  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_1}) {
     grid-template-columns: 1fr;
     gap: 8px;
   }


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1060

## やったこと
フッターのナビゲーションメニューにアクセシビリティカテゴリのページも追加しました。

## 動作確認
https://deploy-preview-314--smarthr-design-system.netlify.app/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/193749099-71523727-ddbd-4bdf-bdb3-3afd6d07efa0.png" alt="" width="350"> | <img src="https://user-images.githubusercontent.com/7822534/193749550-ceef5340-111a-46d2-b2c5-3ed9b023c680.png" alt="" width="350"> |

### レイアウトについて
この各ページへのリンク部分は4カラムのレイアウトになっているため、基本原則を1カラム目に移動し、基本要素の下にアクセシビリティを入れたのが現在の状態です。
結果的に、フッター左端のログインボタンなどがあるカラムとの間の余白が減ってしまい、ちょっとアンバランスな印象かもしれません。

以下、解消できないか手元で試してみた方法です。

#### 1. 余白の最小値を増やす
<img src="https://user-images.githubusercontent.com/7822534/193750832-7c3ace3c-2f7b-45c7-9c5e-207351051010.png" width="350" alt>
現状では↑の2と3の間の最小値は40pxなので、80pxに増やすと以下のようになります。

![image](https://user-images.githubusercontent.com/7822534/193750654-02283d90-fdb1-479e-82a5-341739405156.png)


#### 2.アクセシビリティ以下のページタイトルを縮める
アクセシビリティカテゴリ以下のページタイトルのが比較的長いことが影響しているので、仮に縮められれば以下ようにはなります。ただし、画面幅が狭くなるとまた余白が縮んではきます。

**画面幅が広い**
![image](https://user-images.githubusercontent.com/7822534/193750453-6b19daef-1028-4cae-a372-c82f3ed1d686.png)

**画面幅が狭い**
![image](https://user-images.githubusercontent.com/7822534/193751150-be199c9f-ea6d-4a11-997f-055aea5ad7a4.png)
