### PR TITLE
カラーパレットを追加、rgbaで記述できるように変更

### DIFF
--- a/content/articles/basics/colors/index.mdx
+++ b/content/articles/basics/colors/index.mdx
@@ -21,15 +21,15 @@ SmartHRでは、基本的に以下の色を使用してください。
 SmartHRブランドの中心となるブランドカラーです。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#00c4cc" colorName="SmartHR Blue" description="CMYK(70, 0, 30, 0)DIC 96、PANTONE 2397、白地でのテキストへの使用は非推奨です。" />
+  <ColorPalette colorValue="#00c4cc" colorName="SmartHR Blue" description="CMYK(70, 0, 30, 0)DIC 96、PANTONE 2397、白地でのテキストへの使用は非推奨です。" />
 </ColorPalettesWrapper>
 
 ### Secondary Brand Colors
 Primary Brand Colorを引き立たせるブランドカラーです。
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221f" colorName="Black" description="テキストへの使用を推奨します。" />
-  <ColorPalette hexCode="#ff9900" colorName="Orange" description="アクセントとしての使用を推奨します。" />
-  <ColorPalette hexCode="#ffffff" colorName="White" description="" />
+  <ColorPalette colorValue="#23221f" colorName="Black" description="テキストへの使用を推奨します。" />
+  <ColorPalette colorValue="#ff9900" colorName="Orange" description="アクセントとしての使用を推奨します。" />
+  <ColorPalette colorValue="#ffffff" colorName="White" description="" />
 </ColorPalettesWrapper>
 
 ### Extended Colors
@@ -41,82 +41,82 @@ SmartHRを説明/表現する際に必要な要素（テキスト、イラスト
 
 #### Stone
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f8f7f6" colorName="Stone01" description="" />
-  <ColorPalette hexCode="#edebe6" colorName="Stone02" description="" />
-  <ColorPalette hexCode="#aaa69f" colorName="Stone03" description="" />
-  <ColorPalette hexCode="#4e4c49" colorName="Stone04" description="テキストへの利用を推奨します。" />
+  <ColorPalette colorValue="#f8f7f6" colorName="Stone01" description="" />
+  <ColorPalette colorValue="#edebe6" colorName="Stone02" description="" />
+  <ColorPalette colorValue="#aaa69f" colorName="Stone03" description="" />
+  <ColorPalette colorValue="#4e4c49" colorName="Stone04" description="テキストへの利用を推奨します。" />
 </ColorPalettesWrapper>
 
 #### Aqua
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#d4f4f5" colorName="Aqua01" description="" />
-  <ColorPalette hexCode="#69d9de" colorName="Aqua02" description="" />
-  <ColorPalette hexCode="#12abb1" colorName="Aqua03" description="" />
-  <ColorPalette hexCode="#0f7f85" colorName="Aqua04" description="テキストへの使用を推奨します。" />
+  <ColorPalette colorValue="#d4f4f5" colorName="Aqua01" description="" />
+  <ColorPalette colorValue="#69d9de" colorName="Aqua02" description="" />
+  <ColorPalette colorValue="#12abb1" colorName="Aqua03" description="" />
+  <ColorPalette colorValue="#0f7f85" colorName="Aqua04" description="テキストへの使用を推奨します。" />
 </ColorPalettesWrapper>
 
 #### Sakura
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f9e9f7" colorName="Sakura01" description="" />
-  <ColorPalette hexCode="#f8b2e1" colorName="Sakura02" description="" />
-  <ColorPalette hexCode="#d362af" colorName="Sakura03" description="" />
-  <ColorPalette hexCode="#82407c" colorName="Sakura04" description="" />
+  <ColorPalette colorValue="#f9e9f7" colorName="Sakura01" description="" />
+  <ColorPalette colorValue="#f8b2e1" colorName="Sakura02" description="" />
+  <ColorPalette colorValue="#d362af" colorName="Sakura03" description="" />
+  <ColorPalette colorValue="#82407c" colorName="Sakura04" description="" />
 </ColorPalettesWrapper>
 
 #### Momiji
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffe7e5" colorName="Momiji01" description="" />
-  <ColorPalette hexCode="#ff9e9c" colorName="Momiji02" description="" />
-  <ColorPalette hexCode="#ec5a55" colorName="Momiji03" description="" />
-  <ColorPalette hexCode="#a53f3f" colorName="Momiji04" description="" />
+  <ColorPalette colorValue="#ffe7e5" colorName="Momiji01" description="" />
+  <ColorPalette colorValue="#ff9e9c" colorName="Momiji02" description="" />
+  <ColorPalette colorValue="#ec5a55" colorName="Momiji03" description="" />
+  <ColorPalette colorValue="#a53f3f" colorName="Momiji04" description="" />
 </ColorPalettesWrapper>
 
 #### Sunlight
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#faf2d0" colorName="Sunlight01" description="" />
-  <ColorPalette hexCode="#ffee11" colorName="Sunlight02" description="" />
-  <ColorPalette hexCode="#ffd74a" colorName="Sunlight03" description="" />
-  <ColorPalette hexCode="#f56121" colorName="Sunlight04" description="" />
+  <ColorPalette colorValue="#faf2d0" colorName="Sunlight01" description="" />
+  <ColorPalette colorValue="#ffee11" colorName="Sunlight02" description="" />
+  <ColorPalette colorValue="#ffd74a" colorName="Sunlight03" description="" />
+  <ColorPalette colorValue="#f56121" colorName="Sunlight04" description="" />
 </ColorPalettesWrapper>
 
 #### Grass
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#e6f2c8" colorName="Grass01" description="" />
-  <ColorPalette hexCode="#aee26b" colorName="Grass02" description="" />
-  <ColorPalette hexCode="#3dcc65" colorName="Grass03" description="" />
-  <ColorPalette hexCode="#378445" colorName="Grass04" description="" />
+  <ColorPalette colorValue="#e6f2c8" colorName="Grass01" description="" />
+  <ColorPalette colorValue="#aee26b" colorName="Grass02" description="" />
+  <ColorPalette colorValue="#3dcc65" colorName="Grass03" description="" />
+  <ColorPalette colorValue="#378445" colorName="Grass04" description="" />
 </ColorPalettesWrapper>
 
 #### Sky
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ddf2fb" colorName="Sky01" description="" />
-  <ColorPalette hexCode="#8fe2fc" colorName="Sky02" description="" />
-  <ColorPalette hexCode="#32b7f0" colorName="Sky03" description="" />
-  <ColorPalette hexCode="#1376a0" colorName="Sky04" description="" />
+  <ColorPalette colorValue="#ddf2fb" colorName="Sky01" description="" />
+  <ColorPalette colorValue="#8fe2fc" colorName="Sky02" description="" />
+  <ColorPalette colorValue="#32b7f0" colorName="Sky03" description="" />
+  <ColorPalette colorValue="#1376a0" colorName="Sky04" description="" />
 </ColorPalettesWrapper>
 
 #### Marine
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#dee9ff" colorName="Marine01" description="" />
-  <ColorPalette hexCode="#8ac0ff" colorName="Marine02" description="" />
-  <ColorPalette hexCode="#0075e3" colorName="Marine03" description="" />
-  <ColorPalette hexCode="#26519f" colorName="Marine04" description="" />
+  <ColorPalette colorValue="#dee9ff" colorName="Marine01" description="" />
+  <ColorPalette colorValue="#8ac0ff" colorName="Marine02" description="" />
+  <ColorPalette colorValue="#0075e3" colorName="Marine03" description="" />
+  <ColorPalette colorValue="#26519f" colorName="Marine04" description="" />
 </ColorPalettesWrapper>
 
 #### Galaxy
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#eee5fd" colorName="Galaxy01" description="" />
-  <ColorPalette hexCode="#9d8ef8" colorName="Galaxy02" description="" />
-  <ColorPalette hexCode="#8c5eee" colorName="Galaxy03" description="" />
-  <ColorPalette hexCode="#6e4ca6" colorName="Galaxy04" description="" />
+  <ColorPalette colorValue="#eee5fd" colorName="Galaxy01" description="" />
+  <ColorPalette colorValue="#9d8ef8" colorName="Galaxy02" description="" />
+  <ColorPalette colorValue="#8c5eee" colorName="Galaxy03" description="" />
+  <ColorPalette colorValue="#6e4ca6" colorName="Galaxy04" description="" />
 </ColorPalettesWrapper>
 
 #### Earth
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#fbede1" colorName="Earth01" description="" />
-  <ColorPalette hexCode="#f2d3a4" colorName="Earth02" description="" />
-  <ColorPalette hexCode="#ba621e" colorName="Earth03" description="" />
-  <ColorPalette hexCode="#76533e" colorName="Earth04" description="" />
+  <ColorPalette colorValue="#fbede1" colorName="Earth01" description="" />
+  <ColorPalette colorValue="#f2d3a4" colorName="Earth02" description="" />
+  <ColorPalette colorValue="#ba621e" colorName="Earth03" description="" />
+  <ColorPalette colorValue="#76533e" colorName="Earth04" description="" />
 </ColorPalettesWrapper>
 
 ## ダウンロード

--- a/content/articles/communication/capture/kit.mdx
+++ b/content/articles/communication/capture/kit.mdx
@@ -57,7 +57,7 @@ KeynoteやGoogleスライドなどのスライド資料の場合、サービス�
 サービス画面キャプチャなどに、枠線やテキストといった注釈をつける場合に使用します。
 
 <ColorPalettesWrapper>
- <ColorPalette hexCode="#fc0c59" colorName="Annotaion" description="" />
+ <ColorPalette colorValue="#fc0c59" colorName="Annotaion" description="" />
 </ColorPalettesWrapper>
 
 キャプチャの機能に特化したアプリケーション<a href="https://apps.apple.com/jp/app/skitch-%E6%92%AE%E3%82%8B-%E6%8F%8F%E3%81%8D%E8%BE%BC%E3%82%80-%E5%85%B1%E6%9C%89%E3%81%99%E3%82%8B/id425955336?mt=12" target="_blank">Skitch</a>の、デフォルトのカラーに合わせています。プロダクトキャプチャを利用した説明画像などを作成する際は、この色を使用して注釈やガイド線などを記入してください。

--- a/content/articles/operational-guideline/page-template/style-template.mdx
+++ b/content/articles/operational-guideline/page-template/style-template.mdx
@@ -146,8 +146,8 @@ SmartHR UI Layoutコンポーネントを使用できます。
 import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使用）" />
-  <ColorPalette hexCode="#ffffff" colorName="WHITE" description="コンポーネントの背景色（Base コンポーネントなど）" />
+  <ColorPalette colorValue="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使用）" />
+  <ColorPalette colorValue="#ffffff" colorName="WHITE" description="コンポーネントの背景色（Base コンポーネントなど）" />
 </ColorPalettesWrapper>
 
 ## 画像

--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -12,7 +12,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 色は情報を伝え、動作を示し、反応を促しますが、唯一の視覚的手段にしてはいけません。すべての利用者が同じ情報を知覚できる必要があります。
 
-## セマンティックトークン
+## セマンティクストークン
 
 ### メイン
 
@@ -67,13 +67,13 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
   <ColorPalette colorValue="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
   <ColorPalette colorValue="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
   <ColorPalette colorValue="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
-  <ColorPalette colorValue="#03030226" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
-  <ColorPalette colorValue="#03030280" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
-  <ColorPalette colorValue="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
+  <ColorPalette colorValue="rgba(3,3,2,0.15)" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
+  <ColorPalette colorValue="rgba(3,3,2,0.5)" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
+  <ColorPalette colorValue="rgba(255,255,255,0)" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
 </ColorPalettesWrapper>
 
 ## プリミティブトークン
-**セマンティックトークンだけで視覚設計を十分に行なえない場合のみ**、プリミティブトークンから色を使用できます。
+**セマンティクストークンだけで視覚設計を十分に行なえない場合のみ**、プリミティブトークンから色を使用できます。
 
 ### 基本色
 <ColorPalettesWrapper>
@@ -101,9 +101,9 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 ### 透明色
 <ColorPalettesWrapper>
-  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
-  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
-  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
+  <ColorPalette colorValue="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
+  <ColorPalette colorValue="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
+  <ColorPalette colorValue="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
 </ColorPalettesWrapper>
 
 ## 色の新旧比較
@@ -122,8 +122,8 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### WHITE
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#ffffff" colorName="新 ※変更なし" />
-  <ColorPalette colorValue="#ffffff" colorName="旧" />
+  <ColorPalette colorValue="#fff" colorName="新 ※変更なし" />
+  <ColorPalette colorValue="#fff" colorName="旧" />
 </ColorPalettesWrapper>
 
 ### アクセント
@@ -173,7 +173,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### TEXT_WHITE（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#ffffff" colorName="新" />
+  <ColorPalette colorValue="#fff" colorName="新" />
 </ColorPalettesWrapper>
 
 ### コンポーネント
@@ -219,20 +219,20 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### OVERLAY
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#03030226" colorName="新" />
-  <ColorPalette colorValue="#00000026" colorName="旧" />
+  <ColorPalette colorValue="rgba(3,3,2,0.15)" colorName="新" />
+  <ColorPalette colorValue="rgba(0,0,0,0.15)" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### SCRIM
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#03030280" colorName="新" />
-  <ColorPalette colorValue="#0000007f" colorName="旧" />
+  <ColorPalette colorValue="rgba(3,3,3,0.4)" colorName="新" />
+  <ColorPalette colorValue="rgba(0,0,0,0.5)" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TRANSPARENT
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#ffffff00" colorName="新 ※変更なし" />
-  <ColorPalette colorValue="#ffffff00" colorName="旧" />
+  <ColorPalette colorValue="rgba(255,255,255,0)" colorName="新 ※変更なし" />
+  <ColorPalette colorValue="rgba(255,255,255,0)" colorName="旧" />
 </ColorPalettesWrapper>

--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -21,8 +21,8 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 プライマリーカラーは、プロダクトの印象を司る箇所に使います。具体的な使用箇所は、各コンポーネントを参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
-  <ColorPalette hexCode="#fff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
+  <ColorPalette colorValue="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
+  <ColorPalette colorValue="#fff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
 </ColorPalettesWrapper>
 
 
@@ -34,8 +34,8 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 具体的な使用箇所は、各コンポーネントを参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#e01e5a" colorName="DANGER" description="エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）" />
-  <ColorPalette hexCode="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う" />
+  <ColorPalette colorValue="#e01e5a" colorName="DANGER" description="エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）" />
+  <ColorPalette colorValue="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う" />
 </ColorPalettesWrapper>
 
 
@@ -46,11 +46,11 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 強調などの文字スタイルは、[タイポグラフィ](/products/design-tokens/typography/)を参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221e" colorName="TEXT_BLACK" description="基本的な文字の色" />
-  <ColorPalette hexCode="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
-  <ColorPalette hexCode="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
-  <ColorPalette hexCode="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
-  <ColorPalette hexCode="#fff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
+  <ColorPalette colorValue="#23221e" colorName="TEXT_BLACK" description="基本的な文字の色" />
+  <ColorPalette colorValue="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
+  <ColorPalette colorValue="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
+  <ColorPalette colorValue="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
+  <ColorPalette colorValue="#fff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
 </ColorPalettesWrapper>
 
 
@@ -61,49 +61,49 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 具体的な使用箇所は、各コンポーネントを参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#d6d3d0" colorName="BORDER" description="枠線・罫線の色" />
-  <ColorPalette hexCode="#d6d3d0" colorName="ACTION_BACKGROUND" description="TableBulkActionAreaの背景色" />
-  <ColorPalette hexCode="#edebe8" colorName="HEAD" description="テーブルヘッダーの背景色" />
-  <ColorPalette hexCode="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette hexCode="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette hexCode="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
-  <ColorPalette hexCode="#03030226" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
-  <ColorPalette hexCode="#03030280" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
-  <ColorPalette hexCode="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
+  <ColorPalette colorValue="#d6d3d0" colorName="BORDER" description="枠線・罫線の色" />
+  <ColorPalette colorValue="#d6d3d0" colorName="ACTION_BACKGROUND" description="TableBulkActionAreaの背景色" />
+  <ColorPalette colorValue="#edebe8" colorName="HEAD" description="テーブルヘッダーの背景色" />
+  <ColorPalette colorValue="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
+  <ColorPalette colorValue="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
+  <ColorPalette colorValue="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
+  <ColorPalette colorValue="#03030226" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
+  <ColorPalette colorValue="#03030280" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
+  <ColorPalette colorValue="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
 </ColorPalettesWrapper>
 
 ## プリミティブトークン
-意味を持たない視覚設計等に色を使用する場合は以下のカラーパレットから選んでください。
+**セマンティックトークンだけで視覚設計を十分に行なえない場合のみ**、プリミティブトークンから色を使用できます。
 
 ### 基本色
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#030302" colorName="BLACK" />
-  <ColorPalette hexCode="#fff" colorName="WHITE"/>
-  <ColorPalette hexCode="#0077c7" colorName="BLUE_100" />
-  <ColorPalette hexCode="#0071c1" colorName="BLUE_101" />
-  <ColorPalette hexCode="#e01e5a" colorName="RED_100" />
-  <ColorPalette hexCode="#ff8800" colorName="ORANGE_100" />
-  <ColorPalette hexCode="#ffcc17" colorName="YELLOW_100" />
-  <ColorPalette hexCode="#00c4cc" colorName="SMARTHR_BLUE"/>
+  <ColorPalette colorValue="#030302" colorName="BLACK" />
+  <ColorPalette colorValue="#fff" colorName="WHITE"/>
+  <ColorPalette colorValue="#0077c7" colorName="BLUE_100" />
+  <ColorPalette colorValue="#0071c1" colorName="BLUE_101" />
+  <ColorPalette colorValue="#e01e5a" colorName="RED_100" />
+  <ColorPalette colorValue="#ff8800" colorName="ORANGE_100" />
+  <ColorPalette colorValue="#ffcc17" colorName="YELLOW_100" />
+  <ColorPalette colorValue="#00c4cc" colorName="SMARTHR_BLUE"/>
 </ColorPalettesWrapper>
 
 ### グレースケール
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f8f7f6" colorName="GREY_5" />
-  <ColorPalette hexCode="#f5f4f3" colorName="GREY_6"/>
-  <ColorPalette hexCode="#f2f1f0" colorName="GREY_7" />
-  <ColorPalette hexCode="#edebe8" colorName="GREY_9" />
-  <ColorPalette hexCode="#d6d3d0" colorName="GREY_20" />
-  <ColorPalette hexCode="#c1bdb7" colorName="GREY_30" />
-  <ColorPalette hexCode="#706d65" colorName="GREY_65" />
-  <ColorPalette hexCode="#23221e" colorName="GREY_100"/>
+  <ColorPalette colorValue="#f8f7f6" colorName="GREY_5" />
+  <ColorPalette colorValue="#f5f4f3" colorName="GREY_6"/>
+  <ColorPalette colorValue="#f2f1f0" colorName="GREY_7" />
+  <ColorPalette colorValue="#edebe8" colorName="GREY_9" />
+  <ColorPalette colorValue="#d6d3d0" colorName="GREY_20" />
+  <ColorPalette colorValue="#c1bdb7" colorName="GREY_30" />
+  <ColorPalette colorValue="#706d65" colorName="GREY_65" />
+  <ColorPalette colorValue="#23221e" colorName="GREY_100"/>
 </ColorPalettesWrapper>
 
 ### 透明色
 <ColorPalettesWrapper>
-  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
-  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
-  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
+  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
+  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
+  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
 </ColorPalettesWrapper>
 
 ## 色の新旧比較
@@ -115,124 +115,124 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### MAIN
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0077c7" colorName="新" />
-  <ColorPalette hexCode="#00a5ab" colorName="旧" />
+  <ColorPalette colorValue="#0077c7" colorName="新" />
+  <ColorPalette colorValue="#00a5ab" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### WHITE
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffffff" colorName="新 ※変更なし" />
-  <ColorPalette hexCode="#ffffff" colorName="旧" />
+  <ColorPalette colorValue="#ffffff" colorName="新 ※変更なし" />
+  <ColorPalette colorValue="#ffffff" colorName="旧" />
 </ColorPalettesWrapper>
 
 ### アクセント
 #### DANGER
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#e01e5a" colorName="新" />
-  <ColorPalette hexCode="#ef475b" colorName="旧" />
+  <ColorPalette colorValue="#e01e5a" colorName="新" />
+  <ColorPalette colorValue="#ef475b" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### WARNING（WARNING_YELLOW）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffcc17" colorName="新" />
-  <ColorPalette hexCode="#ff8800" colorName="旧" />
+  <ColorPalette colorValue="#ffcc17" colorName="新" />
+  <ColorPalette colorValue="#ff8800" colorName="旧" />
 </ColorPalettesWrapper>
 
 ### 文字
 #### TEXT_BLACK
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221e" colorName="新" />
-  <ColorPalette hexCode="#333333" colorName="旧" />
+  <ColorPalette colorValue="#23221e" colorName="新" />
+  <ColorPalette colorValue="#333333" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_GREY
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#706d65" colorName="新" />
-  <ColorPalette hexCode="#767676" colorName="旧" />
+  <ColorPalette colorValue="#706d65" colorName="新" />
+  <ColorPalette colorValue="#767676" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_LINK
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0071c1" colorName="新" />
-  <ColorPalette hexCode="#007bc2" colorName="旧" />
+  <ColorPalette colorValue="#0071c1" colorName="新" />
+  <ColorPalette colorValue="#007bc2" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_DISABLED
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#c1bdb7" colorName="新" />
-  <ColorPalette hexCode="#c1c1c1" colorName="旧" />
+  <ColorPalette colorValue="#c1bdb7" colorName="新" />
+  <ColorPalette colorValue="#c1c1c1" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_WHITE（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffffff" colorName="新" />
+  <ColorPalette colorValue="#ffffff" colorName="新" />
 </ColorPalettesWrapper>
 
 ### コンポーネント
 #### BORDER
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#d6d3d0" colorName="新" />
-  <ColorPalette hexCode="#d6d6d6" colorName="旧" />
+  <ColorPalette colorValue="#d6d3d0" colorName="新" />
+  <ColorPalette colorValue="#d6d6d6" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### ACTION_BACKGROUND（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#d6d3d0" colorName="新" />
+  <ColorPalette colorValue="#d6d3d0" colorName="新" />
 </ColorPalettesWrapper>
 
 #### HEAD（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#edebe8" colorName="新" />
+  <ColorPalette colorValue="#edebe8" colorName="新" />
 </ColorPalettesWrapper>
 
 #### OVER_BACKGROUND（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f2f1f0" colorName="新" />
+  <ColorPalette colorValue="#f2f1f0" colorName="新" />
 </ColorPalettesWrapper>
 
 #### COLUMN
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f8f7f6" colorName="新" />
-  <ColorPalette hexCode="#f9f9f9" colorName="旧" />
+  <ColorPalette colorValue="#f8f7f6" colorName="新" />
+  <ColorPalette colorValue="#f9f9f9" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### BACKGROUND
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f8f7f6" colorName="新" />
-  <ColorPalette hexCode="#f5f6fa" colorName="旧" />
+  <ColorPalette colorValue="#f8f7f6" colorName="新" />
+  <ColorPalette colorValue="#f5f6fa" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### OVERLAY
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#03030226" colorName="新" />
-  <ColorPalette hexCode="#00000026" colorName="旧" />
+  <ColorPalette colorValue="#03030226" colorName="新" />
+  <ColorPalette colorValue="#00000026" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### SCRIM
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#03030280" colorName="新" />
-  <ColorPalette hexCode="#0000007f" colorName="旧" />
+  <ColorPalette colorValue="#03030280" colorName="新" />
+  <ColorPalette colorValue="#0000007f" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TRANSPARENT
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffffff00" colorName="新 ※変更なし" />
-  <ColorPalette hexCode="#ffffff00" colorName="旧" />
+  <ColorPalette colorValue="#ffffff00" colorName="新 ※変更なし" />
+  <ColorPalette colorValue="#ffffff00" colorName="旧" />
 </ColorPalettesWrapper>

--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -101,9 +101,9 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 ### 透明色
 <ColorPalettesWrapper>
-  <ColorPalette iscolorValue={false} colorValue="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
-  <ColorPalette iscolorValue={false} colorValue="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
-  <ColorPalette iscolorValue={false} colorValue="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
+  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
+  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
+  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
 </ColorPalettesWrapper>
 
 ## 色の新旧比較

--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -12,7 +12,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 色は情報を伝え、動作を示し、反応を促しますが、唯一の視覚的手段にしてはいけません。すべての利用者が同じ情報を知覚できる必要があります。
 
-## セマンティック
+## セマンティックトークン
 
 ### メイン
 
@@ -21,8 +21,8 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 プライマリーカラーは、プロダクトの印象を司る箇所に使います。具体的な使用箇所は、各コンポーネントを参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
-  <ColorPalette colorValue="#ffffff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
+  <ColorPalette hexCode="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
+  <ColorPalette hexCode="#fff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
 </ColorPalettesWrapper>
 
 
@@ -34,8 +34,8 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 具体的な使用箇所は、各コンポーネントを参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#e01e5a" colorName="DANGER" description="エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）" />
-  <ColorPalette colorValue="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う" />
+  <ColorPalette hexCode="#e01e5a" colorName="DANGER" description="エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）" />
+  <ColorPalette hexCode="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う" />
 </ColorPalettesWrapper>
 
 
@@ -46,11 +46,11 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 強調などの文字スタイルは、[タイポグラフィ](/products/design-tokens/typography/)を参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#23221e" colorName="TEXT_BLACK" description="基本的な文字の色" />
-  <ColorPalette colorValue="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
-  <ColorPalette colorValue="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
-  <ColorPalette colorValue="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
-  <ColorPalette colorValue="#ffffff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
+  <ColorPalette hexCode="#23221e" colorName="TEXT_BLACK" description="基本的な文字の色" />
+  <ColorPalette hexCode="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
+  <ColorPalette hexCode="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
+  <ColorPalette hexCode="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
+  <ColorPalette hexCode="#fff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
 </ColorPalettesWrapper>
 
 
@@ -61,15 +61,15 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 具体的な使用箇所は、各コンポーネントを参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#d6d3d0" colorName="BORDER" description="枠線・罫線の色" />
-  <ColorPalette colorValue="#d6d3d0" colorName="ACTION_BACKGROUND" description="TableBulkActionAreaの背景色" />
-  <ColorPalette colorValue="#edebe8" colorName="HEAD" description="テーブルヘッダーの背景色" />
-  <ColorPalette colorValue="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette colorValue="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette colorValue="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
-  <ColorPalette colorValue="#03030226" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
-  <ColorPalette colorValue="#03030280" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
-  <ColorPalette colorValue="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
+  <ColorPalette hexCode="#d6d3d0" colorName="BORDER" description="枠線・罫線の色" />
+  <ColorPalette hexCode="#d6d3d0" colorName="ACTION_BACKGROUND" description="TableBulkActionAreaの背景色" />
+  <ColorPalette hexCode="#edebe8" colorName="HEAD" description="テーブルヘッダーの背景色" />
+  <ColorPalette hexCode="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
+  <ColorPalette hexCode="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
+  <ColorPalette hexCode="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
+  <ColorPalette hexCode="#03030226" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
+  <ColorPalette hexCode="#03030280" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
+  <ColorPalette hexCode="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
 </ColorPalettesWrapper>
 
 ## プリミティブトークン
@@ -77,33 +77,33 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 ### 基本色
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#030302" colorName="BLACK" />
-  <ColorPalette colorValue="#ffffff" colorName="WHITE"/>
-  <ColorPalette colorValue="#0077c7" colorName="BLUE_100" />
-  <ColorPalette colorValue="#0071c1" colorName="BLUE_101" />
-  <ColorPalette colorValue="#e01e5a" colorName="RED_100" />
-  <ColorPalette colorValue="#ff8800" colorName="ORANGE_100" />
-  <ColorPalette colorValue="#ffcc17" colorName="YELLOW_100" />
-  <ColorPalette colorValue="#00c4cc" colorName="SMARTHR_BLUE"/>
+  <ColorPalette hexCode="#030302" colorName="BLACK" />
+  <ColorPalette hexCode="#fff" colorName="WHITE"/>
+  <ColorPalette hexCode="#0077c7" colorName="BLUE_100" />
+  <ColorPalette hexCode="#0071c1" colorName="BLUE_101" />
+  <ColorPalette hexCode="#e01e5a" colorName="RED_100" />
+  <ColorPalette hexCode="#ff8800" colorName="ORANGE_100" />
+  <ColorPalette hexCode="#ffcc17" colorName="YELLOW_100" />
+  <ColorPalette hexCode="#00c4cc" colorName="SMARTHR_BLUE"/>
 </ColorPalettesWrapper>
 
 ### グレースケール
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#f8f7f6" colorName="GREY_5" />
-  <ColorPalette colorValue="#f5f4f3" colorName="GREY_6"/>
-  <ColorPalette colorValue="#f2f1f0" colorName="GREY_7" />
-  <ColorPalette colorValue="#edebe8" colorName="GREY_9" />
-  <ColorPalette colorValue="#d6d3d0" colorName="GREY_20" />
-  <ColorPalette colorValue="#c1bdb7" colorName="GREY_30" />
-  <ColorPalette colorValue="#706d65" colorName="GREY_65" />
-  <ColorPalette colorValue="#23221e" colorName="GREY_100"/>
+  <ColorPalette hexCode="#f8f7f6" colorName="GREY_5" />
+  <ColorPalette hexCode="#f5f4f3" colorName="GREY_6"/>
+  <ColorPalette hexCode="#f2f1f0" colorName="GREY_7" />
+  <ColorPalette hexCode="#edebe8" colorName="GREY_9" />
+  <ColorPalette hexCode="#d6d3d0" colorName="GREY_20" />
+  <ColorPalette hexCode="#c1bdb7" colorName="GREY_30" />
+  <ColorPalette hexCode="#706d65" colorName="GREY_65" />
+  <ColorPalette hexCode="#23221e" colorName="GREY_100"/>
 </ColorPalettesWrapper>
 
 ### 透明色
 <ColorPalettesWrapper>
-  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
-  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
-  <ColorPalette isHexCode={false} colorValue="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
+  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
+  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
+  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
 </ColorPalettesWrapper>
 
 ## 色の新旧比較
@@ -115,124 +115,124 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### MAIN
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#0077c7" colorName="新" />
-  <ColorPalette colorValue="#00a5ab" colorName="旧" />
+  <ColorPalette hexCode="#0077c7" colorName="新" />
+  <ColorPalette hexCode="#00a5ab" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### WHITE
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#ffffff" colorName="新 ※変更なし" />
-  <ColorPalette colorValue="#ffffff" colorName="旧" />
+  <ColorPalette hexCode="#ffffff" colorName="新 ※変更なし" />
+  <ColorPalette hexCode="#ffffff" colorName="旧" />
 </ColorPalettesWrapper>
 
 ### アクセント
 #### DANGER
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#e01e5a" colorName="新" />
-  <ColorPalette colorValue="#ef475b" colorName="旧" />
+  <ColorPalette hexCode="#e01e5a" colorName="新" />
+  <ColorPalette hexCode="#ef475b" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### WARNING（WARNING_YELLOW）
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#ffcc17" colorName="新" />
-  <ColorPalette colorValue="#ff8800" colorName="旧" />
+  <ColorPalette hexCode="#ffcc17" colorName="新" />
+  <ColorPalette hexCode="#ff8800" colorName="旧" />
 </ColorPalettesWrapper>
 
 ### 文字
 #### TEXT_BLACK
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#23221e" colorName="新" />
-  <ColorPalette colorValue="#333333" colorName="旧" />
+  <ColorPalette hexCode="#23221e" colorName="新" />
+  <ColorPalette hexCode="#333333" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_GREY
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#706d65" colorName="新" />
-  <ColorPalette colorValue="#767676" colorName="旧" />
+  <ColorPalette hexCode="#706d65" colorName="新" />
+  <ColorPalette hexCode="#767676" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_LINK
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#0071c1" colorName="新" />
-  <ColorPalette colorValue="#007bc2" colorName="旧" />
+  <ColorPalette hexCode="#0071c1" colorName="新" />
+  <ColorPalette hexCode="#007bc2" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_DISABLED
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#c1bdb7" colorName="新" />
-  <ColorPalette colorValue="#c1c1c1" colorName="旧" />
+  <ColorPalette hexCode="#c1bdb7" colorName="新" />
+  <ColorPalette hexCode="#c1c1c1" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_WHITE（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#ffffff" colorName="新" />
+  <ColorPalette hexCode="#ffffff" colorName="新" />
 </ColorPalettesWrapper>
 
 ### コンポーネント
 #### BORDER
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#d6d3d0" colorName="新" />
-  <ColorPalette colorValue="#d6d6d6" colorName="旧" />
+  <ColorPalette hexCode="#d6d3d0" colorName="新" />
+  <ColorPalette hexCode="#d6d6d6" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### ACTION_BACKGROUND（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#d6d3d0" colorName="新" />
+  <ColorPalette hexCode="#d6d3d0" colorName="新" />
 </ColorPalettesWrapper>
 
 #### HEAD（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#edebe8" colorName="新" />
+  <ColorPalette hexCode="#edebe8" colorName="新" />
 </ColorPalettesWrapper>
 
 #### OVER_BACKGROUND（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#f2f1f0" colorName="新" />
+  <ColorPalette hexCode="#f2f1f0" colorName="新" />
 </ColorPalettesWrapper>
 
 #### COLUMN
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#f8f7f6" colorName="新" />
-  <ColorPalette colorValue="#f9f9f9" colorName="旧" />
+  <ColorPalette hexCode="#f8f7f6" colorName="新" />
+  <ColorPalette hexCode="#f9f9f9" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### BACKGROUND
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#f8f7f6" colorName="新" />
-  <ColorPalette colorValue="#f5f6fa" colorName="旧" />
+  <ColorPalette hexCode="#f8f7f6" colorName="新" />
+  <ColorPalette hexCode="#f5f6fa" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### OVERLAY
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#03030226" colorName="新" />
-  <ColorPalette colorValue="#00000026" colorName="旧" />
+  <ColorPalette hexCode="#03030226" colorName="新" />
+  <ColorPalette hexCode="#00000026" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### SCRIM
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#03030280" colorName="新" />
-  <ColorPalette colorValue="#0000007f" colorName="旧" />
+  <ColorPalette hexCode="#03030280" colorName="新" />
+  <ColorPalette hexCode="#0000007f" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TRANSPARENT
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="#ffffff00" colorName="新 ※変更なし" />
-  <ColorPalette colorValue="#ffffff00" colorName="旧" />
+  <ColorPalette hexCode="#ffffff00" colorName="新 ※変更なし" />
+  <ColorPalette hexCode="#ffffff00" colorName="旧" />
 </ColorPalettesWrapper>

--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -12,8 +12,9 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 色は情報を伝え、動作を示し、反応を促しますが、唯一の視覚的手段にしてはいけません。すべての利用者が同じ情報を知覚できる必要があります。
 
+## セマンティック
 
-## メイン
+### メイン
 
 プライマリーカラーである`MAIN`と、コンポーネントのベースカラーとなる`WHITE`を定めています。
 
@@ -25,7 +26,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 </ColorPalettesWrapper>
 
 
-## アクセント
+### アクセント
 コンテキストに応じた色を定めています。
 
 `MAIN`と合わせて、ユーザーのメインアクションや、アクションに対する結果、ヘルプの表示、オブジェクトの状態を表します。
@@ -38,7 +39,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 </ColorPalettesWrapper>
 
 
-## 文字
+### 文字
 
 テキストの状態に応じた文字の色を定めています。
 
@@ -53,7 +54,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 </ColorPalettesWrapper>
 
 
-## コンポーネント
+### コンポーネント
 
 コンポーネントを構成する要素に必要な色を定めています。
 
@@ -71,6 +72,39 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
   <ColorPalette hexCode="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
 </ColorPalettesWrapper>
 
+## カラーパレット
+意味を持たない視覚設計等に色を使用する場合は以下のカラーパレットから選んでください。
+
+### プリミティブ
+<ColorPalettesWrapper>
+  <ColorPalette hexCode="#030302" colorName="BLACK" />
+  <ColorPalette hexCode="#fff" colorName="WHITE"/>
+  <ColorPalette hexCode="#0077c7" colorName="BLUE_100" />
+  <ColorPalette hexCode="#0071c1" colorName="BLUE_101" />
+  <ColorPalette hexCode="#e01e5a" colorName="RED_100" />
+  <ColorPalette hexCode="#ff8800" colorName="ORANGE_100" />
+  <ColorPalette hexCode="#ffcc17" colorName="YELLOW_100" />
+  <ColorPalette hexCode="#00c4cc" colorName="SMARTHR_BLUE"/>
+</ColorPalettesWrapper>
+
+### グレースケール
+<ColorPalettesWrapper>
+  <ColorPalette hexCode="#f8f7f6" colorName="GREY_5" />
+  <ColorPalette hexCode="#f5f4f3" colorName="GREY_6"/>
+  <ColorPalette hexCode="#f2f1f0" colorName="GREY_7" />
+  <ColorPalette hexCode="#edebe8" colorName="GREY_9" />
+  <ColorPalette hexCode="#d6d3d0" colorName="GREY_20" />
+  <ColorPalette hexCode="#c1bdb7" colorName="GREY_30" />
+  <ColorPalette hexCode="#706d65" colorName="GREY_65" />
+  <ColorPalette hexCode="#23221e" colorName="GREY_100"/>
+</ColorPalettesWrapper>
+
+### 透明色
+<ColorPalettesWrapper>
+  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
+  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
+  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
+</ColorPalettesWrapper>
 
 ## 色の新旧比較
 2021年2月にプロダクトの色をアップデートしました。
@@ -81,124 +115,124 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### MAIN
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0077c7" colorName="新" description="" />
-  <ColorPalette hexCode="#00a5ab" colorName="旧" description="" />
+  <ColorPalette hexCode="#0077c7" colorName="新" />
+  <ColorPalette hexCode="#00a5ab" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### WHITE
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffffff" colorName="新 ※変更なし" description="" />
-  <ColorPalette hexCode="#ffffff" colorName="旧" description="" />
+  <ColorPalette hexCode="#ffffff" colorName="新 ※変更なし" />
+  <ColorPalette hexCode="#ffffff" colorName="旧" />
 </ColorPalettesWrapper>
 
 ### アクセント
 #### DANGER
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#e01e5a" colorName="新" description="" />
-  <ColorPalette hexCode="#ef475b" colorName="旧" description="" />
+  <ColorPalette hexCode="#e01e5a" colorName="新" />
+  <ColorPalette hexCode="#ef475b" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### WARNING（WARNING_YELLOW）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffcc17" colorName="新" description="" />
-  <ColorPalette hexCode="#ff8800" colorName="旧" description="" />
+  <ColorPalette hexCode="#ffcc17" colorName="新" />
+  <ColorPalette hexCode="#ff8800" colorName="旧" />
 </ColorPalettesWrapper>
 
 ### 文字
 #### TEXT_BLACK
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221e" colorName="新" description="" />
-  <ColorPalette hexCode="#333333" colorName="旧" description="" />
+  <ColorPalette hexCode="#23221e" colorName="新" />
+  <ColorPalette hexCode="#333333" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_GREY
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#706d65" colorName="新" description="" />
-  <ColorPalette hexCode="#767676" colorName="旧" description="" />
+  <ColorPalette hexCode="#706d65" colorName="新" />
+  <ColorPalette hexCode="#767676" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_LINK
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0071c1" colorName="新" description="" />
-  <ColorPalette hexCode="#007bc2" colorName="旧" description="" />
+  <ColorPalette hexCode="#0071c1" colorName="新" />
+  <ColorPalette hexCode="#007bc2" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_DISABLED
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#c1bdb7" colorName="新" description="" />
-  <ColorPalette hexCode="#c1c1c1" colorName="旧" description="" />
+  <ColorPalette hexCode="#c1bdb7" colorName="新" />
+  <ColorPalette hexCode="#c1c1c1" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_WHITE（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffffff" colorName="新" description="" />
+  <ColorPalette hexCode="#ffffff" colorName="新" />
 </ColorPalettesWrapper>
 
 ### コンポーネント
 #### BORDER
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#d6d3d0" colorName="新" description="" />
-  <ColorPalette hexCode="#d6d6d6" colorName="旧" description="" />
+  <ColorPalette hexCode="#d6d3d0" colorName="新" />
+  <ColorPalette hexCode="#d6d6d6" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### ACTION_BACKGROUND（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#d6d3d0" colorName="新" description="" />
+  <ColorPalette hexCode="#d6d3d0" colorName="新" />
 </ColorPalettesWrapper>
 
 #### HEAD（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#edebe8" colorName="新" description="" />
+  <ColorPalette hexCode="#edebe8" colorName="新" />
 </ColorPalettesWrapper>
 
 #### OVER_BACKGROUND（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f2f1f0" colorName="新" description="" />
+  <ColorPalette hexCode="#f2f1f0" colorName="新" />
 </ColorPalettesWrapper>
 
 #### COLUMN
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f8f7f6" colorName="新" description="" />
-  <ColorPalette hexCode="#f9f9f9" colorName="旧" description="" />
+  <ColorPalette hexCode="#f8f7f6" colorName="新" />
+  <ColorPalette hexCode="#f9f9f9" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### BACKGROUND
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f8f7f6" colorName="新" description="" />
-  <ColorPalette hexCode="#f5f6fa" colorName="旧" description="" />
+  <ColorPalette hexCode="#f8f7f6" colorName="新" />
+  <ColorPalette hexCode="#f5f6fa" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### OVERLAY
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#03030226" colorName="新" description="" />
-  <ColorPalette hexCode="#00000026" colorName="旧" description="" />
+  <ColorPalette hexCode="#03030226" colorName="新" />
+  <ColorPalette hexCode="#00000026" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### SCRIM
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#03030280" colorName="新" description="" />
-  <ColorPalette hexCode="#0000007f" colorName="旧" description="" />
+  <ColorPalette hexCode="#03030280" colorName="新" />
+  <ColorPalette hexCode="#0000007f" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TRANSPARENT
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffffff00" colorName="新 ※変更なし" description="" />
-  <ColorPalette hexCode="#ffffff00" colorName="旧" description="" />
+  <ColorPalette hexCode="#ffffff00" colorName="新 ※変更なし" />
+  <ColorPalette hexCode="#ffffff00" colorName="旧" />
 </ColorPalettesWrapper>

--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -72,10 +72,10 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
   <ColorPalette hexCode="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
 </ColorPalettesWrapper>
 
-## カラーパレット
+## プリミティブトークン
 意味を持たない視覚設計等に色を使用する場合は以下のカラーパレットから選んでください。
 
-### プリミティブ
+### 基本色
 <ColorPalettesWrapper>
   <ColorPalette hexCode="#030302" colorName="BLACK" />
   <ColorPalette hexCode="#fff" colorName="WHITE"/>

--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -22,7 +22,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 <ColorPalettesWrapper>
   <ColorPalette colorValue="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
-  <ColorPalette colorValue="#fff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
+  <ColorPalette colorValue="#ffffff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
 </ColorPalettesWrapper>
 
 
@@ -50,7 +50,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
   <ColorPalette colorValue="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
   <ColorPalette colorValue="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
   <ColorPalette colorValue="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
-  <ColorPalette colorValue="#fff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
+  <ColorPalette colorValue="#ffffff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
 </ColorPalettesWrapper>
 
 
@@ -78,7 +78,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 ### 基本色
 <ColorPalettesWrapper>
   <ColorPalette colorValue="#030302" colorName="BLACK" />
-  <ColorPalette colorValue="#fff" colorName="WHITE"/>
+  <ColorPalette colorValue="#ffffff" colorName="WHITE"/>
   <ColorPalette colorValue="#0077c7" colorName="BLUE_100" />
   <ColorPalette colorValue="#0071c1" colorName="BLUE_101" />
   <ColorPalette colorValue="#e01e5a" colorName="RED_100" />

--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -21,8 +21,8 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 プライマリーカラーは、プロダクトの印象を司る箇所に使います。具体的な使用箇所は、各コンポーネントを参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
-  <ColorPalette hexCode="#fff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
+  <ColorPalette colorValue="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
+  <ColorPalette colorValue="#fff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
 </ColorPalettesWrapper>
 
 
@@ -34,8 +34,8 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 具体的な使用箇所は、各コンポーネントを参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#e01e5a" colorName="DANGER" description="エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）" />
-  <ColorPalette hexCode="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う" />
+  <ColorPalette colorValue="#e01e5a" colorName="DANGER" description="エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）" />
+  <ColorPalette colorValue="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う" />
 </ColorPalettesWrapper>
 
 
@@ -46,11 +46,11 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 強調などの文字スタイルは、[タイポグラフィ](/products/design-tokens/typography/)を参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221e" colorName="TEXT_BLACK" description="基本的な文字の色" />
-  <ColorPalette hexCode="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
-  <ColorPalette hexCode="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
-  <ColorPalette hexCode="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
-  <ColorPalette hexCode="#fff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
+  <ColorPalette colorValue="#23221e" colorName="TEXT_BLACK" description="基本的な文字の色" />
+  <ColorPalette colorValue="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
+  <ColorPalette colorValue="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
+  <ColorPalette colorValue="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
+  <ColorPalette colorValue="#fff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
 </ColorPalettesWrapper>
 
 
@@ -61,15 +61,15 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 具体的な使用箇所は、各コンポーネントを参照してください。
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#d6d3d0" colorName="BORDER" description="枠線・罫線の色" />
-  <ColorPalette hexCode="#d6d3d0" colorName="ACTION_BACKGROUND" description="TableBulkActionAreaの背景色" />
-  <ColorPalette hexCode="#edebe8" colorName="HEAD" description="テーブルヘッダーの背景色" />
-  <ColorPalette hexCode="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette hexCode="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette hexCode="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
-  <ColorPalette hexCode="#03030226" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
-  <ColorPalette hexCode="#03030280" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
-  <ColorPalette hexCode="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
+  <ColorPalette colorValue="#d6d3d0" colorName="BORDER" description="枠線・罫線の色" />
+  <ColorPalette colorValue="#d6d3d0" colorName="ACTION_BACKGROUND" description="TableBulkActionAreaの背景色" />
+  <ColorPalette colorValue="#edebe8" colorName="HEAD" description="テーブルヘッダーの背景色" />
+  <ColorPalette colorValue="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
+  <ColorPalette colorValue="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
+  <ColorPalette colorValue="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
+  <ColorPalette colorValue="#03030226" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
+  <ColorPalette colorValue="#03030280" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
+  <ColorPalette colorValue="#ffffff00" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
 </ColorPalettesWrapper>
 
 ## プリミティブトークン
@@ -77,33 +77,33 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 ### 基本色
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#030302" colorName="BLACK" />
-  <ColorPalette hexCode="#fff" colorName="WHITE"/>
-  <ColorPalette hexCode="#0077c7" colorName="BLUE_100" />
-  <ColorPalette hexCode="#0071c1" colorName="BLUE_101" />
-  <ColorPalette hexCode="#e01e5a" colorName="RED_100" />
-  <ColorPalette hexCode="#ff8800" colorName="ORANGE_100" />
-  <ColorPalette hexCode="#ffcc17" colorName="YELLOW_100" />
-  <ColorPalette hexCode="#00c4cc" colorName="SMARTHR_BLUE"/>
+  <ColorPalette colorValue="#030302" colorName="BLACK" />
+  <ColorPalette colorValue="#fff" colorName="WHITE"/>
+  <ColorPalette colorValue="#0077c7" colorName="BLUE_100" />
+  <ColorPalette colorValue="#0071c1" colorName="BLUE_101" />
+  <ColorPalette colorValue="#e01e5a" colorName="RED_100" />
+  <ColorPalette colorValue="#ff8800" colorName="ORANGE_100" />
+  <ColorPalette colorValue="#ffcc17" colorName="YELLOW_100" />
+  <ColorPalette colorValue="#00c4cc" colorName="SMARTHR_BLUE"/>
 </ColorPalettesWrapper>
 
 ### グレースケール
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f8f7f6" colorName="GREY_5" />
-  <ColorPalette hexCode="#f5f4f3" colorName="GREY_6"/>
-  <ColorPalette hexCode="#f2f1f0" colorName="GREY_7" />
-  <ColorPalette hexCode="#edebe8" colorName="GREY_9" />
-  <ColorPalette hexCode="#d6d3d0" colorName="GREY_20" />
-  <ColorPalette hexCode="#c1bdb7" colorName="GREY_30" />
-  <ColorPalette hexCode="#706d65" colorName="GREY_65" />
-  <ColorPalette hexCode="#23221e" colorName="GREY_100"/>
+  <ColorPalette colorValue="#f8f7f6" colorName="GREY_5" />
+  <ColorPalette colorValue="#f5f4f3" colorName="GREY_6"/>
+  <ColorPalette colorValue="#f2f1f0" colorName="GREY_7" />
+  <ColorPalette colorValue="#edebe8" colorName="GREY_9" />
+  <ColorPalette colorValue="#d6d3d0" colorName="GREY_20" />
+  <ColorPalette colorValue="#c1bdb7" colorName="GREY_30" />
+  <ColorPalette colorValue="#706d65" colorName="GREY_65" />
+  <ColorPalette colorValue="#23221e" colorName="GREY_100"/>
 </ColorPalettesWrapper>
 
 ### 透明色
 <ColorPalettesWrapper>
-  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
-  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
-  <ColorPalette isHexCode={false} hexCode="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
+  <ColorPalette iscolorValue={false} colorValue="rgba(3,3,2,0.15)" colorName="TRANSPARENCY_15"/>
+  <ColorPalette iscolorValue={false} colorValue="rgba(3,3,2,0.30)" colorName="TRANSPARENCY_30" />
+  <ColorPalette iscolorValue={false} colorValue="rgba(3,3,2,0.50)" colorName="TRANSPARENCY_50" />
 </ColorPalettesWrapper>
 
 ## 色の新旧比較
@@ -115,124 +115,124 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 #### MAIN
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0077c7" colorName="新" />
-  <ColorPalette hexCode="#00a5ab" colorName="旧" />
+  <ColorPalette colorValue="#0077c7" colorName="新" />
+  <ColorPalette colorValue="#00a5ab" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### WHITE
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffffff" colorName="新 ※変更なし" />
-  <ColorPalette hexCode="#ffffff" colorName="旧" />
+  <ColorPalette colorValue="#ffffff" colorName="新 ※変更なし" />
+  <ColorPalette colorValue="#ffffff" colorName="旧" />
 </ColorPalettesWrapper>
 
 ### アクセント
 #### DANGER
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#e01e5a" colorName="新" />
-  <ColorPalette hexCode="#ef475b" colorName="旧" />
+  <ColorPalette colorValue="#e01e5a" colorName="新" />
+  <ColorPalette colorValue="#ef475b" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### WARNING（WARNING_YELLOW）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffcc17" colorName="新" />
-  <ColorPalette hexCode="#ff8800" colorName="旧" />
+  <ColorPalette colorValue="#ffcc17" colorName="新" />
+  <ColorPalette colorValue="#ff8800" colorName="旧" />
 </ColorPalettesWrapper>
 
 ### 文字
 #### TEXT_BLACK
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#23221e" colorName="新" />
-  <ColorPalette hexCode="#333333" colorName="旧" />
+  <ColorPalette colorValue="#23221e" colorName="新" />
+  <ColorPalette colorValue="#333333" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_GREY
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#706d65" colorName="新" />
-  <ColorPalette hexCode="#767676" colorName="旧" />
+  <ColorPalette colorValue="#706d65" colorName="新" />
+  <ColorPalette colorValue="#767676" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_LINK
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#0071c1" colorName="新" />
-  <ColorPalette hexCode="#007bc2" colorName="旧" />
+  <ColorPalette colorValue="#0071c1" colorName="新" />
+  <ColorPalette colorValue="#007bc2" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_DISABLED
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#c1bdb7" colorName="新" />
-  <ColorPalette hexCode="#c1c1c1" colorName="旧" />
+  <ColorPalette colorValue="#c1bdb7" colorName="新" />
+  <ColorPalette colorValue="#c1c1c1" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TEXT_WHITE（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffffff" colorName="新" />
+  <ColorPalette colorValue="#ffffff" colorName="新" />
 </ColorPalettesWrapper>
 
 ### コンポーネント
 #### BORDER
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#d6d3d0" colorName="新" />
-  <ColorPalette hexCode="#d6d6d6" colorName="旧" />
+  <ColorPalette colorValue="#d6d3d0" colorName="新" />
+  <ColorPalette colorValue="#d6d6d6" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### ACTION_BACKGROUND（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#d6d3d0" colorName="新" />
+  <ColorPalette colorValue="#d6d3d0" colorName="新" />
 </ColorPalettesWrapper>
 
 #### HEAD（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#edebe8" colorName="新" />
+  <ColorPalette colorValue="#edebe8" colorName="新" />
 </ColorPalettesWrapper>
 
 #### OVER_BACKGROUND（新のみ）
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f2f1f0" colorName="新" />
+  <ColorPalette colorValue="#f2f1f0" colorName="新" />
 </ColorPalettesWrapper>
 
 #### COLUMN
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f8f7f6" colorName="新" />
-  <ColorPalette hexCode="#f9f9f9" colorName="旧" />
+  <ColorPalette colorValue="#f8f7f6" colorName="新" />
+  <ColorPalette colorValue="#f9f9f9" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### BACKGROUND
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#f8f7f6" colorName="新" />
-  <ColorPalette hexCode="#f5f6fa" colorName="旧" />
+  <ColorPalette colorValue="#f8f7f6" colorName="新" />
+  <ColorPalette colorValue="#f5f6fa" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### OVERLAY
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#03030226" colorName="新" />
-  <ColorPalette hexCode="#00000026" colorName="旧" />
+  <ColorPalette colorValue="#03030226" colorName="新" />
+  <ColorPalette colorValue="#00000026" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### SCRIM
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#03030280" colorName="新" />
-  <ColorPalette hexCode="#0000007f" colorName="旧" />
+  <ColorPalette colorValue="#03030280" colorName="新" />
+  <ColorPalette colorValue="#0000007f" colorName="旧" />
 </ColorPalettesWrapper>
 
 #### TRANSPARENT
 
 <ColorPalettesWrapper>
-  <ColorPalette hexCode="#ffffff00" colorName="新 ※変更なし" />
-  <ColorPalette hexCode="#ffffff00" colorName="旧" />
+  <ColorPalette colorValue="#ffffff00" colorName="新 ※変更なし" />
+  <ColorPalette colorValue="#ffffff00" colorName="旧" />
 </ColorPalettesWrapper>

--- a/content/articles/products/design-tokens/color.mdx
+++ b/content/articles/products/design-tokens/color.mdx
@@ -22,7 +22,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
 
 <ColorPalettesWrapper>
   <ColorPalette hexCode="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
-  <ColorPalette hexCode="#ffffff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
+  <ColorPalette hexCode="#fff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
 </ColorPalettesWrapper>
 
 
@@ -50,7 +50,7 @@ import { ColorPalette, ColorPalettesWrapper } from '@Components/ColorPalette'
   <ColorPalette hexCode="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
   <ColorPalette hexCode="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
   <ColorPalette hexCode="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
-  <ColorPalette hexCode="#ffffff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
+  <ColorPalette hexCode="#fff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
 </ColorPalettesWrapper>
 
 

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -4,7 +4,7 @@ import Color from 'color'
 import { defaultBreakpoint, defaultColor } from 'smarthr-ui'
 
 // soruce: https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
-const convertHexToRGBA = (hexCode: string): string => {
+const convertHexToRGBA = (hexCode: string, opacity: number = 1): string => {
   let hex = hexCode && hexCode.replace('#', '')
 
   if (hex.length === 3) {
@@ -15,23 +15,28 @@ const convertHexToRGBA = (hexCode: string): string => {
   const g = parseInt(hex.substring(2, 4), 16)
   const b = parseInt(hex.substring(4, 6), 16)
 
-  return `rgba(${r},${g},${b})`
+  if (opacity > 1 && opacity <= 100) {
+    opacity = opacity / 100
+  }
+
+  return `rgba(${r},${g},${b},${opacity})`
 }
 
 type Props = {
+  isHexCode?: boolean
   hexCode: string
   colorName: string
   description: string
 }
 
-export const ColorPalette: FC<Props> = ({ colorName, hexCode, description }) => {
+export const ColorPalette: FC<Props> = ({ isHexCode = true, colorName, hexCode, description }) => {
   return (
     <Wrapper>
       <Thumbnail $color={hexCode}></Thumbnail>
       <Informations>
         <ColorName>{colorName}</ColorName>
         <ColorCode>{hexCode}</ColorCode>
-        <ColorCode>{convertHexToRGBA(hexCode)}</ColorCode>
+        {isHexCode && <ColorCode>{convertHexToRGBA(hexCode)}</ColorCode>}
         {/* <ColorContrast fgColor={hexCode} bgColor={defaultColor.BACKGROUND} /> */}
         <Description>{description}</Description>
       </Informations>

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components'
 import Color from 'color'
 import { defaultBreakpoint, defaultColor } from 'smarthr-ui'
 
-// soruce: https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
+// source: https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
 const convertHexToRGBA = (hexCode: string): string => {
   let hex = hexCode && hexCode.replace('#', '')
 
@@ -20,19 +20,19 @@ const convertHexToRGBA = (hexCode: string): string => {
 
 type Props = {
   isHexCode?: boolean
-  hexCode: string
+  colorValue: string
   colorName: string
   description: string
 }
 
-export const ColorPalette: FC<Props> = ({ isHexCode = true, colorName, hexCode, description }) => {
+export const ColorPalette: FC<Props> = ({ isHexCode = true, colorName, colorValue, description }) => {
   return (
     <Wrapper>
-      <Thumbnail $color={hexCode}></Thumbnail>
+      <Thumbnail $color={colorValue}></Thumbnail>
       <Informations>
         <ColorName>{colorName}</ColorName>
-        <ColorCode>{hexCode}</ColorCode>
-        {isHexCode && <ColorCode>{convertHexToRGBA(hexCode)}</ColorCode>}
+        <ColorCode>{colorValue}</ColorCode>
+        {isHexCode && <ColorCode>{convertHexToRGBA(colorValue)}</ColorCode>}
         <Description>{description}</Description>
       </Informations>
     </Wrapper>

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -19,7 +19,7 @@ const convertHexToRGBA = (hexCode: string, opacity: number = 1): string => {
     opacity = opacity / 100
   }
 
-  return `rgba(${r},${g},${b},${opacity})`
+  return `rgb(${r},${g},${b})`
 }
 
 type Props = {
@@ -37,7 +37,6 @@ export const ColorPalette: FC<Props> = ({ isHexCode = true, colorName, hexCode, 
         <ColorName>{colorName}</ColorName>
         <ColorCode>{hexCode}</ColorCode>
         {isHexCode && <ColorCode>{convertHexToRGBA(hexCode)}</ColorCode>}
-        {/* <ColorContrast fgColor={hexCode} bgColor={defaultColor.BACKGROUND} /> */}
         <Description>{description}</Description>
       </Informations>
     </Wrapper>

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -4,8 +4,8 @@ import Color from 'color'
 import { defaultBreakpoint, defaultColor } from 'smarthr-ui'
 
 // source: https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
-const convertHexToRGBA = (colorValue: string): string => {
-  let hex = colorValue && colorValue.replace('#', '')
+const convertHexToRGBA = (hexCode: string): string => {
+  let hex = hexCode && hexCode.replace('#', '')
 
   if (hex.length === 3) {
     hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -4,8 +4,8 @@ import Color from 'color'
 import { defaultBreakpoint, defaultColor } from 'smarthr-ui'
 
 // source: https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
-const convertHexToRGBA = (colorValue: string): string => {
-  let hex = colorValue && colorValue.replace('#', '')
+const convertHexToRGBA = (hexCode: string): string => {
+  let hex = hexCode && hexCode.replace('#', '')
 
   if (hex.length === 3) {
     hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
@@ -20,19 +20,19 @@ const convertHexToRGBA = (colorValue: string): string => {
 
 type Props = {
   isHexCode?: boolean
-  colorValue: string
+  hexCode: string
   colorName: string
   description: string
 }
 
-export const ColorPalette: FC<Props> = ({ isHexCode = true, colorName, colorValue, description }) => {
+export const ColorPalette: FC<Props> = ({ isHexCode = true, colorName, hexCode, description }) => {
   return (
     <Wrapper>
-      <Thumbnail $color={colorValue}></Thumbnail>
+      <Thumbnail $color={hexCode}></Thumbnail>
       <Informations>
         <ColorName>{colorName}</ColorName>
-        <ColorCode>{colorValue}</ColorCode>
-        {isHexCode && <ColorCode>{convertHexToRGBA(colorValue)}</ColorCode>}
+        <ColorCode>{hexCode}</ColorCode>
+        {isHexCode && <ColorCode>{convertHexToRGBA(hexCode)}</ColorCode>}
         <Description>{description}</Description>
       </Informations>
     </Wrapper>

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -4,7 +4,7 @@ import Color from 'color'
 import { defaultBreakpoint, defaultColor } from 'smarthr-ui'
 
 // soruce: https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
-const convertHexToRGBA = (hexCode: string, opacity: number = 1): string => {
+const convertHexToRGBA = (hexCode: string): string => {
   let hex = hexCode && hexCode.replace('#', '')
 
   if (hex.length === 3) {
@@ -14,10 +14,6 @@ const convertHexToRGBA = (hexCode: string, opacity: number = 1): string => {
   const r = parseInt(hex.substring(0, 2), 16)
   const g = parseInt(hex.substring(2, 4), 16)
   const b = parseInt(hex.substring(4, 6), 16)
-
-  if (opacity > 1 && opacity <= 100) {
-    opacity = opacity / 100
-  }
 
   return `rgb(${r},${g},${b})`
 }

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -19,20 +19,26 @@ const convertHexToRGBA = (colorValue: string): string => {
 }
 
 type Props = {
-  isHexCode?: boolean
-  colorValue: string
   colorName: string
+  colorValue: string
   description: string
 }
 
-export const ColorPalette: FC<Props> = ({ isHexCode = true, colorName, colorValue, description }) => {
+export const ColorPalette: FC<Props> = ({ colorName, colorValue, description }) => {
   return (
     <Wrapper>
       <Thumbnail $color={colorValue}></Thumbnail>
       <Informations>
         <ColorName>{colorName}</ColorName>
-        <ColorCode>{colorValue}</ColorCode>
-        {isHexCode && <ColorCode>{convertHexToRGBA(colorValue)}</ColorCode>}
+
+        {colorValue.startsWith('#') ? (
+          <>
+            <ColorCode>{colorValue}</ColorCode>
+            <ColorCode>{convertHexToRGBA(colorValue)}</ColorCode>
+          </>
+        ) : (
+          <ColorCode>{colorValue}</ColorCode>
+        )}
         <Description>{description}</Description>
       </Informations>
     </Wrapper>

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -4,8 +4,8 @@ import Color from 'color'
 import { defaultBreakpoint, defaultColor } from 'smarthr-ui'
 
 // source: https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
-const convertHexToRGBA = (hexCode: string): string => {
-  let hex = hexCode && hexCode.replace('#', '')
+const convertHexToRGBA = (colorValue: string): string => {
+  let hex = colorValue && colorValue.replace('#', '')
 
   if (hex.length === 3) {
     hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -4,8 +4,8 @@ import Color from 'color'
 import { defaultBreakpoint, defaultColor } from 'smarthr-ui'
 
 // source: https://gist.github.com/danieliser/b4b24c9f772066bcf0a6
-const convertHexToRGBA = (hexCode: string): string => {
-  let hex = hexCode && hexCode.replace('#', '')
+const convertHexToRGBA = (colorValue: string): string => {
+  let hex = colorValue && colorValue.replace('#', '')
 
   if (hex.length === 3) {
     hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
@@ -20,19 +20,19 @@ const convertHexToRGBA = (hexCode: string): string => {
 
 type Props = {
   isHexCode?: boolean
-  hexCode: string
+  colorValue: string
   colorName: string
   description: string
 }
 
-export const ColorPalette: FC<Props> = ({ isHexCode = true, colorName, hexCode, description }) => {
+export const ColorPalette: FC<Props> = ({ isHexCode = true, colorName, colorValue, description }) => {
   return (
     <Wrapper>
-      <Thumbnail $color={hexCode}></Thumbnail>
+      <Thumbnail $color={colorValue}></Thumbnail>
       <Informations>
         <ColorName>{colorName}</ColorName>
-        <ColorCode>{hexCode}</ColorCode>
-        {isHexCode && <ColorCode>{convertHexToRGBA(hexCode)}</ColorCode>}
+        <ColorCode>{colorValue}</ColorCode>
+        {isHexCode && <ColorCode>{convertHexToRGBA(colorValue)}</ColorCode>}
         <Description>{description}</Description>
       </Informations>
     </Wrapper>


### PR DESCRIPTION
## 課題・背景

- デザイントークンに新しい色が追加されてたのでカラーパレットを追加して、既存のカテゴリーはセマンティックに変更
- 透明色が追加されたのでrgbaでも記述できるようにColor PaletteのI/Fを変更


## やったこと

-

<!--
- 〇〇に追記
- 〇〇ページを追加

## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認
https://deploy-preview-350--smarthr-design-system.netlify.app/products/design-tokens/color/

<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
- 
-->
## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
