### PR TITLE
Airtableコンテンツの見出し抽出処理を修正

### DIFF
--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -132,15 +132,20 @@ const Article: FC<Props> = ({ data }) => {
   const title = frontmatter?.title || ''
 
   // Airtableコンテンツのheading。各項目をh2として扱う
-  const airTableHeadings = data.airTable.edges.map((edge) => {
-    return {
-      depth: 2,
-      value: edge.node.data?.name ?? '',
-      recordId: edge.node.data?.record_id ?? '',
-      name: edge.node.data?.name ?? '',
-      order: edge.node.data?.order ?? Number.MAX_SAFE_INTEGER,
-    }
-  })
+  const airTableHeadings = data.airTable.edges
+    .filter((edge) => {
+      return edge.node.data?.name && edge.node.data?.name !== ''
+    })
+    .map((edge) => {
+      return {
+        depth: 2,
+        value: edge.node.data?.name ?? '',
+        recordId: edge.node.data?.record_id ?? '',
+        name: edge.node.data?.name ?? '',
+        order: edge.node.data?.order ?? Number.MAX_SAFE_INTEGER,
+      }
+    })
+
   // Airtableコンテンツは、ページによりソート方法が異なるので、headingの順序もそれに合わせる
   const airtableSortType =
     AIRTABLE_CONTENTS.filter((item: airtableContents) => {


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1168

## やったこと
`/srctemplates/article.tsx`内で、Airtableの各レコードを`h2`レベルの見出しとして扱う処理があるが、[用字用語：一覧](https://smarthr.design/products/contents/idiomatic-usage/data/)のページはテーブル表示のため、見出しとして扱うのは適切ではないため、除外しました。
具体的には、レコードの`name`という項目が`null`になっているものを除外しています。

## 動作確認
https://deploy-preview-458--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/

また、Airtableを利用するページのうち、用字用語：理由のページなどは、各レコードを`h2`レベルの見出しとするのが正しいので、これまで通りで変化はありません。（ https://deploy-preview-458--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/usage/ ）

## キャプチャ
もともと空白文字を囲むタグが出力されている状態だったため、見た目は変わっていません。
ソースコードには空白のタグが出力されなくなりました。
![image](https://user-images.githubusercontent.com/7822534/212259833-0513c5d7-281e-4ab2-b84d-9dae715694a1.png)
