### PR TITLE
LayoutグループのコンポーネントのStorybookへのリンクを修正

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -143,7 +143,7 @@ export const ComponentStory: FC<Props> = ({ name }) => {
 
   const getStoryName = (componentName: string, itemName: string) => {
     // 'Dropdown/FilterDropdown' のような階層ありの場合
-    if (componentName.includes('/')) {
+    if (parentCode !== '') {
       return componentName.replace(/^.*\//, '').replace(/([A-Z])/g, (s) => {
         return '-' + s.charAt(0).toLowerCase()
       })


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1174

## やったこと
#478 で、SmartHR UIのグループ分けに対応した際、Layoutグループのコンポーネントの処理がうまくできていなかったため、修正しました。

## 動作確認
/products/components/layout/center/

同じようにSDSで階層になっているDropdownやInputも問題なく表示されています。
/products/components/dropdown/dropdown-button/
/products/components/input/search-input/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/213644574-bbb5786e-6388-4369-809a-39bf83f4c400.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/213644680-aadd755e-54eb-47e8-8469-5e92f36a1463.png" width="350" alt> |
