### PR TITLE
Netlifyのdevサーバーの設定を調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ yarn export:zip-images
 ローカルで動作させるためには[Netlify CLI](https://docs.netlify.com/cli/get-started/)が必要です。
 
 ```
-npm install netlify-cli 
+npm install netlify-cli -g
 ```
 
 で、`netlify-cli`をインストールし
@@ -103,16 +103,4 @@ npm install netlify-cli
 netlify dev
 ```
 
-コマンドでサーバーを立ち上げてください。(デフォルトで`http://localhost:8888`)
-
-それとは別に、
-
-```
-yarn dev
-```
-
-でGatsbyのサーバーを立ち上げます。(デフォルトで`http://localhost:8000`)
-
-そうすれば、netlify-cliで立ち上げたほうのサーバー( http://localhost:8888 )から確認できます。
-
-
+コマンドを実行すると、立ち上がったNetlifyサーバー( http://localhost:8888 )から確認できます。

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
 command = 'yarn build'
 [context.deploy-preview]
 command = 'yarn build'
+[dev]
+command = 'yarn dev'
+targetPort = 8000
+port = 8888
+publish = 'public'


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1131

## やったこと
devサーバー起動時に、
```
◈ No app server detected. Using simple static server
◈ Unable to determine public folder to serve files from. Using current working directory
◈ Setup a netlify.toml file with a [dev] section to specify your dev server settings.
◈ See docs at: https://cli.netlify.com/netlify-dev#project-detection
◈ Running static server from "smarthr-design-system"
◈ Setting up local development server
```
という表示が出ており、何らかの原因で、"No app server detected."な状態になっている様子でした。Gatsbyまたはnetlify-cliのアップデートにより、何か状況が変わったのかもしれません。（以前はGatsbyのdevサーバーを"detect"できていたと思うので。）

下の行にある、"◈ See docs at: 〜"の[リンク先](https://cli.netlify.com/netlify-dev#project-detection)を参考に、`netlify.toml`に、devサーバーの設定を追記しました。

あわせてREADME.mdの内容も更新しました。
- Netlifyのドキュメントによると`netlify-cli`のインストールは`npm -g`となっているので、グローバルインストールに変更
  - このプロジェクトでも、`package.json`や`yarn.lock`での管理もしていない様子なので
- 更新後の方法では、netlify-cli経由で`yarn dev`を実行することになり、手動でのGatsbyサーバーの起動は不要なため、記述を修正

また、現在のバージョンの`netlify-cli`をインストールすると、自動的に`.netlify`ディレクトリができ、`.gitignore`にも追加されますが、そのままにしてあります。

## 動作確認
ローカル環境にて、`netlify dev`を実行すると、`http://localhost:8888`にてログイン・リダイレクトができることを確認しました。