### PR TITLE
ESLintの`a11y-anchor-has-href-attribute`ルールをoffにする

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,4 +9,8 @@ module.exports = {
       },
     },
   ],
+  rules: {
+    // GatsbyのLinkコンポーネントで警告が出てしまうためoffにする
+    'smarthr/a11y-anchor-has-href-attribute': 0,
+  },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,12 @@
 module.exports = {
   extends: ['smarthr'],
-  overrides: [{
-    files: '*.mdx',
-    extends: ['smarthr', 'plugin:mdx/recommended'],
-    rules: {
-      'react/jsx-filename-extension': [1, {
-        extensions: ['.jsx', '.tsx', '.mdx']
-      }]
-    }
-  }]
-};
+  overrides: [
+    {
+      files: '*.mdx',
+      extends: ['smarthr', 'plugin:mdx/recommended'],
+      rules: {
+        'react/jsx-filename-extension': [1, { extensions: ['.jsx', '.tsx', '.mdx'] }],
+      },
+    },
+  ],
+}


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1186

## やったこと
- `.eslintrc.js`に、ルールを追加して`a11y-anchor-has-href-attribute`ルールをoffにしました。
- `.eslintrc.js`でprettierが警告を出していた部分も修正しました。

## 動作確認
ローカルにて、`yarn lint:ts`で出ていた警告がすべて消えたのを確認しました。

## キャプチャ
Linterの警告解消のみなので、ビルド結果への影響はありません。