### PR TITLE
react-helmetプラグインをGatsby Head APIに置き換え

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,9 +1,12 @@
-import dotenv from 'dotenv'
 import path from 'path'
-import type { GatsbyConfig } from 'gatsby'
-import { AIRTABLE_CONTENTS } from './src/constants/airtable'
-import { algoliaConfig } from './gatsby-plugin-algolia-config'
+
+import dotenv from 'dotenv'
 import emoji from 'remark-emoji'
+
+import { algoliaConfig } from './gatsby-plugin-algolia-config'
+import { AIRTABLE_CONTENTS } from './src/constants/airtable'
+
+import type { GatsbyConfig } from 'gatsby'
 
 dotenv.config({
   path: '.env',
@@ -29,7 +32,6 @@ const config: GatsbyConfig = {
       },
     },
     ...(process.env.IS_TYPE_GEN ? ['gatsby-plugin-typegen'] : []),
-    'gatsby-plugin-react-helmet',
     'gatsby-plugin-styled-components',
     'gatsby-plugin-sharp',
     {

--- a/gatsby-ssr.ts
+++ b/gatsby-ssr.ts
@@ -1,0 +1,5 @@
+import { GatsbySSR } from 'gatsby'
+
+export const onRenderBody: GatsbySSR['onRenderBody'] = ({ setHtmlAttributes }) => {
+  setHtmlAttributes({ lang: 'ja' })
+}

--- a/src/components/Head/Head.tsx
+++ b/src/components/Head/Head.tsx
@@ -1,6 +1,5 @@
 import { graphql, useStaticQuery } from 'gatsby'
 import React, { FC } from 'react'
-import { Helmet } from 'react-helmet'
 
 const query = graphql`
   query Head {
@@ -44,57 +43,22 @@ export const Head: FC<Props> = ({ title, ogTitle, description, meta = [] }) => {
   }
 
   return (
-    <Helmet
-      htmlAttributes={{ lang: 'ja' }}
-      title={pageTitle}
-      meta={[
-        {
-          name: 'description',
-          content: metaDescription,
-        },
-        {
-          property: 'og:title',
-          content: pageTitle,
-        },
-        {
-          property: 'og:description',
-          content: metaDescription,
-        },
-        {
-          property: 'og:type',
-          content: 'website',
-        },
-        { property: 'og:image', content: ogCloudinaryUrl || ogImagePath },
-        {
-          name: 'twitter:card',
-          content: 'summary',
-        },
-        {
-          name: 'twitter:creator',
-          content: siteMetadata?.author || '',
-        },
-        {
-          name: 'twitter:title',
-          content: pageTitle,
-        },
-        {
-          name: 'twitter:description',
-          content: metaDescription,
-        },
-        ...meta,
-      ]}
-      link={[
-        {
-          rel: 'icon',
-          href: '/favicon-32x32.png',
-          type: 'image/png',
-        },
-        {
-          rel: 'icon',
-          href: '/favicon.svg',
-          type: 'image/svg+xml',
-        },
-      ]}
-    />
+    <>
+      <title>{pageTitle}</title>
+      <meta name="description" content={metaDescription} />
+      <meta property="og:title" content={pageTitle} />
+      <meta property="og:description" content={metaDescription} />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content={ogCloudinaryUrl || ogImagePath} />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:creator" content={siteMetadata?.author || ''} />
+      <meta name="twitter:title" content={pageTitle} />
+      <meta name="twitter:description" content={metaDescription} />
+      {meta.map((item, index) => {
+        return <meta key={index} name={item.name} content={item.content} />
+      })}
+      <link rel="icon" href="/favicon-32x32.png" type="image/png" />
+      <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    </>
   )
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -21,15 +21,6 @@ export const Head = () => {
 
 const NotFoundPage: FC = () => (
   <>
-    {/* <Head
-      title="404 Page not found"
-      meta={[
-        {
-          name: 'robots',
-          content: 'noindex',
-        },
-      ]}
-    /> */}
     <GlobalStyle />
     <Header />
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,13 +1,13 @@
-import { Head } from '@Components/Head'
+import { Head as HeadComponent } from '@Components/Head'
 import { Footer } from '@Components/shared/Footer/Footer'
 import { GlobalStyle } from '@Components/shared/GlobalStyle/GlobalStyle'
 import { Header } from '@Components/shared/Header/Header'
 import React, { FC } from 'react'
 import styled from 'styled-components'
 
-const NotFoundPage: FC = () => (
-  <>
-    <Head
+export const Head = () => {
+  return (
+    <HeadComponent
       title="404 Page not found"
       meta={[
         {
@@ -16,6 +16,20 @@ const NotFoundPage: FC = () => (
         },
       ]}
     />
+  )
+}
+
+const NotFoundPage: FC = () => (
+  <>
+    {/* <Head
+      title="404 Page not found"
+      meta={[
+        {
+          name: 'robots',
+          content: 'noindex',
+        },
+      ]}
+    /> */}
     <GlobalStyle />
     <Header />
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Head } from '@Components/Head'
+export { Head } from '@Components/Head'
 import { ContentNavigation } from '@Components/index/ContentNavigation'
 import { FaqList } from '@Components/index/Faq'
 import { Gotcha } from '@Components/index/Gotcha'
@@ -14,7 +14,6 @@ import styled from 'styled-components'
 const Home: FC = () => {
   return (
     <>
-      <Head />
       <GlobalStyle />
       <Header isIndex />
       <GotchaContainer>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { Head } from '@Components/Head'
+import { Head as HeadComponent } from '@Components/Head'
 import { LoginPage } from '@Components/login/Login'
 import { GlobalStyle } from '@Components/shared/GlobalStyle/GlobalStyle'
 import { Header } from '@Components/shared/Header/Header'
@@ -6,10 +6,13 @@ import { CSS_SIZE } from '@Constants/style'
 import React, { FC } from 'react'
 import styled from 'styled-components'
 
+export const Head = () => {
+  return <HeadComponent title="従業員向けログイン" description="従業員向けのログインページです。" />
+}
+
 const Login: FC = () => {
   return (
     <>
-      <Head title="従業員向けログイン" description="従業員向けのログインページです。" />
       <GlobalStyle />
       <Header />
 

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,4 +1,4 @@
-import { Head } from '@Components/Head'
+import { Head as HeadComponent } from '@Components/Head'
 import { IndexList } from '@Components/search/IndexList/IndexList'
 import { CustomSearchBox } from '@Components/search/Search'
 import { Footer } from '@Components/shared/Footer/Footer'
@@ -10,12 +10,15 @@ import React, { FC } from 'react'
 import { InstantSearch } from 'react-instantsearch-dom'
 import styled from 'styled-components'
 
+export const Head = () => {
+  return <HeadComponent title="検索" description="検索ページです。" />
+}
+
 const searchClient = algoliasearch(process.env.GATSBY_ALGOLIA_APP_ID || '', process.env.GATSBY_ALGOLIA_SEARCH_API_KEY || '')
 
 const SearchPage: FC = () => {
   return (
     <>
-      <Head title="検索" description="検索ページです。" />
       <GlobalStyle />
 
       <Wrapper>

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -1,4 +1,4 @@
-import { Head } from '@Components/Head'
+import { Head as HeadComponent } from '@Components/Head'
 import { SmartHRUIMetaInfo } from '@Components/SmartHRUIMetaInfo'
 import { CodeBlock } from '@Components/article/CodeBlock'
 import { FragmentTitle } from '@Components/article/FragmentTitle/FragmentTitle'
@@ -130,21 +130,6 @@ const Article: FC<Props> = ({ data }) => {
   const slug = fields?.slug || ''
 
   const title = frontmatter?.title || ''
-  const description = frontmatter?.description || ''
-
-  // 親階層のノードを探す
-  const parentCategorySlug = slug.replace(/[^/]+\/$/, '') //例・'/basics/typography/'→'/basics/'
-  const parentCategoryNode =
-    parentCategory.edges.find((edge) => {
-      if (edge.node?.fields?.slug === parentCategorySlug) {
-        return true
-      }
-      return false
-    }) ?? null
-  const parentCategoryName = parentCategoryNode?.node.frontmatter?.title ?? title
-
-  // memo: カテゴリのtitleとカテゴリ直下のindexページのタイトルが重複した場合はカテゴリ名のみを表示する
-  const headTitle = title === parentCategoryName ? title : `${title} | ${parentCategoryName}`
 
   // Airtableコンテンツのheading。各項目をh2として扱う
   const airTableHeadings = data.airTable.edges.map((edge) => {
@@ -297,7 +282,6 @@ const Article: FC<Props> = ({ data }) => {
 
   return (
     <Theme>
-      <Head title={headTitle} ogTitle={title} description={description} />
       <GlobalStyle />
 
       <Wrapper>
@@ -358,6 +342,36 @@ const Article: FC<Props> = ({ data }) => {
 }
 
 export default Article
+
+export const Head: FC<Props> = ({ data }) => {
+  const { mdx: article, parentCategoryAllMdx: parentCategory } = data
+
+  if (!article) {
+    return <HeadComponent />
+  }
+
+  const { frontmatter, fields } = article
+  const slug = fields?.slug || ''
+
+  const title = frontmatter?.title || ''
+  const description = frontmatter?.description || ''
+
+  // 親階層のノードを探す
+  const parentCategorySlug = slug.replace(/[^/]+\/$/, '') //例・'/basics/typography/'→'/basics/'
+  const parentCategoryNode =
+    parentCategory.edges.find((edge) => {
+      if (edge.node?.fields?.slug === parentCategorySlug) {
+        return true
+      }
+      return false
+    }) ?? null
+  const parentCategoryName = parentCategoryNode?.node.frontmatter?.title ?? title
+
+  // memo: カテゴリのtitleとカテゴリ直下のindexページのタイトルが重複した場合はカテゴリ名のみを表示する
+  const headTitle = title === parentCategoryName ? title : `${title} | ${parentCategoryName}`
+
+  return <HeadComponent title={headTitle} description={description} />
+}
 
 const Wrapper = styled.div`
   display: flex;


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1138

[gatsby-plugin-react-helmetが非推奨になる](https://www.gatsbyjs.com/plugins/gatsby-plugin-react-helmet/#%EF%B8%8F-this-package-will-be-deprecated)予定とのこと。おそらくreact-helmetの開発が停滞しているため。

## やったこと
現在、HTMLヘッダーに出力されているのと同じものを、[Gatsby Head API](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/)を利用して出力するようにしました。

- `<html>`要素に`lang="ja"`を指定
  - [ドキュメント](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/#editing-html-and-body)に従って、`gatsby-ssr.ts`を追加しました
- `<title>`・`<meta>`・`<link>`
  - `/src/components/Head/Head.tsx` からreact-helmetを削除し、直接記述しています。

各ページからは、[`Head`という名前でコンポーネントをexportする](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/#using-gatsby-head-in-your-page)必要があるため、`/src/pages/`以下の各ページと、`/src/templates/article.tsx`を書き換えました。

## 動作確認
トップページで出力されているもの（改行を入れています）：
```
<!DOCTYPE html><html lang="ja"><head>
<meta charSet="utf-8"/>
<meta http-equiv="x-ua-compatible" content="ie=edge"/>
<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
<meta name="generator" content="Gatsby 4.24.8"/>
<meta name="description" content="SmartHR Design Systemは、だれでも・効率よく・迷わずにSmartHRらしい表現をするためのデザインシステムです。" data-gatsby-head="true"/>
<meta property="og:title" content="SmartHR Design System" data-gatsby-head="true"/>
<meta property="og:description" content="SmartHR Design Systemは、だれでも・効率よく・迷わずにSmartHRらしい表現をするためのデザインシステムです。" data-gatsby-head="true"/>
<meta property="og:type" content="website" data-gatsby-head="true"/>
<meta property="og:image" content="https://smarthr.design/images/ogp.png" data-gatsby-head="true"/>
<meta name="twitter:card" content="summary" data-gatsby-head="true"/>
<meta name="twitter:creator" content="@smarthr" data-gatsby-head="true"/>
<meta name="twitter:title" content="SmartHR Design System" data-gatsby-head="true"/>
<meta name="twitter:description" content="SmartHR Design Systemは、だれでも・効率よく・迷わずにSmartHRらしい表現をするためのデザインシステムです。" data-gatsby-head="true"/>
<meta name="theme-color" content="#00C4CC"/>
<title data-gatsby-head="true">SmartHR Design System</title>
<link rel="icon" href="/favicon-32x32.png" type="image/png" data-gatsby-head="true"/>
<link rel="icon" href="/favicon.svg" type="image/svg+xml" data-gatsby-head="true"/>
<link rel="preconnect" href="https://www.googletagmanager.com"/>
<link rel="dns-prefetch" href="https://www.googletagmanager.com"/>
//以下、スタイル、manifestなど省略
```

`data-react-helmet="true"`だったところは、`data-gatsby-head="true"`に変わりました。

- 404ページ（https://deploy-preview-409--smarthr-design-system.netlify.app/404 ）：追加で指定している、`<meta name="robots" content="noindex" data-gatsby-head="true"/>`が出力されています
- 検索ページ、ログインページ、コンテンツのページではそれぞれのtitle、descriptionが出力されています
  - https://deploy-preview-409--smarthr-design-system.netlify.app/search/
  - https://deploy-preview-409--smarthr-design-system.netlify.app/login/
  - https://deploy-preview-409--smarthr-design-system.netlify.app/basics/colors/
    - →タイトルがこれまでどおり「色 | 基本要素 | SmartHR Design System」という 、親階層を含んだものになっている

## キャプチャ
HTMLの`body`内には変化がないので、見た目は変わりません。