### PR TITLE
ハンバーガーメニューを開くボタンのaria-controlsの出力を調整

### DIFF
--- a/gatsby-plugin-algolia-config.ts
+++ b/gatsby-plugin-algolia-config.ts
@@ -115,5 +115,5 @@ export const algoliaConfig = {
   indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME,
   queries: [...mdxQueries, ...airtableQueries],
   dryRun: process.env.BRANCH !== 'main',
-  continueOnFailure: true,
+  continueOnFailure: false,
 }

--- a/gatsby-plugin-algolia-config.ts
+++ b/gatsby-plugin-algolia-config.ts
@@ -115,5 +115,5 @@ export const algoliaConfig = {
   indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME,
   queries: [...mdxQueries, ...airtableQueries],
   dryRun: process.env.BRANCH !== 'main',
-  continueOnFailure: false,
+  continueOnFailure: true,
 }

--- a/src/components/shared/Header/Header.tsx
+++ b/src/components/shared/Header/Header.tsx
@@ -2,7 +2,7 @@ import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
 import { LoginContext } from '@Context/LoginContext'
 import { useLocation } from '@reach/router'
 import { Link as LinkComponent } from 'gatsby'
-import React, { FC, useContext, useEffect, useState } from 'react'
+import React, { FC, useContext, useState } from 'react'
 import { AnchorButton, Cluster, FaBarsIcon, FaSearchIcon, defaultColor, Dialog as shrDialog } from 'smarthr-ui'
 import styled, { createGlobalStyle, css } from 'styled-components'
 
@@ -23,13 +23,8 @@ type Props = {
 export const Header: FC<Props> = ({ isIndex = false }) => {
   const location = useLocation()
   const [isOpen, setIsOpen] = useState(false)
-  const [isClient, setIsClient] = useState(false)
 
   const { loginStatus, loginLabel } = useContext(LoginContext)
-
-  useEffect(() => {
-    setIsClient(typeof window !== 'undefined')
-  }, [])
 
   const isCurrent = (url: string) => {
     const regexp = new RegExp(`${url}`)
@@ -73,19 +68,18 @@ export const Header: FC<Props> = ({ isIndex = false }) => {
             </ul>
             <MenuContainer>
               <StyledOpenButton
-                // サーバー時は対象となるDialogコンポーネントをレンダリングできないため、aria-controlsは出力しない
-                {...(isClient && { 'aria-controls': 'panel-menu' })}
                 type="button"
                 onClick={() => {
                   setIsOpen(true)
                 }}
                 title="メニューを開く"
                 aria-haspopup="true"
+                aria-controls="panel-menu"
               >
                 <FaBarsIcon size={24} />
               </StyledOpenButton>
               {/* サーバー時は`document`が存在せずエラーになるため、Dialogコンポーネントをレンダリングしない */}
-              {isClient ? (
+              {typeof window !== 'undefined' ? (
                 <Dialog
                   isOpen={isOpen}
                   top={0}
@@ -138,7 +132,10 @@ export const Header: FC<Props> = ({ isIndex = false }) => {
                     </MenuLinkContainer>
                   </MenuContentsContainer>
                 </Dialog>
-              ) : null}
+              ) : (
+                // id="panel-menu"の要素が存在しないと、ボタンの`aria-controls="panel-menu"`が不正になるため、SSR時のプレースホルダーを出力する
+                <div id="panel-menu" aria-hidden="true"></div>
+              )}
             </MenuContainer>
           </StyledNav>
         </Container>

--- a/src/components/shared/Header/Header.tsx
+++ b/src/components/shared/Header/Header.tsx
@@ -2,7 +2,7 @@ import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
 import { LoginContext } from '@Context/LoginContext'
 import { useLocation } from '@reach/router'
 import { Link as LinkComponent } from 'gatsby'
-import React, { FC, useContext, useState } from 'react'
+import React, { FC, useContext, useEffect, useState } from 'react'
 import { AnchorButton, Cluster, FaBarsIcon, FaSearchIcon, defaultColor, Dialog as shrDialog } from 'smarthr-ui'
 import styled, { createGlobalStyle, css } from 'styled-components'
 
@@ -23,8 +23,13 @@ type Props = {
 export const Header: FC<Props> = ({ isIndex = false }) => {
   const location = useLocation()
   const [isOpen, setIsOpen] = useState(false)
+  const [isClient, setIsClient] = useState(false)
 
   const { loginStatus, loginLabel } = useContext(LoginContext)
+
+  useEffect(() => {
+    setIsClient(typeof window !== 'undefined')
+  }, [])
 
   const isCurrent = (url: string) => {
     const regexp = new RegExp(`${url}`)
@@ -68,17 +73,19 @@ export const Header: FC<Props> = ({ isIndex = false }) => {
             </ul>
             <MenuContainer>
               <StyledOpenButton
+                // サーバー時は対象となるDialogコンポーネントをレンダリングできないため、aria-controlsは出力しない
+                {...(isClient && { 'aria-controls': 'panel-menu' })}
                 type="button"
                 onClick={() => {
                   setIsOpen(true)
                 }}
                 title="メニューを開く"
                 aria-haspopup="true"
-                aria-controls="panel-menu"
               >
                 <FaBarsIcon size={24} />
               </StyledOpenButton>
-              {typeof window !== 'undefined' ? (
+              {/* サーバー時は`document`が存在せずエラーになるため、Dialogコンポーネントをレンダリングしない */}
+              {isClient ? (
                 <Dialog
                   isOpen={isOpen}
                   top={0}


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1142

## やったこと
SSR時（`window`オブジェクトが存在しない場合）には、ハンバーガーメニューを開くボタンの`aria-controls="panel-menu"`を出力しないようにしました。

コントロール対象となる`id="panel-menu"`の要素は、smarthr-uiのDialogコンポーネントを利用していますが、このコンポーネントも（`document`を利用するため）SSR時は出力しないようになっているので、ボタンの`aria-controls`も同じ条件で出力しています。

## 動作確認
https://deploy-preview-423--smarthr-design-system.netlify.app/

HTMLのバリデーションエラーは出なくなりました。また、ブラウザでのレンダリング時には`aria-controls`が出力されています。
![image](https://user-images.githubusercontent.com/7822534/207776090-1fe00ca3-dc3d-4e60-b8f6-7cc3a3ee66cf.png)

## キャプチャ
見た目や動作に影響はありません。