### PR TITLE
開発時のAlgoliaへのindex送信まわりを修正

### DIFF
--- a/gatsby-plugin-algolia-config.ts
+++ b/gatsby-plugin-algolia-config.ts
@@ -120,5 +120,5 @@ export const algoliaConfig = {
   indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME,
   queries: [...mdxQueries, ...airtableQueries],
   dryRun: process.env.BRANCH !== 'main',
-  continueOnFailure: false,
+  continueOnFailure: process.env.BRANCH !== 'main',
 }

--- a/gatsby-plugin-algolia-config.ts
+++ b/gatsby-plugin-algolia-config.ts
@@ -1,3 +1,8 @@
+import dotenv from 'dotenv'
+dotenv.config({
+  path: '.env',
+})
+
 import { AIRTABLE_CONTENTS } from './src/constants/airtable'
 
 const mdxQueries = [


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1133

gatsby-plugin-algolia のアップデートに伴い、`skipIndexing`オプションが`dryRun`に変更された結果、挙動が変わったようです。
`skipIndexing`では何も実行されませんでしたが、`dryRun`ではインデックス登録の試行が行われるため、`GATSBY_ALGOLIA_APP_ID`などの環境変数が存在しない場合はエラーになってしまいます。
そして、`continueOnFailure`オプションが`false`なので、エラーになった場合にはビルドが止まってしまいます。

## やったこと
ローカルの開発環境ではAlgoliaの動作確認が不要な場面もありそうなので、`continueOnFailure`も`dryRun`と同様に、`process.env.BRANCH !== 'main'`としました。

また、`gatsby-plugin-algolia-config.ts`内では、`process.env.GATSBY_...`が`undefined`になっていたので、dotenvのimportを追加しました。

## 動作確認
ローカルでは、
- mainブランチ以外では、Algolia関連の環境変数がなくてもビルドエラーにはならない
- mainブランチ以外では、環境変数をセットしておけばdryRunが実行され、想定される送信レコード数や設定などのステータスがターミナルに出力される
- mainブランチ（dryRunしない）では、環境変数に誤りがある場合などはエラーとなりビルドが止まる

ことを確認しました。
また、このPRのプレビュー（mainブランチではないが環境変数はセットされている状況）では、dryRunが成功していました。
https://app.netlify.com/sites/smarthr-design-system/deploys/639bd527cde5ef00089d4f63