### PR TITLE
Gotchaの画像をCloudinaryに配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ import { hoge } from '@Components/hoge'
 yarn export:zip-images
 ```
 
+### Gotchaアイテムの追加・削除・編集方法
+
+Gotchaの画像はサイズが大きいため、画像配信CDN[Cloudinary](https://cloudinary.com/)を利用しています。画像の追加・更新の際はCloudinaryの`sds`フォルダに追加したい画像をアップロードしてください。
+
+アップロードすると、Cloudinary上で名前がつきますので、`/src/data/gotchaItem.json`にその画像名と、タイトル等の情報を記載してください。
+
+※Cloudinaryは、1回目の画像アクセス時に画像の最適化・キャッシュを行うので、初回表示時のみ数秒程度の時間がかかるかもしれません。2回目以降の表示が高速であれば問題ありません。
+
+アイテムを削除したい場合は、`/src/data/gotchaItem.json`から該当の項目を削除すれば表示されなくなります。Cloudinary上の画像もあわせて削除しても構いません。
+
 ## ローカルで従業員ログインを動作させる
 
 `yarn dev`で実行される`gatsby develop`コマンドで立ち上げたローカル環境では従業員ログインが動作しません。

--- a/src/components/index/Gotcha.tsx
+++ b/src/components/index/Gotcha.tsx
@@ -69,10 +69,12 @@ export const Gotcha: FC<unknown> = () => {
     }
     nextImgIsReady = false
     nextImg.srcset = `
-      ${CLOUDINARY_URL}f_auto/w_1272/sds/${gotchaItem[randomNum].image} 1272w,
+      ${CLOUDINARY_URL}f_auto/w_2720/sds/${gotchaItem[randomNum].image} 2720w,
+      ${CLOUDINARY_URL}f_auto/w_1536/sds/${gotchaItem[randomNum].image} 1536w,
       ${CLOUDINARY_URL}f_auto/w_768/sds/${gotchaItem[randomNum].image} 768w
     `
     nextImg.src = `${CLOUDINARY_URL}f_auto/sds/${gotchaItem[randomNum].image}`
+    nextImg.sizes = '(min-width: 1024px) 2720px, 100vw'
     setNextItemIndex(randomNum)
   }
 
@@ -92,12 +94,14 @@ export const Gotcha: FC<unknown> = () => {
           {nextItemIndex > -1 && (
             <img
               srcSet={`
-                ${CLOUDINARY_URL}f_auto/w_1272/sds/${gotchaItem[nextItemIndex].image} 1272w,
+                ${CLOUDINARY_URL}f_auto/w_2720/sds/${gotchaItem[nextItemIndex].image} 2720w,
+                ${CLOUDINARY_URL}f_auto/w_1536/sds/${gotchaItem[nextItemIndex].image} 1536w,
                 ${CLOUDINARY_URL}f_auto/w_768/sds/${gotchaItem[nextItemIndex].image} 768w
               `}
               src={`${CLOUDINARY_URL}f_auto/sds/${gotchaItem[nextItemIndex].image}`}
               width="1272"
               height="352"
+              sizes="(min-width: 1024px) 2720px, 100vw"
               alt={gotchaItem[nextItemIndex].alt}
               aria-hidden="true"
               onLoad={() => nextImgOnload()}
@@ -108,10 +112,12 @@ export const Gotcha: FC<unknown> = () => {
             // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
             <img
               srcSet={`
-                ${CLOUDINARY_URL}f_auto/w_1272/sds/${gotchaItem[currentItemIndex].image} 1272w,
+                ${CLOUDINARY_URL}f_auto/w_2720/sds/${gotchaItem[currentItemIndex].image} 2720w,
+                ${CLOUDINARY_URL}f_auto/w_1536/sds/${gotchaItem[currentItemIndex].image} 1536w,
                 ${CLOUDINARY_URL}f_auto/w_768/sds/${gotchaItem[currentItemIndex].image} 768w
               `}
               src={`${CLOUDINARY_URL}f_auto/sds/${gotchaItem[currentItemIndex].image}`}
+              sizes="(min-width: 1024px) 2720px, 100vw"
               width="1272"
               height="352"
               alt={gotchaItem[currentItemIndex].alt}

--- a/src/components/index/Gotcha.tsx
+++ b/src/components/index/Gotcha.tsx
@@ -10,7 +10,7 @@ import type { FC } from 'react'
 
 const BUTTON_TEXT: string = 'GOTCHA!' // アニメーションするため、css、reactのどちらでも必要なのでここで
 
-const CLOUDINARY_URL = `https://res.cloudinary.com/dxxditmn9/image/upload/`
+const CLOUDINARY_URL = `https://res.cloudinary.com/${process.env.GATSBY_CLOUDINARY_CLOUD_NAME}/image/upload/`
 
 type GotchaItem = {
   image: string

--- a/src/components/index/Gotcha.tsx
+++ b/src/components/index/Gotcha.tsx
@@ -1,6 +1,6 @@
 import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import { Link } from 'gatsby'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { FaRedoIcon } from 'smarthr-ui'
 import styled, { css } from 'styled-components'
 
@@ -9,6 +9,8 @@ import gotchaItemJson from '../../data/gotchaItem.json'
 import type { FC } from 'react'
 
 const BUTTON_TEXT: string = 'GOTCHA!' // アニメーションするため、css、reactのどちらでも必要なのでここで
+
+const CLOUDINARY_URL = `https://res.cloudinary.com/dxxditmn9/image/upload/`
 
 type GotchaItem = {
   image: string
@@ -31,12 +33,15 @@ export const Gotcha: FC<unknown> = () => {
   }, [])
 
   const [isAnimated, setIsAnimated] = useState(false)
-  const [shouldDisabled, setShouldDisabled] = useState(true)
-
-  if (gotchaItem.length === 0) return null
 
   let currentImgIsReady = false
   let nextImgIsReady = false
+
+  const shouldDisabled: boolean = useMemo(() => {
+    return currentImgIsReady && nextImgIsReady
+  }, [currentImgIsReady, nextImgIsReady])
+
+  if (gotchaItem.length === 0) return null
 
   const runGotcha = (): void => {
     //ボタンが押されたらアニメーションする
@@ -46,7 +51,7 @@ export const Gotcha: FC<unknown> = () => {
   const finishAnimation = (): void => {
     setCurrentItemIndex(nextItemIndex)
 
-    //画像の入れ替えが終わっていないとチラつくことがあるので、100ms待つ。
+    //画像の入れ替えが終わっていないとチラつくことがあるので、200ms待つ。
     setTimeout(() => {
       //アニメーション開始位置に要素を戻しておく
       setIsAnimated(false)
@@ -61,26 +66,22 @@ export const Gotcha: FC<unknown> = () => {
     const nextImg = new Image()
     nextImg.onload = () => {
       nextImgIsReady = true
-      setShouldDisabled(false)
     }
     nextImgIsReady = false
-    nextImg.src = gotchaItem[randomNum].image
+    nextImg.srcset = `
+      ${CLOUDINARY_URL}f_auto/w_1272/sds/${gotchaItem[randomNum].image} 1272w,
+      ${CLOUDINARY_URL}f_auto/w_768/sds/${gotchaItem[randomNum].image} 768w
+    `
+    nextImg.src = `${CLOUDINARY_URL}f_auto/sds/${gotchaItem[randomNum].image}`
     setNextItemIndex(randomNum)
-
-    //100ms以内に画像が読み込めていなかったらいったんボタンをdisabledにする
-    setTimeout(() => {
-      if (!nextImgIsReady) setShouldDisabled(true)
-    }, 100)
   }
 
   const currentImgOnLoad = (): void => {
     currentImgIsReady = true
-    if (nextImgIsReady) setShouldDisabled(false)
   }
 
   const nextImgOnload = (): void => {
     nextImgIsReady = true
-    if (currentImgIsReady) setShouldDisabled(false)
   }
 
   return (
@@ -90,7 +91,11 @@ export const Gotcha: FC<unknown> = () => {
           {/* 次の画像 */}
           {nextItemIndex > -1 && (
             <img
-              src={gotchaItem[nextItemIndex].image}
+              srcSet={`
+                ${CLOUDINARY_URL}f_auto/w_1272/sds/${gotchaItem[nextItemIndex].image} 1272w,
+                ${CLOUDINARY_URL}f_auto/w_768/sds/${gotchaItem[nextItemIndex].image} 768w
+              `}
+              src={`${CLOUDINARY_URL}f_auto/sds/${gotchaItem[nextItemIndex].image}`}
               width="1272"
               height="352"
               alt={gotchaItem[nextItemIndex].alt}
@@ -102,7 +107,11 @@ export const Gotcha: FC<unknown> = () => {
           {currentItemIndex > -1 && (
             // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
             <img
-              src={gotchaItem[currentItemIndex].image}
+              srcSet={`
+                ${CLOUDINARY_URL}f_auto/w_1272/sds/${gotchaItem[currentItemIndex].image} 1272w,
+                ${CLOUDINARY_URL}f_auto/w_768/sds/${gotchaItem[currentItemIndex].image} 768w
+              `}
+              src={`${CLOUDINARY_URL}f_auto/sds/${gotchaItem[currentItemIndex].image}`}
               width="1272"
               height="352"
               alt={gotchaItem[currentItemIndex].alt}

--- a/src/data/gotchaItem.json
+++ b/src/data/gotchaItem.json
@@ -1,6 +1,6 @@
 [
   {
-    "image": "/images/casestudy-01.png",
+    "image": "casestudy-01.png",
     "title": "SmartHR 人事評価機能 評価シート入力画面",
     "alt": "SmartHR 人事評価機能 評価シート入力画面",
     "links": [
@@ -19,7 +19,7 @@
     ]
   },
   {
-    "image": "/images/casestudy-02.png",
+    "image": "casestudy-02.png",
     "title": "SmartHRスクール内イラストレーション",
     "alt": "SmartHRスクール内イラストレーション",
     "links": [
@@ -42,7 +42,7 @@
     ]
   },
   {
-    "image": "/images/casestudy-03.jpg",
+    "image": "casestudy-03.jpg",
     "title": "人事労務カレンダー",
     "alt": "人事労務カレンダー",
     "links": [
@@ -53,7 +53,7 @@
     ]
   },
   {
-    "image": "/images/casestudy-04.png",
+    "image": "casestudy-04.png",
     "title": "営業資料テンプレート",
     "alt": "営業資料テンプレート",
     "links": [
@@ -72,7 +72,7 @@
     ]
   },
   {
-    "image": "/images/casestudy-05.jpg",
+    "image": "casestudy-05.jpg",
     "title": "SmartHRの大きいトート",
     "alt": "SmartHRの大きいトート",
     "links": [
@@ -91,7 +91,7 @@
     ]
   },
   {
-    "image": "/images/casestudy-06.jpg",
+    "image": "casestudy-06.jpg",
     "title": "オンライン飲み会セットの箱",
     "alt": "オンライン飲み会セットの箱",
     "links": [
@@ -102,7 +102,7 @@
     ]
   },
   {
-    "image": "/images/casestudy-07.png",
+    "image": "casestudy-07.png",
     "title": "SmartHR ご案内パンフレット",
     "alt": "SmartHR ご案内パンフレット",
     "links": [
@@ -117,7 +117,7 @@
     ]
   },
   {
-    "image": "/images/casestudy-08.jpg",
+    "image": "casestudy-08.jpg",
     "title": "年末調整書類があつまる封筒",
     "alt": "年末調整書類があつまる封筒",
     "links": [
@@ -132,7 +132,7 @@
     ]
   },
   {
-    "image": "/images/casestudy-09.jpg",
+    "image": "casestudy-09.jpg",
     "title": "SmartHR Blue カラーチップ Version1.0",
     "alt": "SmartHR Blue カラーチップ Version1.0",
     "links": [
@@ -155,7 +155,7 @@
     ]
   },
   {
-    "image": "/images/casestudy-10.jpg",
+    "image": "casestudy-10.jpg",
     "title": "PARK online ベータ版の招待状一式",
     "alt": "PARK online ベータ版の招待状一式",
     "links": [

--- a/src/data/gotchaItem.json
+++ b/src/data/gotchaItem.json
@@ -1,6 +1,6 @@
 [
   {
-    "image": "casestudy-01.png",
+    "image": "casestudy-01_ouyi8g.png",
     "title": "SmartHR 人事評価機能 評価シート入力画面",
     "alt": "SmartHR 人事評価機能 評価シート入力画面",
     "links": [
@@ -19,7 +19,7 @@
     ]
   },
   {
-    "image": "casestudy-02.png",
+    "image": "casestudy-02_xpdq4b.png",
     "title": "SmartHRスクール内イラストレーション",
     "alt": "SmartHRスクール内イラストレーション",
     "links": [
@@ -42,7 +42,7 @@
     ]
   },
   {
-    "image": "casestudy-03.jpg",
+    "image": "casestudy-03_kxqvjh.png",
     "title": "人事労務カレンダー",
     "alt": "人事労務カレンダー",
     "links": [
@@ -53,7 +53,7 @@
     ]
   },
   {
-    "image": "casestudy-04.png",
+    "image": "casestudy-04_x8fl2m.png",
     "title": "営業資料テンプレート",
     "alt": "営業資料テンプレート",
     "links": [
@@ -72,7 +72,7 @@
     ]
   },
   {
-    "image": "casestudy-05.jpg",
+    "image": "casestudy-05_dfujdp.png",
     "title": "SmartHRの大きいトート",
     "alt": "SmartHRの大きいトート",
     "links": [
@@ -91,7 +91,7 @@
     ]
   },
   {
-    "image": "casestudy-06.jpg",
+    "image": "casestudy-06_qrtekv.png",
     "title": "オンライン飲み会セットの箱",
     "alt": "オンライン飲み会セットの箱",
     "links": [
@@ -102,7 +102,7 @@
     ]
   },
   {
-    "image": "casestudy-07.png",
+    "image": "casestudy-07_urau6m.png",
     "title": "SmartHR ご案内パンフレット",
     "alt": "SmartHR ご案内パンフレット",
     "links": [
@@ -117,7 +117,7 @@
     ]
   },
   {
-    "image": "casestudy-08.jpg",
+    "image": "casestudy-08_mzo4yq.png",
     "title": "年末調整書類があつまる封筒",
     "alt": "年末調整書類があつまる封筒",
     "links": [
@@ -132,7 +132,7 @@
     ]
   },
   {
-    "image": "casestudy-09.jpg",
+    "image": "casestudy-09_emh2tw.png",
     "title": "SmartHR Blue カラーチップ Version1.0",
     "alt": "SmartHR Blue カラーチップ Version1.0",
     "links": [
@@ -155,7 +155,7 @@
     ]
   },
   {
-    "image": "casestudy-10.jpg",
+    "image": "casestudy-10_kvdipw.png",
     "title": "PARK online ベータ版の招待状一式",
     "alt": "PARK online ベータ版の招待状一式",
     "links": [


### PR DESCRIPTION
※Cloudinaryアカウントがテスト用のため、マージはアカウント切り替え後に行う

## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1165

## やったこと
Gotchaで使われている画像をCloudinaryにアップロードした画像に差し替えました。
Cloudinaryを利用することで、以下のような画像の出し分けができます。
- ブラウザに応じて最適な画像フォーマットが選択される
- 画像幅を指定したリクエストができるので、`img`要素の`srcset`属性と合わせて、画面幅が狭い時には小さい画像を利用できる

→これにより、パフォーマンスの向上が見込めます。

また、画像の読み込みが速くなったためか、2枚の画像（表示中画像と隠れている次の画像）の読み込み終わり判定がうまくいかないケースがあったため、`useMemo`を使うように変更しています。

## やらなかったこと
`picture`要素ではなく、`img`要素＋`srcset`属性を使っているので、実際にどのソース画像が選択されるかはブラウザ依存です。Viewportが768pxだと768pxの画像が選択されるわけではなく、dprなども考慮されるので、たとえばChromeではViewport500pxくらいからは大きな画像が選ばれるようです。

今は1272pxと768pxの2つですが、もう少し細かい刻みで画像を増やしてもいいかもしれません。

また、Gotcha以外のトップページの画像については従来のままなので、こちらもCloudinaryを利用してフォーマットの最適かをしても良いかもしれません。

## 動作確認
https://deploy-preview-469--smarthr-design-system.netlify.app/

## キャプチャ
**"Mobile"でのLighthouseの結果**

Before
![スクリーンショット 2023-01-16 11 32 01](https://user-images.githubusercontent.com/7822534/212586223-c47a5793-9e12-43c2-9d60-e3ad749df24f.png)

After
![スクリーンショット 2023-01-16 11 30 35](https://user-images.githubusercontent.com/7822534/212586243-343c1436-9631-4532-95c1-e79665705418.png)

- プレビューではNetlifyが出力するJSなどが入るので、画像以外にも多少の差異があります。
- スコアは何度かやっているとけっこう変動しますが、画像についてのメッセージが減っているのは確認できます。