### PR TITLE
input要素にname属性値を追加

### DIFF
--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -23,6 +23,7 @@ export const LoginPage: FC = () => {
           width="100%"
           onChange={(e) => setPassword(e.currentTarget.value)}
           value={password}
+          name="password"
         />
 
         <Button

--- a/src/components/search/Search/SearchBox.tsx
+++ b/src/components/search/Search/SearchBox.tsx
@@ -51,6 +51,7 @@ const SearchBox: FC<SearchBoxProvided> = ({ refine }) => {
           autoFocus // eslint-disable-line jsx-a11y/no-autofocus
           aria-labelledby="label-for-search-input"
           aria-describedby="desc-for-search-input"
+          name="query"
         />
       </InputOuter>
 


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1173

eslint-plugin-smarthrの以下のルールに最近アップデートがあったことから、警告が出るようになったのかもしれません。
https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-input-has-name-attribute
（ローカルでも`yarn --frozen-lockfile`してから`yarn lint:ts`すると同様の警告が出ました。）

## やったこと
検索とログインパスワードのinput要素にname属性値を追加しました。

- 検索：`query`
- ログインパスワード：`password`

## やらなかったこと
`autocomplete`属性は追加していないので、`name`属性を追加したことでブラウザが値の補完を行う可能性があります。

## 動作確認
https://deploy-preview-474--smarthr-design-system.netlify.app/search/
https://deploy-preview-474--smarthr-design-system.netlify.app/login/

https://github.com/kufu/smarthr-design-system/actions/runs/3936427868 → Warningは出なくなりました

## キャプチャ
表示上の変化はありません。