### PR TITLE
グローバルに`overflow-wrap: break-word`を追加・調整

### DIFF
--- a/src/components/contents/AppWriting/AppWriting.tsx
+++ b/src/components/contents/AppWriting/AppWriting.tsx
@@ -90,5 +90,5 @@ const Wrapper = styled.div``
 
 const StyledText = styled(Text)`
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 `

--- a/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
+++ b/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
@@ -89,5 +89,5 @@ export const BasicConceptTable: FC = () => {
 const Wrapper = styled.div``
 const StyledText = styled(Text)`
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 `

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -221,5 +221,5 @@ const ReasonTd = styled(Td)`
 `
 const StyledText = styled(Text)`
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 `

--- a/src/components/shared/GlobalStyle/GlobalStyle.tsx
+++ b/src/components/shared/GlobalStyle/GlobalStyle.tsx
@@ -15,6 +15,7 @@ export const GlobalStyle = createGlobalStyle`
     font-family: Yu Gothic Medium, 游ゴシック Medium, YuGothic, 游ゴシック体, sans-serif;
     line-height: ${defaultLeading.RELAXED};
     color: ${defaultColor.TEXT_BLACK};
+    overflow-wrap: break-word;
   }
 
   /* stylelint-disable */
@@ -26,7 +27,6 @@ export const GlobalStyle = createGlobalStyle`
   a {
     color: ${defaultColor.TEXT_LINK};
     text-decoration: underline;
-    overflow-wrap: break-word;
   }
 
   table {
@@ -41,6 +41,5 @@ export const GlobalStyle = createGlobalStyle`
   table td {
     box-sizing: border-box;
     padding: 0.5rem 1rem;
-    word-break: break-word;
   }
 `


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1178
→ 改行問題

## やったこと
### グローバルに `overflow-wrap: break-word;`を追加
これまで：`table td`に`word-break: break-word;`、`a`に`overflow-wrap: break-word;`が適用されていましたが、これらは削除し、`body`に`overflow-wrap: break-word;`を適用しました。

※`overflow-wrap: break-word;`は各ブラウザともかなり前から実装しているようで、その点は問題なさそうです→ https://caniuse.com/mdn-css_properties_overflow-wrap_break-word

### `word-wrap`→`overflow-wrap`に変更しました
https://developer.mozilla.org/ja/docs/Web/CSS/overflow-wrap
> このプロパティはもともと、標準外かつ接頭辞のない word-wrap と呼ばれる Microsoft 拡張であり、多くのブラウザーはこの名前で実装していました。 overflow-wrap に改名されたため、 word-wrap は別名になりました。

→基本的には、すべての要素に`break-word`が適用されるので、はみ出す可能性は減っているはずです。ただし、`word-break`と`overflow-wrap`の挙動の違い（単語がおさまらない場合のみ改行する）から、テーブル幅の算出結果などは少し変わっていそうです。

## やらなかったこと
以下はそのままですので、グローバルの`overflow-wrap: break-word;`を上書きする挙動になります。
- コードブロックの`word-break: break-all;`
- カラーパレットの`word-break: break-all;`

## 動作確認
SP表示でもタイトルが改行されるようになりました：
https://deploy-preview-496--smarthr-design-system.netlify.app/products/components/notification-bar/

テーブル幅のレイアウトに多少影響がありそうです：
https://deploy-preview-496--smarthr-design-system.netlify.app/basics/icons/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/214216130-57c16063-2dfc-40e0-8c9e-c98364bfa799.png" alt width="350"> | <img src="https://user-images.githubusercontent.com/7822534/214216103-87cbe8c7-c246-496d-a27c-5cf733497712.png" alt width="350"> |

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/214216423-a44f2637-9659-477c-8ce6-9cbc9ddf88c4.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/214216390-e959f76f-4432-41ec-942e-74aeb54a9d55.png" alt width="350"> |