### PR TITLE
テーブル内のテキストは`break-all`→`break-word`に変更

### DIFF
--- a/src/components/shared/GlobalStyle/GlobalStyle.tsx
+++ b/src/components/shared/GlobalStyle/GlobalStyle.tsx
@@ -41,6 +41,6 @@ export const GlobalStyle = createGlobalStyle`
   table td {
     box-sizing: border-box;
     padding: 0.5rem 1rem;
-    word-break: break-all;
+    word-break: break-word;
   }
 `


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1079

## やったこと
グローバルなCSS内で、`th`・`td`に対して`word-break: break-all;`が適用されていましたが、これを`break-word`に変更しました。

## やらなかったこと
`break-all`が適用されているのは他に、
- カラーパレット（ https://smarthr.design/products/design-tokens/color/#h2-3 ）
- コードブロック

がありますが、これらはそのままです。

## 動作確認
https://deploy-preview-329--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/

ダウンロードページのテーブルにも影響しているはずですが、URLなどは折り返されているので大丈夫そうです。
https://deploy-preview-329--smarthr-design-system.netlify.app/downloads/#h2-1

## キャプチャ

|Before|After|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/7822534/196334568-15d412a6-4151-4643-b9b1-62e7216e6222.png) | ![image](https://user-images.githubusercontent.com/7822534/196334594-b904a8fe-178f-42a7-9200-a06d0f4dfca9.png) |