### PR TITLE
階層のあるsmarthr-uiコンポーネントのリンク先を修正

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -160,12 +160,19 @@ export const ComponentStory: FC<Props> = ({ name }) => {
     return `${kebab}`
   }
 
+  const getChildStoryName = (componentName: string) => {
+    if (parentCode === '') return ''
+    return componentName.replace(/^.*\//, '-').replace(/([A-Z])/g, (s) => {
+      return '-' + s.charAt(0).toLowerCase()
+    })
+  }
+
   if (typeof window === undefined || storiesCode === '') {
     return null
   }
   return (
     <>
-      <SmartHRUIMetaInfo name={name} groupPath={groupPath} />
+      <SmartHRUIMetaInfo name={name} groupPath={`${groupPath}${getChildStoryName(name)}`} />
       <Tab>
         {storyItems.map((item: StoryItem, index: number) => {
           return (


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1174
https://github.com/kufu/smarthr-design-system/pull/478

SmartHR UIのグループ分けに対応した際、#478で`<SmartHRUIMetaInfo>`コンポーネントを移動しましたが、以下の3ページで階層構造が考慮できておらず、グループ追加前とStorybookのリンク先が変わってしまっていました。

https://smarthr.design/products/components/dropdown/dropdown-menu-button/
https://smarthr.design/products/components/dropdown/filter-dropdown/
https://smarthr.design/products/components/input/search-input/

## やったこと
リンク先が1階層深い、個別のストーリーになるように修正しました
`https://smarthr-ui.netlify.app/?path=/story/buttons（ボタン）-dropdown`
↓
`https://smarthr-ui.netlify.app/?path=/story/buttons（ボタン）-dropdown--dropdown-menu-button`

`https://smarthr-ui.netlify.app/?path=/story/buttons（ボタン）-dropdown`
↓
`https://smarthr-ui.netlify.app/?path=/story/buttons（ボタン）-dropdown--filter-dropdown`

`https://smarthr-ui.netlify.app/?path=/story/forms（フォーム）-input`
↓
`https://smarthr-ui.netlify.app/?path=/story/forms（フォーム）-input--search-input`

この3ページ以外は、1つ上の階層（コンポーネントごと）へのリンクなので、変更ありません。
例：
[AccordionPanel](https://smarthr.design/products/components/accordion-panel/)ページ→
`https://smarthr-ui.netlify.app/?path=/story/data-display（データ表示）-accordionpanel` へリンク（リンク先で、先頭の"Accordion style"ストーリーにリダイレクトされます）

また、SDS上では階層になっているLayoutページは、UI側では階層ではないので今回の修正は影響していません。

## 動作確認
https://deploy-preview-499--smarthr-design-system.netlify.app//products/components/dropdown/dropdown-menu-button/
https://deploy-preview-499--smarthr-design-system.netlify.app//products/components/dropdown/filter-dropdown/
https://deploy-preview-499--smarthr-design-system.netlify.app//products/components/input/search-input/


## キャプチャ

