### PR TITLE
remark-pluginのコードを修正

### DIFF
--- a/src/plugins/gatsby-remark-index-id-header/index.js
+++ b/src/plugins/gatsby-remark-index-id-header/index.js
@@ -32,7 +32,7 @@ module.exports = ({ markdownAST }) => {
     // 参考
     // - https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-autolink-headers/src/index.js
     patch(data, `id`, id)
-    patch(data, `htmlAttributes`, id)
+    patch(data, `htmlAttributes`, {})
     patch(data, `hProperties`, {})
     patch(data.htmlAttributes, `id`, id)
     patch(data.hProperties, `id`, id)


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1106

## やったこと
`src/plugins/gatsby-remark-index-id-header/index.js`のコードで、参考にしたGatsby公式のプラグインと異なる点があり、意図した動作にもなってなさそうなので、修正しました。

結果として、.mdxに含まれるh2〜h6ノードが持つ`data`オブジェクトの中身が、
**before**  
`{ id: 'h2-3', htmlAttributes: 'h2-3', hProperties: { id: 'h2-3' } }`

**after**
`{ id: 'h2-3', htmlAttributes: { id: 'h2-3' }, hProperties: { id: 'h2-3' } }`

に変わってしまいますが、その後の処理では`id`propsをhtmlの`id`として使うので、動作には影響がなさそうです。
このあたり→ https://github.com/kufu/smarthr-design-system/blob/6f3e729cdeef71865308afd965cd31d65915b65a/src/templates/article.tsx#L29-L52

## 動作確認
.mdx由来のページで、見出しへのアンカーリンクが以前と同様に動作していることを確認しました。
例：https://deploy-preview-347--smarthr-design-system.netlify.app/foundation/#h3-0

## キャプチャ
見た目の変化はありません。