### PR TITLE
GOTCHA!に名刺の画像を追加

### DIFF
--- a/src/data/gotchaItem.json
+++ b/src/data/gotchaItem.json
@@ -168,5 +168,28 @@
         "url": "/basics/colors/#h3-0"
       }
     ]
+  },
+  {
+    "image": "casestudy-11_my2jl6.png",
+    "title": "名刺",
+    "alt": "名刺",
+    "links": [
+      {
+        "text": "ロゴ",
+        "url": "/basics/logos/"
+      },
+      {
+        "text": "色｜SmartHR Blue",
+        "url": "/basics/colors/#h3-0"
+      },
+      {
+        "text": "色｜印刷ガイドライン",
+        "url": "/basics/colors/printguideline/"
+      },
+      {
+        "text": "タイポグラフィ｜游ゴシック",
+        "url": "/basics/typography/"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## 課題・背景
GOTCHA!に名刺の画像も追加する
- シン名刺の導線をトップに配置し、回遊できる状態をつくる
- ユースケースの提示

## やったこと
- GOTCHA!に名刺の画像を追加

## やらなかったこと
特になし

## 動作確認
https://deploy-preview-501--smarthr-design-system.netlify.app/

## キャプチャ
<img width="1512" alt="スクリーンショット 2023-01-26 18 08 58" src="https://user-images.githubusercontent.com/101125529/214797806-46134aff-aa89-42b6-b2ec-4347ce5ecae4.png">


## issue
https://github.com/kufu/smarthr-design-system-issues/issues/1158