### PR TITLE
フッターとハンバーガーメニューで表示されるメニューリンクのクリック領域を広げた

### DIFF
--- a/src/components/shared/Footer/FootStaticLinks.tsx
+++ b/src/components/shared/Footer/FootStaticLinks.tsx
@@ -65,11 +65,11 @@ export const FootStaticLinks: FC<Props> = () => {
         {Link1.map(({ title, path, isExternal }, index) => (
           <li key={index}>
             {isExternal ? (
-              <a href={path} target="_blank" rel="noopener noreferrer">
+              <StyledAnchor href={path} target="_blank" rel="noopener noreferrer">
                 {title}
-              </a>
+              </StyledAnchor>
             ) : (
-              <Link to={path}>{title}</Link>
+              <StyledLink to={path}>{title}</StyledLink>
             )}
           </li>
         ))}
@@ -79,11 +79,11 @@ export const FootStaticLinks: FC<Props> = () => {
         {Link2.map(({ title, path, isExternal }, index) => (
           <li key={index}>
             {isExternal ? (
-              <a href={path} target="_blank" rel="noopener noreferrer">
+              <StyledAnchor href={path} target="_blank" rel="noopener noreferrer">
                 {title}
-              </a>
+              </StyledAnchor>
             ) : (
-              <Link to={path}>{title}</Link>
+              <StyledLink to={path}>{title}</StyledLink>
             )}
           </li>
         ))}
@@ -131,4 +131,14 @@ const StyledAnchorButton = styled(AnchorButton)`
   &.loginStatusPending {
     visibility: hidden;
   }
+`
+
+const StyledAnchor = styled.a`
+  display: inline-block;
+  width: 100%;
+`
+
+const StyledLink = styled(Link)`
+  display: inline-block;
+  width: 100%;
 `

--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -116,7 +116,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
         <Col2Container>
           <div>
             <StyledH3>
-              <Link to="/concept/">コンセプト</Link>
+              <StyledLink to="/concept/">コンセプト</StyledLink>
             </StyledH3>
             {concept.length > 0 && (
               <StyledUl>
@@ -125,14 +125,14 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
                   if (frontmatter?.title === undefined) return null
                   return (
                     <li key={fields.slug}>
-                      <Link to={fields.slug}>{frontmatter.title}</Link>
+                      <StyledLink to={fields.slug}>{frontmatter.title}</StyledLink>
                     </li>
                   )
                 })}
               </StyledUl>
             )}
             <StyledH3>
-              <Link to="/foundation/">基本原則</Link>
+              <StyledLink to="/foundation/">基本原則</StyledLink>
               {foundation.length > 0 && (
                 <StyledUl>
                   {foundation.map(({ fields, frontmatter }) => {
@@ -140,7 +140,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
                     if (frontmatter?.title === undefined) return null
                     return (
                       <li key={fields.slug}>
-                        <Link to={fields.slug}>{frontmatter.title}</Link>
+                        <StyledLink to={fields.slug}>{frontmatter.title}</StyledLink>
                       </li>
                     )
                   })}
@@ -150,7 +150,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
           </div>
           <div>
             <StyledH3>
-              <Link to="/basics/">基本要素</Link>
+              <StyledLink to="/basics/">基本要素</StyledLink>
             </StyledH3>
             {basics.length > 0 && (
               <StyledUl>
@@ -159,14 +159,14 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
                   if (frontmatter?.title === undefined) return null
                   return (
                     <li key={fields.slug}>
-                      <Link to={fields.slug}>{frontmatter.title}</Link>
+                      <StyledLink to={fields.slug}>{frontmatter.title}</StyledLink>
                     </li>
                   )
                 })}
               </StyledUl>
             )}
             <StyledH3>
-              <Link to="/accessibility/">アクセシビリティ</Link>
+              <StyledLink to="/accessibility/">アクセシビリティ</StyledLink>
             </StyledH3>
             {accessibility.length > 0 && (
               <StyledUl>
@@ -175,7 +175,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
                   if (frontmatter?.title === undefined) return null
                   return (
                     <li key={fields.slug}>
-                      <Link to={fields.slug}>{frontmatter.title}</Link>
+                      <StyledLink to={fields.slug}>{frontmatter.title}</StyledLink>
                     </li>
                   )
                 })}
@@ -184,7 +184,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
           </div>
           <div>
             <StyledH3>
-              <Link to="/products/">プロダクト</Link>
+              <StyledLink to="/products/">プロダクト</StyledLink>
             </StyledH3>
             {products.length > 0 && (
               <StyledUl>
@@ -193,7 +193,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
                   if (frontmatter?.title === undefined) return null
                   return (
                     <li key={fields.slug}>
-                      <Link to={fields.slug}>{frontmatter.title}</Link>
+                      <StyledLink to={fields.slug}>{frontmatter.title}</StyledLink>
                     </li>
                   )
                 })}
@@ -202,7 +202,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
           </div>
           <div>
             <StyledH3>
-              <Link to="/communication/">コミュニケーション</Link>
+              <StyledLink to="/communication/">コミュニケーション</StyledLink>
             </StyledH3>
             {communication.length > 0 && (
               <StyledUl>
@@ -211,7 +211,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
                   if (frontmatter?.title === undefined) return null
                   return (
                     <li key={fields.slug}>
-                      <Link to={fields.slug}>{frontmatter.title}</Link>
+                      <StyledLink to={fields.slug}>{frontmatter.title}</StyledLink>
                     </li>
                   )
                 })}
@@ -377,6 +377,11 @@ const StyledUl = styled.ul`
       margin-bottom: 4px;
     }
   }
+`
+
+const StyledLink = styled(Link)`
+  display: inline-block;
+  width: 100%;
 `
 
 const StyledCopyright = styled.p`

--- a/src/components/shared/Header/Header.tsx
+++ b/src/components/shared/Header/Header.tsx
@@ -119,9 +119,9 @@ export const Header: FC<Props> = ({ isIndex = false }) => {
                       <MenuStyledCategoryUl>
                         {headerContents.map(({ title, key, path }) => (
                           <li key={key}>
-                            <LinkComponent to={path} className={key && (isCurrent(key) ? '-active' : '')}>
+                            <StyledMenuLink to={path} className={key && (isCurrent(key) ? '-active' : '')}>
                               {title}
-                            </LinkComponent>
+                            </StyledMenuLink>
                           </li>
                         ))}
                       </MenuStyledCategoryUl>
@@ -378,6 +378,11 @@ const MenuStyledCategoryUl = styled.ul`
       text-decoration: underline;
     }
   }
+`
+
+const StyledMenuLink = styled(LinkComponent)`
+  display: inline-block;
+  width: 100%;
 `
 
 const MenuFootLinkContainer = styled.div`


### PR DESCRIPTION
## 課題・背景

https://github.com/kufu/smarthr-design-system-issues/issues/1154

## やったこと

- ハンバーガーメニューで表示されるダイアログ内のメニューリンクのクリック領域を広げた
- フッター内のメニューリンクのクリック領域を広げた

## やらなかったこと

フッター内のリンクは横には広げられたものの、フォントが小さくて縦に広げることはできないため、Ligthhouseのモバイル版チェックでは相変わらず警告が出てしまうが、デザインの変更を伴わざるをえないので、ここでは対応しなかった。

## 動作確認

https://deploy-preview-428--smarthr-design-system.netlify.app/

## キャプチャ

* 横幅は広がりましたが、縦幅が48px以上無いということで依然としてLighthouseに警告されてしまいます。

|Before|After|
| --- | --- |
| <img width="654" alt="image" src="https://user-images.githubusercontent.com/1369376/208368504-01b8088b-552a-4b54-bc00-e063f0efab80.png"> | <img width="654" alt="image" src="https://user-images.githubusercontent.com/1369376/208368579-2ea2cb40-4f30-439f-9cc5-a4117e9b359c.png"> |
