### PR TITLE
コピーライトから発行年を削除

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2022 SmartHR
+Copyright SmartHR
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -223,7 +223,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
         <CopyrightContainer>
           <StyledCopyright>
             <img src="/images/logo_smarthr.svg" alt="SmartHR" width="84" height="15" />
-            <small>© 2022, SmartHR, Inc.</small>
+            <small>© SmartHR, Inc.</small>
           </StyledCopyright>
         </CopyrightContainer>
       </LayoutContainer>


### PR DESCRIPTION
## 課題・背景
毎年コピーライト表記の年号を変更するのは少し手間
https://github.com/kufu/smarthr-design-system-issues/issues/1150

## やったこと
コピーライトから発行年を削除

## やらなかったこと
とくになし

## 動作確認


## キャプチャ

|Before|After|
| --- | --- |
| <img width="885" alt="スクリーンショット 2022-12-29 19 44 48" src="https://user-images.githubusercontent.com/101125529/209940369-ae395757-41bb-4785-8d68-f878724f8ee2.png"> | <img width="892" alt="スクリーンショット 2022-12-29 19 43 58" src="https://user-images.githubusercontent.com/101125529/209940362-2f2ce69f-89af-4e71-b8ef-039695f47c35.png"> 


<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
