### PR TITLE
アクセシビリティのリンクを修正

### DIFF
--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -165,7 +165,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
               </StyledUl>
             )}
             <StyledH3>
-              <Link to="/products/">アクセシビリティ</Link>
+              <Link to="/accessibility/">アクセシビリティ</Link>
             </StyledH3>
             {accessibility.length > 0 && (
               <StyledUl>


### PR DESCRIPTION
## 課題・背景

フッターのアクセシビリティのリンク先がプロダクトになっていたので、
アクセシビリティに変更しました


## やったこと
フッターのアクセシビリティのリンク先を`/accessibility/`に変更

## 動作確認
https://deploy-preview-349--smarthr-design-system.netlify.app/
