### PR TITLE
ログインチェックのリクエストメソッドをHEADに変更

### DIFF
--- a/src/context/LoginContext.tsx
+++ b/src/context/LoginContext.tsx
@@ -32,7 +32,7 @@ export const LoginContextProvider: FC<Props> = ({ children }) => {
     // Chromeで、history.back()後のfetchが失敗する現象が起こるため、setTimeout()からタスクに追加してバグを回避する。
     // https://bugs.chromium.org/p/chromium/issues/detail?id=1244230
     setTimeout(() => {
-      fetch(PRIVATE_DOC_PATH).then(
+      fetch(PRIVATE_DOC_PATH, { method: 'HEAD' }).then(
         (res) => {
           if (res.status === 200) {
             setLoginStatus('loggedIn')


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1163

## やったこと
ログイン状態の確認のために、従業員専用ページにアクセスする際のメソッドを`GET`ではなく`HEAD`に変更しました。

## やらなかったこと
アクセス先などは変更ありません。
コンソールにエラーが出てしまう点は、非ログイン状態でも400未満のステータスコードが返ってくれば回避できるのですが、Netlifyから401が返っているので難しそうです。

## 動作確認
https://deploy-preview-446--smarthr-design-system.netlify.app/

プレビューにて、最初のアクセス時には`HEAD`でリクエストが飛んでいる点、ログイン機能には影響がない点を確認しました。
![image](https://user-images.githubusercontent.com/7822534/210955639-066c6f50-1d04-41cc-8ac6-4b1c38563610.png)

## キャプチャ
見た目上の変更はありません。
