### PR TITLE
リンクチェッカーを実行するGitHub Actionsを追加

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,52 @@
+# 週1回リンクチェッカーを実行し、エラーがあればissueを作成します。
+
+name: Link check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * 1' # Monday, 2am(UTC+0)
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Setup Node.js
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+
+      # Install npm packages
+      - name: Install dependencies
+        run: yarn
+      # リンクチェックの実行
+      - id: linkCheck
+        name: Execute link checker
+        #リンクエラーが見つかるとスクリプトはexit(1)で終了するが、このactionは中止しない。
+        continue-on-error: true
+        # linkChecker.tsを実行し、`console.error()`の内容をerrors.txtに出力する
+        # link-check-issue.mdを作成し、タイトル（Link check failed + 日付）と本文（`console.error()`の中身）を出力する
+        run: |
+          npx ts-node scripts/linkChecker.ts 2> errors.txt || true
+          echo errors=`cat errors.txt` >> $GITHUB_OUTPUT
+          echo '---' >> link-check-issue.md
+          today=$(date "+%Y-%m-%d")
+          echo "title: Link check failed ${today}" >> link-check-issue.md
+          echo '---' >> link-check-issue.md
+          echo '```' >> link-check-issue.md
+          while read error; do
+            echo "$error" >> link-check-issue.md
+          done <errors.txt
+          echo '```'
+      # GitHub issueを作成する
+      - name: Create an issue
+        # 前のstepでエラーがあった場合のみ作成
+        if: steps.linkCheck.outputs.errors != ''
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # 前のstepで書き出したlink-check-issue.mdをの内容でissueを作る
+          filename: link-check-issue.md


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1125

## やったこと
`scripts/linkChecker.ts`を実行するGitHub Actionsを作成しました。月曜日のAM9時（日本時間）と、Actionsタブからの手動実行ができるようになっています。

リンクチェックでエラー（リンク切れなど）があった場合はこのリポジトリにissueが作成されます。

## やらなかったこと
issueが作られた時の、Asigneesや通知などの設定は特に追加していません。

## 動作確認
（Webサイト本体への影響はありません。）

## キャプチャ
エラーがあった場合、以下のようなissueが作成されます（テスト用リポジトリでの画面です）。
![image](https://user-images.githubusercontent.com/7822534/204995426-20272ed4-5b82-4d28-9d3b-ab8737c5e88f.png)