### PR TITLE
ロゴページのダウンロードセクション表記を調整

### DIFF
--- a/content/articles/basics/logos/index.mdx
+++ b/content/articles/basics/logos/index.mdx
@@ -122,7 +122,7 @@ SmartHRロゴを本ガイドラインおよび[利用規約](/terms/)に違反�
 
 PNG・SVG・AIのファイル形式のロゴをダウンロードできます。
 
-[PNGファイル](/SmartHR_Logo_png.zip)／[SVGファイル](/SmartHR_Logo_svg.zip)／[AIファイル（カラー）](/SmartHR_Logo_ai.zip)／[AIファイル（モノクロ）](/SmartHR_Logo_monochrome.zip)
+[PNG](/SmartHR_Logo_png.zip)／[SVG](/SmartHR_Logo_svg.zip)／[AI（カラー）](/SmartHR_Logo_ai.zip)／[AI（モノクロ）](/SmartHR_Logo_monochrome.zip)
 
 
 ## ライセンス情報

--- a/content/articles/basics/logos/index.mdx
+++ b/content/articles/basics/logos/index.mdx
@@ -120,9 +120,10 @@ SmartHRロゴを本ガイドラインおよび[利用規約](/terms/)に違反�
 
 ## ダウンロード
 
-ai , png , svg形式のロゴをダウンロードできます。
+PNG・SVG・AIのファイル形式のロゴをダウンロードできます。
 
-[PNG](/SmartHR_Logo_png.zip) / [SVG](/SmartHR_Logo_svg.zip) / [ai](/SmartHR_Logo_ai.zip) / [ai（モノクロ）](/SmartHR_Logo_monochrome.zip)
+[PNGファイル](/SmartHR_Logo_png.zip)／[SVGファイル](/SmartHR_Logo_svg.zip)／[AIファイル（カラー）](/SmartHR_Logo_ai.zip)／[AIファイル（モノクロ）](/SmartHR_Logo_monochrome.zip)
+
 
 ## ライセンス情報
 


### PR DESCRIPTION
## 課題・背景
- ロゴページのダウンロードセクションの表記に揺れがあったり、誤りがあったりしました。

## やったこと
- 記述記号を全角にする
  - 参考：[記述記号は全角を使用し、前後にスペースは入れない](https://smarthr.design/products/contents/writing-style/#recrVEn3NYr2AV33o-0)
- ファイル形式間の区切りは、「・」を使用
  - 参考：[複数の語句を列挙する場合の、読点（、）とナカグロ（・）の使い分け](https://smarthr.design/products/contents/writing-style/#recKGcTEWxvwUk5pp-0)
- ダウンロードできるテキストリンクは、「形式+ファイル」に。
  - ユーザーがダウンロードするのは、ファイルなので。
- AIファイルのテキストリンクに、カラー or モノクロを記載
  - データの内容を明示

## やらなかったこと
- ファイル自体の調整
  -  ドキュメントのみ調整しました

## 動作確認
https://deploy-preview-387--smarthr-design-system.netlify.app/basics/logos/#h2-1

## キャプチャ

|Before|After|
| --- | --- |
| <img width="1376" alt="スクリーンショット 2022-11-22 15 11 03" src="https://user-images.githubusercontent.com/101125529/203238342-5211ceec-9a60-4b05-b3b6-a459255cdbc8.png"> | <img width="1352" alt="スクリーンショット 2022-11-22 15 16 18" src="https://user-images.githubusercontent.com/101125529/203241837-4f4c03d3-3cb5-4510-ad23-e3a02e8f5b07.png"> |



<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
