### PR TITLE
本環境ではJSのソースマップURLが出力されないよう設定

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -18,9 +18,9 @@ export const onCreateWebpackConfig = ({ actions }: CreateWebpackConfigArgs) => {
       },
     },
   })
-  if (process.env.BRANCH === 'main') {
-    actions.setWebpackConfig({
-      devtool: false,
-    })
-  }
+  // if (process.env.BRANCH === 'main') {
+  actions.setWebpackConfig({
+    devtool: false,
+  })
+  // }
 }

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -18,9 +18,9 @@ export const onCreateWebpackConfig = ({ actions }: CreateWebpackConfigArgs) => {
       },
     },
   })
-  // if (process.env.BRANCH === 'main') {
-  actions.setWebpackConfig({
-    devtool: false,
-  })
-  // }
+  if (process.env.BRANCH === 'main') {
+    actions.setWebpackConfig({
+      devtool: false,
+    })
+  }
 }

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -18,6 +18,7 @@ export const onCreateWebpackConfig = ({ actions }: CreateWebpackConfigArgs) => {
       },
     },
   })
+  // Gatsbyではビルド時には常にNODE_ENV=productionになるため、ブランチで判定
   if (process.env.BRANCH === 'main') {
     actions.setWebpackConfig({
       devtool: false,

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,7 +1,8 @@
 import path from 'path'
-import type { CreateWebpackConfigArgs, GatsbyNode } from 'gatsby'
 
-import * as gatsbyNode from './src/gatsby-node/index'
+import * as gatsbyNode from './src/gatsby-node'
+
+import type { CreateWebpackConfigArgs, GatsbyNode } from 'gatsby'
 
 export const onCreateNode: GatsbyNode['onCreateNode'] = gatsbyNode.onCreateNode
 export const createPages: GatsbyNode['createPages'] = gatsbyNode.createPages
@@ -17,4 +18,9 @@ export const onCreateWebpackConfig = ({ actions }: CreateWebpackConfigArgs) => {
       },
     },
   })
+  if (process.env.BRANCH === 'main') {
+    actions.setWebpackConfig({
+      devtool: false,
+    })
+  }
 }


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1162

## やったこと
webpackのオプションを追加し、mainブランチではソースマップのURLを出力しないようにしました。

[gatsby-plugin-no-sourcemaps](https://www.gatsbyjs.com/plugins/gatsby-plugin-no-sourcemaps/)というプラグインもありますが、Node.js v18以上が条件となっていること、[ソースコード](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-no-sourcemaps/gatsby-node.js)を見ると、webpackに`devtool: false`を追加しているだけであることから、プラグインは利用しませんでした。

また、編集した`gatsby-node.ts`の`import`文部分でeslintエラーが出るようになっていたので合わせて修正しています。

## 動作確認
mainブランチ以外では、Gatsbyが生成したJSファイル内（おもに末尾）に、
```
//# sourceMappingURL=9ca8d63625eed7145188ccefa38d3172193a88f3-1c9b720a44169db194e3.js.map
```
のような文字列がありますが、mainブランチではこれが出力されなくなります。`public`ディレクトリ内の`*.js.map`も出力されません。

**Before**
![image](https://user-images.githubusercontent.com/7822534/211462722-d36a7977-86ff-4a51-9077-63d4e1de395b.png)

**After**
（テストのため、全ブランチで`devtool: false`したときのNetlifyプレビュー）
![image](https://user-images.githubusercontent.com/7822534/211463394-44ca7abc-478a-4a79-8030-25dd5d0af7c0.png)
コンソールに警告が出ていないことも確認できました。

## キャプチャ
見た目上の変化はありません。