### PR TITLE
右サイドバーに表示するものがない場合は空divを出力しない

### DIFF
--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -295,7 +295,11 @@ const Article: FC<Props> = ({ data }) => {
             <Sidebar path={slug ?? ''} nestedSidebarItems={nestedSidebarItems} />
           </MainSidebar>
 
-          <MainIndexNav>{headingList.length > 0 && <IndexNav headings={headingList} />}</MainIndexNav>
+          {headingList.length > 0 && (
+            <MainIndexNav>
+              <IndexNav headings={headingList} />
+            </MainIndexNav>
+          )}
 
           <MainArticle>
             <MainArticleTitle>


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1179

## やったこと
右サイドバーに表示するものがない場合でも、`position: sticky; height: 100vh;`の空`div`が書き出されていましたが、出力しないようにしました。

## やらなかったこと
テーブルが中央のグリッドエリアからはみ出している、という状態については何もしていないため、解決していません。

## 動作確認
https://deploy-preview-495--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/

他に、右サイドバーが空のページは以下のようなものがありますが、表示の崩れなどはありません。
https://deploy-preview-495--smarthr-design-system.netlify.app/products/design-patterns-core-features/
https://deploy-preview-495--smarthr-design-system.netlify.app/operational-guideline/page-template/

## キャプチャ

https://user-images.githubusercontent.com/7822534/214201109-c7576077-4074-4bbf-abba-6e3513b02bca.mov
