### PR TITLE
ライブエディタで使用するTypeScriptをCDNからの読み込みに変更

### DIFF
--- a/src/@types/cdn-typescript/index.d.ts
+++ b/src/@types/cdn-typescript/index.d.ts
@@ -1,0 +1,41 @@
+// CodeBlock -> LiveEditorで、入力されたコードのトランスパイルに使用するTypeScript用の型定義
+// tsライブラリ自体はCDNから読み込む（容量が大きいため、Gatsbyのバンドルから除外したい）
+// 参考：https://github.com/microsoft/TypeScript/blob/main/lib/typescript.d.ts
+
+interface Window {
+  ts: {
+    transpile: (input: string, compilerOptions?: CdnTs.CompilerOptions) => string
+    JsxEmit: typeof CdnTs.JsxEmit
+    ScriptTarget: typeof CdnTs.ScriptTarget
+  }
+}
+
+declare namespace CdnTs {
+  interface CompilerOptions {
+    jsx?: JsxEmit
+    target?: ScriptTarget
+  }
+  enum JsxEmit {
+    None = 0,
+    Preserve = 1,
+    React = 2,
+    ReactNative = 3,
+    ReactJSX = 4,
+    ReactJSXDev = 5,
+  }
+  enum ScriptTarget {
+    ES3 = 0,
+    ES5 = 1,
+    ES2015 = 2,
+    ES2016 = 3,
+    ES2017 = 4,
+    ES2018 = 5,
+    ES2019 = 6,
+    ES2020 = 7,
+    ES2021 = 8,
+    ES2022 = 9,
+    ESNext = 99,
+    JSON = 100,
+    Latest = 99,
+  }
+}

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -14,14 +14,6 @@ import { ComponentPreview } from '../../ComponentPreview'
 
 import { CopyButton } from './CopyButton'
 
-declare type TsType = typeof import('typescript/lib/typescript.js')
-
-declare global {
-  interface Window {
-    ts: TsType
-  }
-}
-
 type Props = {
   children: string
   className?: Language
@@ -46,7 +38,7 @@ const theme = {
 
 const smarthrTheme = ui.createTheme()
 
-const transformCode = (snippet: string, tslib: TsType | undefined) => {
+const transformCode = (snippet: string, tslib: typeof window.ts) => {
   if (tslib === undefined) return ''
   // Storybookでも利用するため、コード内に`import`・`export`が記述されているが、ここではエラーになるので削除する。
   const code = snippet.replace(/^import\s.*\sfrom\s.*$/gm, '').replace(/^export\s/gm, '')


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1153

## やったこと
ライブエディタで使用するTypeScriptのライブラリの容量が大きいため、`script`タグを使ってCDN（https://unpkg.com/typescript@latest/lib/typescriptServices.js ）から読み込むようにし、Gatsbyが生成するJSバンドルに含めないようにしました。
合わせて、ライブエディタ部分はクライアントでのみレンダリングされるように変更しました。

また、`script`タグでのJSの読み込みがロードされないケースがあり、この部分もクライアントのみでレンダリングされるようにすると問題が回避できました。

## やらなかったこと
型定義のみ、そのまま
```
declare type TsType = typeof import('typescript/lib/typescript.js')
```
として利用しているので、`package.json`にはtypescriptへの依存が残っています。とはいえ、コード自体はクライアントでCDNから読み込むわけなので、型は`any`にしてしまい、依存もなくす、というのもありかもしれません。

## 動作確認
ライブエディタのあるページ例：
https://deploy-preview-445--smarthr-design-system.netlify.app/products/design-patterns/upward-navigation/#h2-1
https://deploy-preview-445--smarthr-design-system.netlify.app/products/design-patterns/select-company-account/#h2-2
https://deploy-preview-445--smarthr-design-system.netlify.app/products/components/button/#h2-0

## キャプチャ
トップページで読み込んでいるJSの容量は減っています。

**Before**
![image](https://user-images.githubusercontent.com/7822534/210500724-cae38cbc-6806-492b-aba5-0b85f0b400f1.png)

**After**
![image](https://user-images.githubusercontent.com/7822534/210502593-00269e1b-367d-4a7f-841b-7c44976f3904.png)

↑ netlify.jsとwebpack〜はNetlifyのプレビュー機能で読み込んでしまっているもの。TSが含まれていた1.3MBのJSファイルは399kBになっている。
