### PR TITLE
見出し一覧が空の場合はIndexNavを出力しないように変更

### DIFF
--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -297,9 +297,7 @@ const Article: FC<Props> = ({ data }) => {
             <Sidebar path={slug ?? ''} nestedSidebarItems={nestedSidebarItems} />
           </MainSidebar>
 
-          <MainIndexNav>
-            <IndexNav headings={headingList} />
-          </MainIndexNav>
+          <MainIndexNav>{headingList.length > 0 && <IndexNav headings={headingList} />}</MainIndexNav>
 
           <MainArticle>
             <MainArticleTitle>


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1171

## やったこと
テンプレート（`/src/templates/article.tsx`）内で、そのページの見出しリストが空配列の場合は、`<IndexNav>`コンポーネントを出力しないようにしました。

空の`nav`要素と`ul`要素が出力されなくなります。

## 動作確認
出力されないページ例：
https://deploy-preview-470--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/
https://deploy-preview-470--smarthr-design-system.netlify.app/communication/

## キャプチャ
**Before**
![image](https://user-images.githubusercontent.com/7822534/212635539-e306e7f0-995b-489a-ba25-e16a77eab062.png)

**After**
![image](https://user-images.githubusercontent.com/7822534/212635472-5d29cd1d-974b-4e2d-b4b4-7038ce3c3b60.png)


