### PR TITLE
リンクチェッカーのエラーメッセージを修正

### DIFF
--- a/scripts/linkChecker.ts
+++ b/scripts/linkChecker.ts
@@ -118,12 +118,11 @@ const check = async (existPathList: string[], linkList: LinkItem[]) => {
   })
   if (missingLinkList.length > 0) {
     missingLinkList.forEach((item) => {
-      console.error(
-        `Missing ${item.type === 'image' ? 'image source' : 'link'}: ${item.link} in /${path.relative(
-          `${__dirname}/../`,
-          item.filePath,
-        )} at L:${item.lineNo}`,
-      )
+      let errorType = `Missing ${item.type === 'image' ? 'image source' : 'link'}`
+      if (existPathList.includes(`${item.link}/`)) {
+        errorType = `No trailing slash`
+      }
+      console.error(`${errorType}: ${item.link} in /${path.relative(`${__dirname}/../`, item.filePath)} at L:${item.lineNo}`)
     })
     console.log(`Found ${missingLinkList.length} missing links. Link check finished.`)
     process.exit(1)


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1130

## やったこと
リンク切れと判定していたもののうち、末尾にスラッシュがないだけで、リンク自体は機能しているものは、`Missing link:  ...`ではなく、`No trailing slash: ...`というエラーメッセージに変更しました。
（厳密には”リンク切れ”ではなく、末尾スラッシュをつけるという方針に沿っていないだけ、というものです。）

## 動作確認
`npx ts-node scripts/linkChecker.ts`
↓
```
No trailing slash: /products/design-process/usability-test/planing_tips in /content/articles/products/design-process/usability-test/index.mdx at L:31
Found 1 missing links. Link check finished.
```

## キャプチャ
ビルドされるサイト自体には影響ありません。
（現時点では実際にはリンク切れ箇所はありませんでした。）