### PR TITLE
テーブル幅が100%超える場合、レイアウトを崩さず横スクロールにする

### DIFF
--- a/content/articles/accessibility/policy.mdx
+++ b/content/articles/accessibility/policy.mdx
@@ -6,6 +6,8 @@ order: 1
 
 import { Table, Text, Td, Th } from 'smarthr-ui'
 
+import { TableWrapper } from '@Components/contents/shared/TableWrapper'
+
 ## 社会の非合理をつくりださない
 
 SmartHRは「[社会の非合理を、ハックする。](https://smarthr.co.jp/about/)」というミッションを掲げ、働くすべての人を後押しするプラットフォームをつくっています。
@@ -63,43 +65,45 @@ SmartHRは「[社会の非合理を、ハックする。](https://smarthr.co.jp/
 
 ### SmartHR UIのスケジュール
 
-<Table>
-  <thead>
-    <tr>
-      <Th>
-        時期
-      </Th>
-      <Th>
-        目標
-      </Th>
-      <Th>
-        結果
-      </Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td> <time datatime="2021-06" style="white-space: nowrap">2021年6月</time> </Td>
-      <Td> レベルA一部準拠 <div><small>開発中のコンポーネント、または試験開始時点で完成していなかったコンポーネントをのぞく</small></div> </Td>
-      <Td> レベルA一部準拠 </Td>
-    </tr>
-    <tr>
-      <Td> <time datatime="2021-12" style="white-space: nowrap">2021年12月</time> </Td>
-      <Td> レベルA準拠 </Td>
-      <Td> レベルA一部準拠 </Td>
-    </tr>
-    <tr>
-      <Td> <time datatime="2022-06" style="white-space: nowrap">2022年6月</time> </Td>
-      <Td> JIS X 8341-3:2016 レベルAと追加する達成基準に準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
-      <Td></Td>
-    </tr>
-    <tr>
-      <Td> <time datatime="2022-12" style="white-space: nowrap">2022年12月</time> </Td>
-      <Td> JIS X 8341-3:2016 レベルAAに準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
-      <Td></Td>
-    </tr>
-  </tbody>
-</Table>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>
+          時期
+        </Th>
+        <Th>
+          目標
+        </Th>
+        <Th>
+          結果
+        </Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td> <time datatime="2021-06" style="white-space: nowrap">2021年6月</time> </Td>
+        <Td> レベルA一部準拠 <div><small>開発中のコンポーネント、または試験開始時点で完成していなかったコンポーネントをのぞく</small></div> </Td>
+        <Td> レベルA一部準拠 </Td>
+      </tr>
+      <tr>
+        <Td> <time datatime="2021-12" style="white-space: nowrap">2021年12月</time> </Td>
+        <Td> レベルA準拠 </Td>
+        <Td> レベルA一部準拠 </Td>
+      </tr>
+      <tr>
+        <Td> <time datatime="2022-06" style="white-space: nowrap">2022年6月</time> </Td>
+        <Td> JIS X 8341-3:2016 レベルAと追加する達成基準に準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
+        <Td></Td>
+      </tr>
+      <tr>
+        <Td> <time datatime="2022-12" style="white-space: nowrap">2022年12月</time> </Td>
+        <Td> JIS X 8341-3:2016 レベルAAに準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
+        <Td></Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 ### SmartHR 製品の目標とスケジュール
 
@@ -109,44 +113,46 @@ SmartHRは「[社会の非合理を、ハックする。](https://smarthr.co.jp/
 
 ## 試験結果
 
-<Table>
-  <thead>
-    <tr>
-      <Th>試験年月</Th>
-      <Th>試験対象</Th>
-      <Th>達成した等級</Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td>
-        <a href="../test/202105/">
-          <time datatime="2021-05" style={{ whiteSpace: "no-wrap" }}>2021年5月</time>
-        </a>
-      </Td>
-      <Td>
-        SmartHR UIのコンポーネント
-        <small>（開発中のコンポーネントを除く）</small>
-      </Td>
-      <Td>
-        レベルA一部準拠
-      </Td>
-    </tr>
-    <tr>
-      <Td>
-        <a href="../test/202112/">
-          <time datatime="2021-12" style={{ whiteSpace: "no-wrap" }}>2021年12月</time>
-        </a>
-      </Td>
-      <Td>
-        SmartHR UIのコンポーネント
-      </Td>
-      <Td>
-        レベルA一部準拠
-      </Td>
-    </tr>
-  </tbody>
-</Table>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>試験年月</Th>
+        <Th>試験対象</Th>
+        <Th>達成した等級</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td>
+          <a href="../test/202105/">
+            <time datatime="2021-05" style={{ whiteSpace: "no-wrap" }}>2021年5月</time>
+          </a>
+        </Td>
+        <Td>
+          SmartHR UIのコンポーネント
+          <small>（開発中のコンポーネントを除く）</small>
+        </Td>
+        <Td>
+          レベルA一部準拠
+        </Td>
+      </tr>
+      <tr>
+        <Td>
+          <a href="../test/202112/">
+            <time datatime="2021-12" style={{ whiteSpace: "no-wrap" }}>2021年12月</time>
+          </a>
+        </Td>
+        <Td>
+          SmartHR UIのコンポーネント
+        </Td>
+        <Td>
+          レベルA一部準拠
+        </Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 ## 問い合わせ先
 

--- a/content/articles/accessibility/test/202105/index.mdx
+++ b/content/articles/accessibility/test/202105/index.mdx
@@ -6,6 +6,8 @@ order: 1
 
 import { Table, Td, Th, DefinitionList } from 'smarthr-ui'
 
+import { TableWrapper } from '@Components/contents/shared/TableWrapper'
+
 <!-- textlint-disable -->
 
 ## 試験の結果および実施方法
@@ -58,16 +60,17 @@ import { Table, Td, Th, DefinitionList } from 'smarthr-ui'
 
 達成基準のリンクは<abbr title="Web Contents Accessibility Guidelines">WCAG</abbr> 2.0解説書へのリンクです。
 
-<Table>
-  <thead>
-    <tr>
-      <Th>達成基準</Th>
-      <Th>等級</Th>
-      <Th>適用</Th>
-      <Th>結果</Th>
-    </tr>
-  </thead>
-  <tbody>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>達成基準</Th>
+        <Th>等級</Th>
+        <Th>適用</Th>
+        <Th>結果</Th>
+      </tr>
+    </thead>
+    <tbody>
 
 <tr>
     <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/text-equiv-all.html">1.1.1 非テキストコンテンツ</a></Td>
@@ -243,8 +246,9 @@ import { Table, Td, Th, DefinitionList } from 'smarthr-ui'
     <Td>○</Td>
     <Td>×</Td>
 </tr>
-  </tbody>
-</Table>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 - 「2.4.2 ページタイトル」および「3.1.1 ページの言語」は、ページが検証対象ではないため該当箇所なしとした。
 - 「3.2.1 フォーカス時」および「3.2.2 入力時」は、実際の操作が与えられない状態での検証のため該当箇所なしとした。

--- a/content/articles/accessibility/test/202112/index.mdx
+++ b/content/articles/accessibility/test/202112/index.mdx
@@ -6,6 +6,8 @@ order: 1
 
 import { Table, Td, Th, DefinitionList } from 'smarthr-ui'
 
+import { TableWrapper } from '@Components/contents/shared/TableWrapper'
+
 ## 試験概要
 
 [ウェブアクセシビリティ試験結果 - 2021年5月](../202105/)にて満たせていなかった達成基準の改善と、新規に開発されたコンポーネントについての試験です。
@@ -65,16 +67,17 @@ import { Table, Td, Th, DefinitionList } from 'smarthr-ui'
 
 達成基準のリンクは<abbr title="Web Contents Accessibility Guidelines">WCAG</abbr> 2.0解説書へのリンクです。
 
-<Table>
-  <thead>
-    <tr>
-      <Th>達成基準</Th>
-      <Th>等級</Th>
-      <Th>適用</Th>
-      <Th>結果</Th>
-    </tr>
-  </thead>
-  <tbody>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>達成基準</Th>
+        <Th>等級</Th>
+        <Th>適用</Th>
+        <Th>結果</Th>
+      </tr>
+    </thead>
+    <tbody>
 
 <tr>
     <Td><a href="https://waic.jp/docs/UNDERSTANDING-WCAG20/text-equiv-all.html">1.1.1 非テキストコンテンツ</a></Td>
@@ -250,8 +253,9 @@ import { Table, Td, Th, DefinitionList } from 'smarthr-ui'
     <Td>○</Td>
     <Td>×</Td>
 </tr>
-  </tbody>
-</Table>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 - 「2.4.2 ページタイトル」および「3.1.1 ページの言語」は、ページが検証対象ではないため該当箇所なしとした。
 - 「3.2.1 フォーカス時」および「3.2.2 入力時」は、実際の操作が与えられない状態での検証のため該当箇所なしとした。

--- a/content/articles/operational-guideline/page-template/style-template.mdx
+++ b/content/articles/operational-guideline/page-template/style-template.mdx
@@ -8,6 +8,7 @@ import { Button, Cluster, FaPlusCircleIcon, LineUp, Stack, Table, Td, Th, Text }
 import { ComponentPreview } from '@Components/ComponentPreview'
 import { DoAndDont } from '@Components/DoAndDont'
 import { StaticImage } from '@Components/StaticImage'
+import { TableWrapper } from '@Components/contents/shared/TableWrapper'
 
 ## h2 相当のタイトル
 
@@ -77,31 +78,33 @@ import { StaticImage } from '@Components/StaticImage'
 
 ### SmartHR UI テーブル
 
-<Table>
-  <thead>
-    <tr>
-      <Th>thead</Th>
-      <Th>thead</Th>
-      <Th>thead</Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td>cell</Td>
-      <Td>cell</Td>
-      <Td>
-        <Button variant="primary">Button</Button>
-      </Td>
-    </tr>
-    <tr>
-      <Td>cell</Td>
-      <Td>cell</Td>
-      <Td>
-        <Button variant="primary">Button</Button>
-      </Td>
-    </tr>
-  </tbody>
-</Table>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>thead</Th>
+        <Th>thead</Th>
+        <Th>thead</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td>cell</Td>
+        <Td>cell</Td>
+        <Td>
+          <Button variant="primary">Button</Button>
+        </Td>
+      </tr>
+      <tr>
+        <Td>cell</Td>
+        <Td>cell</Td>
+        <Td>
+          <Button variant="primary">Button</Button>
+        </Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 ## レイアウト
 SmartHR UI Layoutコンポーネントを使用できます。

--- a/content/articles/products/components/heading.mdx
+++ b/content/articles/products/components/heading.mdx
@@ -7,6 +7,7 @@ import { Heading, Stack, Table, Td, Th } from 'smarthr-ui'
 import { CodeBlock } from '@Components/article/CodeBlock'
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
+import { TableWrapper } from '@Components/contents/shared/TableWrapper'
 
 Headingコンポーネントは、直後に続くコンテンツの見出しに使います。
 
@@ -38,118 +39,128 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
 
 画面のタイトルとして、画面ごとに1度しか使えません。
 
-<Table>
-  <thead>
-    <tr>
-      <Th>タイプ</Th>
-      <Th>フォントサイズ</Th>
-      <Th>ウェイト</Th>
-      <Th>色</Th>
-      <Th>サンプル</Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td>screenTitle</Td>
-      <Td><a href="/products/design-tokens/typography/"><code>XL</code></a></Td>
-      <Td>normal</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_BLACK</code></a></Td>
-      <Td><Heading type="screenTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
-    </tr>
-  </tbody>
-</Table>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>タイプ</Th>
+        <Th>フォントサイズ</Th>
+        <Th>ウェイト</Th>
+        <Th>色</Th>
+        <Th>サンプル</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td>screenTitle</Td>
+        <Td><a href="/products/design-tokens/typography/"><code>XL</code></a></Td>
+        <Td>normal</Td>
+        <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_BLACK</code></a></Td>
+        <Td><Heading type="screenTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 ### セクションタイトル
 
-<Table>
-  <thead>
-    <tr>
-      <Th>タイプ</Th>
-      <Th>フォントサイズ</Th>
-      <Th>ウェイト</Th>
-      <Th>色</Th>
-      <Th>サンプル</Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td>sectionTitle</Td>
-      <Td><a href="/products/design-tokens/typography/"><code>L</code></a></Td>
-      <Td>normal</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_BLACK</code></a></Td>
-      <Td><Heading type="sectionTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
-    </tr>
-  </tbody>
-</Table>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>タイプ</Th>
+        <Th>フォントサイズ</Th>
+        <Th>ウェイト</Th>
+        <Th>色</Th>
+        <Th>サンプル</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td>sectionTitle</Td>
+        <Td><a href="/products/design-tokens/typography/"><code>L</code></a></Td>
+        <Td>normal</Td>
+        <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_BLACK</code></a></Td>
+        <Td><Heading type="sectionTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 ### ブロックタイトル
 
-<Table>
-  <thead>
-    <tr>
-      <Th>タイプ</Th>
-      <Th>フォントサイズ</Th>
-      <Th>ウェイト</Th>
-      <Th>色</Th>
-      <Th>サンプル</Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td>blockTitle</Td>
-      <Td><a href="/products/design-tokens/typography/"><code>M</code></a></Td>
-      <Td>bold</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_BLACK</code></a></Td>
-      <Td><Heading type="blockTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
-    </tr>
-  </tbody>
-</Table>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>タイプ</Th>
+        <Th>フォントサイズ</Th>
+        <Th>ウェイト</Th>
+        <Th>色</Th>
+        <Th>サンプル</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td>blockTitle</Td>
+        <Td><a href="/products/design-tokens/typography/"><code>M</code></a></Td>
+        <Td>bold</Td>
+        <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_BLACK</code></a></Td>
+        <Td><Heading type="blockTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 ### サブ・ブロックタイトル
 
-<Table>
-  <thead>
-    <tr>
-      <Th>タイプ</Th>
-      <Th>フォントサイズ</Th>
-      <Th>ウェイト</Th>
-      <Th>色</Th>
-      <Th>サンプル</Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td>subBlockTitle</Td>
-      <Td><a href="/products/design-tokens/typography/"><code>M</code></a></Td>
-      <Td>bold</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_GREY</code></a></Td>
-      <Td><Heading type="subBlockTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
-    </tr>
-  </tbody>
-</Table>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>タイプ</Th>
+        <Th>フォントサイズ</Th>
+        <Th>ウェイト</Th>
+        <Th>色</Th>
+        <Th>サンプル</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td>subBlockTitle</Td>
+        <Td><a href="/products/design-tokens/typography/"><code>M</code></a></Td>
+        <Td>bold</Td>
+        <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_GREY</code></a></Td>
+        <Td><Heading type="subBlockTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 ### サブ・サブ・ブロックタイトル
 
-<Table>
-  <thead>
-    <tr>
-      <Th>タイプ</Th>
-      <Th>フォントサイズ</Th>
-      <Th>ウェイト</Th>
-      <Th>色</Th>
-      <Th>サンプル</Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td>subSubBlockTitle</Td>
-      <Td><a href="/products/design-tokens/typography/"><code>S</code></a></Td>
-      <Td>bold</Td>
-      <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_GREY</code></a></Td>
-      <Td><Heading type="subSubBlockTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
-    </tr>
-  </tbody>
-</Table>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>タイプ</Th>
+        <Th>フォントサイズ</Th>
+        <Th>ウェイト</Th>
+        <Th>色</Th>
+        <Th>サンプル</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td>subSubBlockTitle</Td>
+        <Td><a href="/products/design-tokens/typography/"><code>S</code></a></Td>
+        <Td>bold</Td>
+        <Td><a href="/products/design-tokens/color/#h3-2"><code>TEXT_GREY</code></a></Td>
+        <Td><Heading type="subSubBlockTitle" tag="span">well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Heading></Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 
 ## レイアウト

--- a/content/articles/products/design-tokens/typography.mdx
+++ b/content/articles/products/design-tokens/typography.mdx
@@ -7,6 +7,7 @@ order: 2
 import { createTheme } from 'smarthr-ui'
 import { Table, Td, Th } from 'smarthr-ui'
 
+import { TableWrapper } from '@Components/contents/shared/TableWrapper'
 
 export const Sampletext = ({size = 'M', children}) => {
   const theme = createTheme()
@@ -77,33 +78,34 @@ font-family: system-ui, sans-serif;
 
 サイズ小とサイズ極小の積極的な使用は避け、レイアウトの都合上、どうしようもない場合に使います。
 
-<Table>
-  <thead>
-    <tr>
-      <Th>種類</Th>
-      <Th>フォントサイズ</Th>
-      <Th>サンプル</Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td>標準</Td>
-      <Td><code>M</code></Td>
-      <Td><Sampletext size={'M'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
-    </tr>
-    <tr>
-      <Td>サイズ小</Td>
-      <Td><code>S</code></Td>
-      <Td><Sampletext size={'S'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
-    </tr>
-    <tr>
-      <Td>サイズ極小</Td>
-      <Td><code>XS</code></Td>
-      <Td><Sampletext size={'XS'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
-    </tr>
-  </tbody>
-</Table>
-
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>種類</Th>
+        <Th>フォントサイズ</Th>
+        <Th>サンプル</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td>標準</Td>
+        <Td><code>M</code></Td>
+        <Td><Sampletext size={'M'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
+      </tr>
+      <tr>
+        <Td>サイズ小</Td>
+        <Td><code>S</code></Td>
+        <Td><Sampletext size={'S'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
+      </tr>
+      <tr>
+        <Td>サイズ極小</Td>
+        <Td><code>XS</code></Td>
+        <Td><Sampletext size={'XS'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 ### ラベルテキスト
 段落ではないボタンなどのラベルテキストに使います。  
@@ -111,27 +113,29 @@ font-family: system-ui, sans-serif;
 
 サイズ小の積極的な使用は避け、レイアウトの都合上、どうしようもない場合に使います。
 
-<Table>
-  <thead>
-    <tr>
-      <Th>種類</Th>
-      <Th>フォントサイズ</Th>
-      <Th>サンプル</Th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <Td>標準</Td>
-      <Td><code>M</code></Td>
-      <Td><Sampletext size={'M'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
-    </tr>
-    <tr>
-      <Td>サイズ小</Td>
-      <Td><code>S</code></Td>
-      <Td><Sampletext size={'S'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
-    </tr>
-  </tbody>
-</Table>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>種類</Th>
+        <Th>フォントサイズ</Th>
+        <Th>サンプル</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td>標準</Td>
+        <Td><code>M</code></Td>
+        <Td><Sampletext size={'M'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
+      </tr>
+      <tr>
+        <Td>サイズ小</Td>
+        <Td><code>S</code></Td>
+        <Td><Sampletext size={'S'}>well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。</Sampletext></Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 ### 表
 表中のテキストは、基本的に段落テキストと同じスタイルで揃えます。表で固有のスタイルは以下のとおりです。

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -5,6 +5,7 @@ import { Table, Td, Text, Th } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import { FragmentTitle } from '../../article/FragmentTitle/FragmentTitle'
+import { TableWrapper } from '../shared/TableWrapper'
 import { TextUrlToLink } from '../shared/TextUrlToLink'
 
 const query = graphql`
@@ -191,7 +192,7 @@ export const IdiomaticUsageTable: FC<Props> = ({ type }) => {
   )
 }
 
-const Wrapper = styled.div`
+const Wrapper = styled(TableWrapper)`
   & th,
   td {
     vertical-align: baseline;

--- a/src/components/contents/shared/TableWrapper.tsx
+++ b/src/components/contents/shared/TableWrapper.tsx
@@ -2,11 +2,12 @@ import React, { FC } from 'react'
 import styled from 'styled-components'
 
 type Props = {
+  mdTable?: boolean
   children: React.ReactNode
 }
 
-export const TableWrapper: FC<Props> = ({ children }) => {
-  return <Wrapper>{children}</Wrapper>
+export const TableWrapper: FC<Props> = ({ mdTable = false, children }) => {
+  return <Wrapper>{mdTable ? <table>{children}</table> : children}</Wrapper>
 }
 
 const Wrapper = styled.div`

--- a/src/components/contents/shared/TableWrapper.tsx
+++ b/src/components/contents/shared/TableWrapper.tsx
@@ -1,0 +1,14 @@
+import React, { FC } from 'react'
+import styled from 'styled-components'
+
+type Props = {
+  children: React.ReactNode
+}
+
+export const TableWrapper: FC<Props> = ({ children }) => {
+  return <Wrapper>{children}</Wrapper>
+}
+
+const Wrapper = styled.div`
+  overflow-x: auto;
+`

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -3,6 +3,7 @@ import { CodeBlock } from '@Components/article/CodeBlock'
 import { FragmentTitle } from '@Components/article/FragmentTitle/FragmentTitle'
 import { IndexNav } from '@Components/article/IndexNav/IndexNav'
 import { Sidebar } from '@Components/article/Sidebar/Sidebar'
+import { TableWrapper } from '@Components/contents/shared/TableWrapper'
 import { Footer } from '@Components/shared/Footer/Footer'
 import { GlobalStyle } from '@Components/shared/GlobalStyle/GlobalStyle'
 import { Header } from '@Components/shared/Header/Header'
@@ -51,6 +52,7 @@ const components: MDXProviderComponents = {
       {children}
     </FragmentTitle>
   ),
+  table: ({ children }) => <TableWrapper mdTable={true}>{children}</TableWrapper>,
 }
 
 const shortcodes = {


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1183

## やったこと

テーブルの表示まわりを確認したところ、`<ComponentPropsTable>`コンポーネントでは[親の`div`に`overflow-x: auto;`が適用されており](https://github.com/kufu/smarthr-design-system/blob/454b435354fa3874c3670ef00319846ea5b65800/src/components/ComponentPropsTable/ComponentPropsTable.tsx#L93-L94)、テーブル幅が100%超える場合にはスクロールバーが表示されていましたので、それ以外のテーブルも同じようにしました。

### smarthr-uiのTableコンポーネント
`overflow-x: auto;`を適用した`TableWrapper`コンポーネントを用意し、
```
<TableWrapper>
  <Table>...</Table>
</TableWrapper>
```
のようにラップしました。

### MDX内のtable記法
[Gatsbyのカスタムコンポーネント](https://www.gatsbyjs.com/docs/how-to/routing/customizing-components/)を利用して、`table`要素（GFMのtable記法）があれば、`TableWrapper`コンポーネントでラップするようにしました。

```article.tsx
table: ({ children }) => <TableWrapper mdTable={true}>{children}</TableWrapper>,
```
↑このとき、`children`には`table`要素自体は含まれないので、`<table>{children}</table>`を返却する必要があるのですが、ここで`<table>`を含めると再帰で無限ループしてしまうようなので、`<TableWrapper>`コンポーネント内で`<table>`を追加しています（その判別のために`mdTable={true}`を渡しています）。

## やらなかったこと
ページによっては、スクロールできることがわかりにくかったり、スクロールできるにもかかわらず非常に幅の狭いセルになっていたりするので、適宜`td`に`min-width`など設定しても良いのかもしれません。例えば`<ComponentPropsTable>`では`min-width: 11em;`などの指定があります。

## 動作確認
※Netlifyにログインした状態でプレビューを確認すると、Netlifyが追加するフッターがあるためにレイアウトがずれてそうです。シークレットウィンドウでの確認が良さそうです。

SP表示時にはみ出していたページ
https://deploy-preview-508--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/
https://deploy-preview-508--smarthr-design-system.netlify.app/products/components/dialog/
https://deploy-preview-508--smarthr-design-system.netlify.app/products/components/heading/
https://deploy-preview-508--smarthr-design-system.netlify.app/products/design-tokens/typography/
https://deploy-preview-508--smarthr-design-system.netlify.app/downloads/

はみ出してはいないが、テーブルが使われているページ
（こちらにも`TableWrapper`を適用してあります。）
https://deploy-preview-508--smarthr-design-system.netlify.app/accessibility/test/202105/
https://deploy-preview-508--smarthr-design-system.netlify.app/accessibility/test/202112/
https://deploy-preview-508--smarthr-design-system.netlify.app/operational-guideline/page-template/style-template/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/215389431-50fb1fa3-fc69-43b3-b6e8-bf5c235dc947.png" alt width="350"> | <img src="https://user-images.githubusercontent.com/7822534/215389206-b1fe01fa-5cac-4885-91b1-7a8ab8661dd5.png" alt width="350"> |