### PR TITLE
Storybookのコード取得・iframeのレンダリングをクライアント→サーバーサイドへ変更

### DIFF
--- a/content/articles/products/components/accordion-panel.mdx
+++ b/content/articles/products/components/accordion-panel.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'AccordionPanel'
 description: ''
+storyName: 'AccordionPanel'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/app-navi.mdx
+++ b/content/articles/products/components/app-navi.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'AppNavi'
 description: ''
+storyName: 'AppNavi'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/background-jobs-panel.mdx
+++ b/content/articles/products/components/background-jobs-panel.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'BackgroundJobsPanel'
 description: ''
+storyName: 'BackgroundJobsPanel'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/base.mdx
+++ b/content/articles/products/components/base.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Base'
 description: ' '
+storyName: 'Base'
 ---
 
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/bottom-fixed-area.mdx
+++ b/content/articles/products/components/bottom-fixed-area.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'BottomFixedArea'
 description: ''
+storyName: 'BottomFixedArea'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/button.mdx
+++ b/content/articles/products/components/button.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Button'
 description: ' '
+storyName: 'Button'
 ---
 
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/calendar.mdx
+++ b/content/articles/products/components/calendar.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Calendar'
 description: ''
+storyName: 'Calendar'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/check-box.mdx
+++ b/content/articles/products/components/check-box.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'CheckBox'
 description: ''
+storyName: 'CheckBox'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/combo-box.mdx
+++ b/content/articles/products/components/combo-box.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'ComboBox'
 description: ''
+storyName: 'ComboBox'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/compact-information-panel.mdx
+++ b/content/articles/products/components/compact-information-panel.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'CompactInformationPanel'
 description: ''
+storyName: 'CompactInformationPanel'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/date-picker.mdx
+++ b/content/articles/products/components/date-picker.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'DatePicker'
 description: ''
+storyName: 'DatePicker'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/definition-list.mdx
+++ b/content/articles/products/components/definition-list.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'DefinitionList'
 description: ''
+storyName: 'DefinitionList'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/dialog.mdx
+++ b/content/articles/products/components/dialog.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Dialog'
 description: ' '
+storyName: 'Dialog'
 ---
 
 import { useEffect, useState } from 'react'

--- a/content/articles/products/components/drop-zone.mdx
+++ b/content/articles/products/components/drop-zone.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'DropZone'
 description: ''
+storyName: 'DropZone'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/dropdown/dropdown-menu-button.mdx
+++ b/content/articles/products/components/dropdown/dropdown-menu-button.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'DropdownMenuButton'
 description: ''
+storyName: 'Dropdown/DropdownMenuButton'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/dropdown/filter-dropdown.mdx
+++ b/content/articles/products/components/dropdown/filter-dropdown.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'FilterDropdown'
 description: ''
+storyName: 'Dropdown/FilterDropdown'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/dropdown/index.mdx
+++ b/content/articles/products/components/dropdown/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Dropdown'
 description: ''
+storyName: 'Dropdown'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/field-set.mdx
+++ b/content/articles/products/components/field-set.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'FieldSet（非推奨）'
 description: ''
+storyName: 'FieldSet'
 ---
 import { CompactInformationPanel } from 'smarthr-ui'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/flash-message.mdx
+++ b/content/articles/products/components/flash-message.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'FlashMessage（非推奨）'
 description: ' '
+storyName: 'FlashMessage'
 ---
 
 import { useState } from 'react'

--- a/content/articles/products/components/float-area.mdx
+++ b/content/articles/products/components/float-area.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'FloatArea'
 description: ''
+storyName: 'FloatArea'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/form-group.mdx
+++ b/content/articles/products/components/form-group.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'FormGroup'
 description: ''
+storyName: 'FormGroup'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/header.mdx
+++ b/content/articles/products/components/header.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Header'
 description: ''
+storyName: 'Header'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/heading.mdx
+++ b/content/articles/products/components/heading.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Heading'
 description: ''
+storyName: 'Heading'
 ---
 
 import { Heading, Stack, Table, Td, Th } from 'smarthr-ui'

--- a/content/articles/products/components/headline-area.mdx
+++ b/content/articles/products/components/headline-area.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'HeadlineArea'
 description: ''
+storyName: 'HeadlineArea'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/icon.mdx
+++ b/content/articles/products/components/icon.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Icon'
 description: ' '
+storyName: 'Icon'
 ---
 
 import {

--- a/content/articles/products/components/information-panel.mdx
+++ b/content/articles/products/components/information-panel.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'InformationPanel'
 description: ''
+storyName: 'InformationPanel'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/input-file.mdx
+++ b/content/articles/products/components/input-file.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'InputFile'
 description: ''
+storyName: 'InputFile'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/input/index.mdx
+++ b/content/articles/products/components/input/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Input'
 description: ''
+storyName: 'Input'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/input/search-input.mdx
+++ b/content/articles/products/components/input/search-input.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'SearchInput'
 description: ''
+storyName: 'Input/SearchInput'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/layout/center.mdx
+++ b/content/articles/products/components/layout/center.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Center'
 description: ''
+storyName: 'Layout/Center'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/layout/cluster.mdx
+++ b/content/articles/products/components/layout/cluster.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Cluster'
 description: ''
+storyName: 'Layout/Cluster'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/layout/line-up.mdx
+++ b/content/articles/products/components/layout/line-up.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'LineUp（非推奨）'
 description: ''
+storyName: 'Layout/LineUp'
 ---
 import { CompactInformationPanel } from 'smarthr-ui'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/layout/reel.mdx
+++ b/content/articles/products/components/layout/reel.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Reel'
 description: ''
+storyName: 'Layout/Reel'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/layout/sidebar.mdx
+++ b/content/articles/products/components/layout/sidebar.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Sidebar'
 description: ''
+storyName: 'Layout/Sidebar'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/layout/stack.mdx
+++ b/content/articles/products/components/layout/stack.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Stack'
 description: ''
+storyName: 'Layout/Stack'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/line-clamp.mdx
+++ b/content/articles/products/components/line-clamp.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'LineClamp'
 description: ''
+storyName: 'LineClamp'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/loader.mdx
+++ b/content/articles/products/components/loader.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Loader'
 description: ''
+storyName: 'Loader'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/message-screen.mdx
+++ b/content/articles/products/components/message-screen.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'MessageScreen'
 description: ''
+storyName: 'MessageScreen'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/notification-bar.mdx
+++ b/content/articles/products/components/notification-bar.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'NotificationBar'
 description: 'NotificationBarは、ユーザーへ伝えたいフィードバックやメッセージを伝えるために使います。'
-smarthr-ui: 'NotificationBar'
+storyName: 'NotificationBar'
 ---
 import { useEffect, useState } from 'react'
 import { ComponentPreview } from '@Components/ComponentPreview'

--- a/content/articles/products/components/page-counter.mdx
+++ b/content/articles/products/components/page-counter.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'PageCounter'
 description: ''
+storyName: 'PageCounter'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/pagination.mdx
+++ b/content/articles/products/components/pagination.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Pagination'
 description: ''
+storyName: 'Pagination'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/radio-button.mdx
+++ b/content/articles/products/components/radio-button.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'RadioButton'
 description: ''
+storyName: 'RadioButton'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/right-fixed-note.mdx
+++ b/content/articles/products/components/right-fixed-note.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'RightFixedNote'
 description: ''
+storyName: 'RightFixedNote'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/segmented-control.mdx
+++ b/content/articles/products/components/segmented-control.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'SegmentedControl'
 description: ''
+storyName: 'SegmentedControl'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/select.mdx
+++ b/content/articles/products/components/select.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Select'
 description: ''
+storyName: 'Select'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/side-nav.mdx
+++ b/content/articles/products/components/side-nav.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'SideNav'
 description: ''
+storyName: 'SideNav'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/smarthr-logo.mdx
+++ b/content/articles/products/components/smarthr-logo.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'SmartHRLogo'
 description: ''
+storyName: 'SmartHRLogo'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/status-label.mdx
+++ b/content/articles/products/components/status-label.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'StatusLabel'
 description: ''
+storyName: 'StatusLabel'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/tab-bar.mdx
+++ b/content/articles/products/components/tab-bar.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'TabBar'
 description: ''
+storyName: 'TabBar'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/table.mdx
+++ b/content/articles/products/components/table.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Table'
 description: ''
+storyName: 'Table'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/text-link.mdx
+++ b/content/articles/products/components/text-link.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'TextLink'
 description: ''
+storyName: 'TextLink'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/text.mdx
+++ b/content/articles/products/components/text.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Text'
 description: ''
+storyName: 'Text'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/textarea.mdx
+++ b/content/articles/products/components/textarea.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Textarea'
 description: ''
+storyName: 'Textarea'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Tooltip'
 description: ''
+storyName: 'Tooltip'
 ---
 import {
   FaArrowAltCircleDownIcon,

--- a/src/__generated__/gatsby-types.d.ts
+++ b/src/__generated__/gatsby-types.d.ts
@@ -860,12 +860,16 @@ type FileFieldsEnum =
   | 'childMdx.fields.category'
   | 'childMdx.fields.hierarchy'
   | 'childMdx.fields.slug'
+  | 'childMdx.fields.storyData.code'
+  | 'childMdx.fields.storyData.groupPath'
+  | 'childMdx.fields.storyData.storyItems'
   | 'childMdx.fileAbsolutePath'
   | 'childMdx.frontmatter.author'
   | 'childMdx.frontmatter.date'
   | 'childMdx.frontmatter.description'
   | 'childMdx.frontmatter.order'
   | 'childMdx.frontmatter.smarthr_ui'
+  | 'childMdx.frontmatter.storyName'
   | 'childMdx.frontmatter.title'
   | 'childMdx.headings'
   | 'childMdx.headings.depth'
@@ -927,12 +931,16 @@ type FileFieldsEnum =
   | 'childrenMdx.fields.category'
   | 'childrenMdx.fields.hierarchy'
   | 'childrenMdx.fields.slug'
+  | 'childrenMdx.fields.storyData.code'
+  | 'childrenMdx.fields.storyData.groupPath'
+  | 'childrenMdx.fields.storyData.storyItems'
   | 'childrenMdx.fileAbsolutePath'
   | 'childrenMdx.frontmatter.author'
   | 'childrenMdx.frontmatter.date'
   | 'childrenMdx.frontmatter.description'
   | 'childrenMdx.frontmatter.order'
   | 'childrenMdx.frontmatter.smarthr_ui'
+  | 'childrenMdx.frontmatter.storyName'
   | 'childrenMdx.frontmatter.title'
   | 'childrenMdx.headings'
   | 'childrenMdx.headings.depth'
@@ -1324,6 +1332,7 @@ type MdxFields = {
   readonly category: Maybe<Scalars['String']>;
   readonly hierarchy: Maybe<Scalars['String']>;
   readonly slug: Maybe<Scalars['String']>;
+  readonly storyData: Maybe<MdxFieldsStoryData>;
 };
 
 type MdxFieldsEnum =
@@ -1374,12 +1383,19 @@ type MdxFieldsEnum =
   | 'fields.category'
   | 'fields.hierarchy'
   | 'fields.slug'
+  | 'fields.storyData.code'
+  | 'fields.storyData.groupPath'
+  | 'fields.storyData.storyItems'
+  | 'fields.storyData.storyItems.iframeName'
+  | 'fields.storyData.storyItems.label'
+  | 'fields.storyData.storyItems.name'
   | 'fileAbsolutePath'
   | 'frontmatter.author'
   | 'frontmatter.date'
   | 'frontmatter.description'
   | 'frontmatter.order'
   | 'frontmatter.smarthr_ui'
+  | 'frontmatter.storyName'
   | 'frontmatter.title'
   | 'headings'
   | 'headings.depth'
@@ -1449,6 +1465,35 @@ type MdxFieldsFilterInput = {
   readonly category: InputMaybe<StringQueryOperatorInput>;
   readonly hierarchy: InputMaybe<StringQueryOperatorInput>;
   readonly slug: InputMaybe<StringQueryOperatorInput>;
+  readonly storyData: InputMaybe<MdxFieldsStoryDataFilterInput>;
+};
+
+type MdxFieldsStoryData = {
+  readonly code: Maybe<Scalars['String']>;
+  readonly groupPath: Maybe<Scalars['String']>;
+  readonly storyItems: Maybe<ReadonlyArray<Maybe<MdxFieldsStoryDataStoryItems>>>;
+};
+
+type MdxFieldsStoryDataFilterInput = {
+  readonly code: InputMaybe<StringQueryOperatorInput>;
+  readonly groupPath: InputMaybe<StringQueryOperatorInput>;
+  readonly storyItems: InputMaybe<MdxFieldsStoryDataStoryItemsFilterListInput>;
+};
+
+type MdxFieldsStoryDataStoryItems = {
+  readonly iframeName: Maybe<Scalars['String']>;
+  readonly label: Maybe<Scalars['String']>;
+  readonly name: Maybe<Scalars['String']>;
+};
+
+type MdxFieldsStoryDataStoryItemsFilterInput = {
+  readonly iframeName: InputMaybe<StringQueryOperatorInput>;
+  readonly label: InputMaybe<StringQueryOperatorInput>;
+  readonly name: InputMaybe<StringQueryOperatorInput>;
+};
+
+type MdxFieldsStoryDataStoryItemsFilterListInput = {
+  readonly elemMatch: InputMaybe<MdxFieldsStoryDataStoryItemsFilterInput>;
 };
 
 type MdxFilterInput = {
@@ -1481,6 +1526,7 @@ type MdxFrontmatter = {
   readonly description: Scalars['String'];
   readonly order: Maybe<Scalars['Int']>;
   readonly smarthr_ui: Maybe<Scalars['String']>;
+  readonly storyName: Maybe<Scalars['String']>;
   readonly title: Scalars['String'];
 };
 
@@ -1490,6 +1536,7 @@ type MdxFrontmatterFilterInput = {
   readonly description: InputMaybe<StringQueryOperatorInput>;
   readonly order: InputMaybe<IntQueryOperatorInput>;
   readonly smarthr_ui: InputMaybe<StringQueryOperatorInput>;
+  readonly storyName: InputMaybe<StringQueryOperatorInput>;
   readonly title: InputMaybe<StringQueryOperatorInput>;
 };
 
@@ -3108,6 +3155,11 @@ type SearchQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type SearchQuery = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly frontmatter: { readonly title: string, readonly order: number | null } | null, readonly fields: { readonly category: string | null, readonly hierarchy: string | null, readonly slug: string | null } | null }> } };
+
+type StoryDataQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type StoryDataQuery = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly frontmatter: { readonly storyName: string | null } | null, readonly fields: { readonly storyData: { readonly code: string | null, readonly groupPath: string | null, readonly storyItems: ReadonlyArray<{ readonly label: string | null, readonly name: string | null, readonly iframeName: string | null } | null> | null } | null } | null }> } };
 
 
 }

--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -1,7 +1,8 @@
 import { SmartHRUIMetaInfo } from '@Components/SmartHRUIMetaInfo'
-import { SHRUI_GITHUB_RAW, SHRUI_STORYBOOK_IFRAME } from '@Constants/application'
+import { SHRUI_STORYBOOK_IFRAME } from '@Constants/application'
 import { CSS_COLOR } from '@Constants/style'
-import React, { FC, useEffect, useState } from 'react'
+import { graphql, useStaticQuery } from 'gatsby'
+import React, { FC, useState } from 'react'
 import { Loader, TabBar, TabItem, TextLink } from 'smarthr-ui'
 import styled from 'styled-components'
 
@@ -13,125 +14,43 @@ type Props = {
   name: string
 }
 
-type StoryItem = {
-  name: string
-  label: string
-}
+const query = graphql`
+  query StoryData {
+    allMdx(filter: { frontmatter: { storyName: { ne: null } } }) {
+      nodes {
+        frontmatter {
+          storyName
+        }
+        fields {
+          storyData {
+            code
+            storyItems {
+              label
+              name
+              iframeName
+            }
+            groupPath
+          }
+        }
+      }
+    }
+  }
+`
 
 export const ComponentStory: FC<Props> = ({ name }) => {
-  const storyPaths = name.split('/')
-  const fileName = storyPaths[storyPaths.length - 1]
+  const {
+    allMdx: { nodes },
+  } = useStaticQuery<GatsbyTypes.StoryDataQuery>(query)
+  const storyData = nodes.find((node) => {
+    return node.frontmatter?.storyName === name
+  })?.fields?.storyData
 
-  // "Dropdown/DropdownButton"のような階層のある名前に対応
-  const parentName = storyPaths.length > 1 ? storyPaths[0] : null
+  const code = storyData?.code ?? ''
+  const groupPath = storyData?.groupPath ?? ''
+  const storyItems = storyData?.storyItems ?? []
 
-  const filePath = `${SHRUI_GITHUB_RAW}/src/components/${name}/${fileName}.stories.tsx`
-  const parentPath = `${SHRUI_GITHUB_RAW}/src/components/${parentName}/${parentName}.stories.tsx`
-
-  const [storiesCode, setStoriesCode] = useState<string>('')
-  const [parentCode, setParentCode] = useState<string>('')
-  const [storyItems, setStoryItems] = useState<StoryItem[]>([])
-  const [groupPath, setGroupPath] = useState<string>('')
-  const [currentIFrame, setCurrentIFrame] = useState<string>('')
   const [isIFrameLoaded, setIsIFrameLoaded] = useState<boolean>(false)
-  const [isCodeLoaded, setIsCodeLoaded] = useState<boolean>(false)
-  const [isParentCodeLoaded, setIsParentCodeLoaded] = useState<boolean>(false)
-
-  useEffect(() => {
-    const fetchCode = async () => {
-      const res = await fetch(filePath)
-
-      // 404の場合など
-      if (res.status >= 400) {
-        setIsCodeLoaded(true)
-        return
-      }
-
-      const text = await res.text()
-      setStoriesCode(text)
-
-      setIsCodeLoaded(true)
-    }
-    fetchCode()
-  }, [filePath])
-
-  useEffect(() => {
-    if (parentPath === null) {
-      setIsParentCodeLoaded(true)
-      return
-    }
-
-    const fetchCode = async () => {
-      const res = await fetch(parentPath)
-
-      // 404の場合など
-      if (res.status >= 400) {
-        setIsParentCodeLoaded(true)
-        return
-      }
-
-      const text = await res.text()
-      setParentCode(text)
-
-      setIsParentCodeLoaded(true)
-    }
-    fetchCode()
-  }, [parentPath])
-
-  useEffect(() => {
-    if (!(isCodeLoaded && isParentCodeLoaded)) return
-
-    //親グループ名（例："Buttons（ボタン）"）を取得
-    const targetCode = parentCode === '' ? storiesCode : parentCode
-    const matchGroupNames = targetCode.matchAll(/export\sdefault\s\{\s+title:.*?'(.*?)'/gm)
-    const groupNames = [...matchGroupNames].map((result) => {
-      return result
-    })
-    setGroupPath(groupNames.length > 0 ? `${groupNames[0][1].replace(/\s|\//g, '-').toLowerCase()}` : '')
-
-    // "export const AccordionStyle: Story" や "export const All = Template.bind({})" のような、Story名をexportするコードから名前を抜き出す
-    // 注意1：export { Default as DropdownButton } from ...のようなコードにはマッチしない
-    // 注意2：ストーリー名に全角文字が入るケースがある（例：Body以外のPortalParent）
-    const matchStoryNames = storiesCode.matchAll(
-      /export\sconst\s([\w\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]*)/g,
-    )
-    const items1 = [...matchStoryNames].map((result) => {
-      // '_'を削除
-      const storyName = result[1].replace('_', '')
-      // 文字列中の大文字の前にスペースを追加してラベルにする
-      const storyLabel = storyName.replace(/.([A-Z])/g, (s) => {
-        return `${s.charAt(0)} ${s.slice(1, s.length)}`
-      })
-      return { name: storyName, label: storyLabel }
-    })
-
-    // ".add('full', "のようなケースもある（e.g. MessageScreen.stories.tsx）
-    const matchAddNames = storiesCode.matchAll(/\.add\('(.*?)',\s/g)
-    const items2 = [...matchAddNames].map((result) => {
-      // UpperCamel caseにする
-      const storyName = result[1]
-        .split(' ')
-        .map((word) => {
-          return word.charAt(0).toUpperCase() + word.slice(1, word.length)
-        })
-        .join('')
-      return { name: storyName, label: result[1] }
-    })
-
-    const items = [...items1, ...items2]
-
-    // "AccordionStyle.storyName = 'Accordion style'" のような表示名の定義があればラベルとして利用する
-    const matchStoryLabels = storiesCode.matchAll(/(\S*)\.storyName\s=\s'(.*)'/g)
-    Array.from(matchStoryLabels).forEach((result) => {
-      const targetItem = items.find((item) => {
-        return item.name === result[1]
-      })
-      if (targetItem) targetItem.label = result[2]
-    })
-
-    if (items.length > 0) setCurrentIFrame(items[0].name)
-    setStoryItems(items)
-  }, [storiesCode, parentCode, isCodeLoaded, isParentCodeLoaded])
+  const [currentIFrame, setCurrentIFrame] = useState<string>(storyItems[0]?.name ?? '')
 
   const onClickTab = (itemId: string): void => {
     if (itemId === currentIFrame) return
@@ -141,43 +60,20 @@ export const ComponentStory: FC<Props> = ({ name }) => {
     return
   }
 
-  const getStoryName = (componentName: string, itemName: string) => {
-    // 'Dropdown/FilterDropdown' のような階層ありの場合
-    if (parentCode !== '') {
-      return componentName.replace(/^.*\//, '').replace(/([A-Z])/g, (s) => {
-        return '-' + s.charAt(0).toLowerCase()
-      })
-    }
-    const kebab = itemName
-      // UpperCamel case -> Kebab case
-      .replace(/([A-Z])/g, (s) => {
-        return '-' + s.charAt(0).toLowerCase()
-      })
-      // 小文字のみの場合に `-item-name` とならないので補完
-      .replace(/^[a-z]+$/, (s) => `-${s.charAt(0)}`)
-      // コンポーネントとStoryが同名の場合に、頭に'_'がついていることがあるので、削除
-      .replace(/^_/, '')
-    return `${kebab}`
+  const getStoryName = (currentName: string) => {
+    return storyItems?.find((item) => {
+      return item?.name === currentName
+    })?.iframeName
   }
 
-  const getChildStoryName = (componentName: string) => {
-    if (parentCode === '') return ''
-    return componentName.replace(/^.*\//, '-').replace(/([A-Z])/g, (s) => {
-      return '-' + s.charAt(0).toLowerCase()
-    })
-  }
-
-  if (typeof window === undefined || storiesCode === '') {
-    return null
-  }
   return (
     <>
-      <SmartHRUIMetaInfo name={name} groupPath={`${groupPath}${getChildStoryName(name)}`} />
+      <SmartHRUIMetaInfo name={name} groupPath={groupPath} />
       <Tab>
-        {storyItems.map((item: StoryItem, index: number) => {
+        {storyItems.map((item, index: number) => {
           return (
-            <TabItem id={item.name} key={index} onClick={onClickTab} selected={item.name === currentIFrame}>
-              {item.label}
+            <TabItem id={item?.name ?? ''} key={index} onClick={onClickTab} selected={item?.name === currentIFrame}>
+              {item?.label}
             </TabItem>
           )
         })}
@@ -186,7 +82,7 @@ export const ComponentStory: FC<Props> = ({ name }) => {
         <>
           <LinkWrapper>
             <TextLink
-              href={`${SHRUI_STORYBOOK_IFRAME}?id=${groupPath}-${getStoryName(name, currentIFrame)}&viewMode=story`}
+              href={`${SHRUI_STORYBOOK_IFRAME}?id=${groupPath}-${getStoryName(currentIFrame)}&viewMode=story`}
               target="_blank"
             >
               別画面で開く
@@ -198,18 +94,17 @@ export const ComponentStory: FC<Props> = ({ name }) => {
             <StoryIframe
               title={
                 storyItems.find((item) => {
-                  return item.name === currentIFrame
+                  return item?.name === currentIFrame
                 })?.label || ''
               }
-              src={`${SHRUI_STORYBOOK_IFRAME}?id=${groupPath}-${getStoryName(name, currentIFrame)}`}
+              src={`${SHRUI_STORYBOOK_IFRAME}?id=${groupPath}-${getStoryName(currentIFrame)}`}
               onLoad={() => setIsIFrameLoaded(true)}
             />
           </ResizableContainer>
         </>
       )}
       <CodeWrapper>
-        <StoryLoader className={isCodeLoaded && isParentCodeLoaded ? '' : '-show'} />
-        <CodeBlock className="tsx">{storiesCode}</CodeBlock>
+        <CodeBlock className="tsx">{code}</CodeBlock>
       </CodeWrapper>
     </>
   )

--- a/src/gatsby-node/fetchStoryData.ts
+++ b/src/gatsby-node/fetchStoryData.ts
@@ -1,0 +1,103 @@
+import { SHRUI_GITHUB_RAW } from '../constants/application'
+
+type StoryItem = {
+  name: string
+  label: string
+  iframeName: string
+}
+
+export const fetchStoryData = async (storyName: string) => {
+  let storiesCode = ''
+  let parentCode = ''
+
+  const storyPaths = storyName.split('/')
+  const storyFileName = storyPaths[storyPaths.length - 1]
+
+  // "Dropdown/DropdownMenuButton"のような階層のある名前に対応
+  const parentName = storyPaths.length > 1 ? storyPaths[0] : null
+
+  const filePath =
+    storyName && storyFileName ? `${SHRUI_GITHUB_RAW}/src/components/${storyName}/${storyFileName}.stories.tsx` : null
+  const parentPath = parentName ? `${SHRUI_GITHUB_RAW}/src/components/${parentName}/${parentName}.stories.tsx` : null
+
+  if (filePath) {
+    const res = await fetch(filePath)
+    storiesCode = res.ok ? await res.text() : ''
+  }
+
+  if (parentPath) {
+    const res = await fetch(parentPath)
+    parentCode = res.ok ? await res.text() : ''
+  }
+
+  //親グループ名（例："Buttons（ボタン）"）を取得
+  const targetCode = parentCode === '' ? storiesCode : parentCode
+  const matchGroupNames = targetCode.matchAll(/export\sdefault\s\{\s+title:.*?'(.*?)'/gm)
+  const groupNames = [...matchGroupNames].map((result) => {
+    return result
+  })
+  const groupPath = groupNames.length > 0 ? `${groupNames[0][1].replace(/\s|\//g, '-').toLowerCase()}` : ''
+
+  // "export const AccordionStyle: Story" や "export const All = Template.bind({})" のような、Story名をexportするコードから名前を抜き出す
+  // 注意1：export { Default as DropdownButton } from ...のようなコードにはマッチしない
+  // 注意2：ストーリー名に全角文字が入るケースがある（例：Body以外のPortalParent）
+  const matchStoryNames = storiesCode.matchAll(
+    /export\sconst\s([\w\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]*)/g,
+  )
+  const items1 = [...matchStoryNames].map((result) => {
+    // '_'を削除
+    const name = result[1].replace('_', '')
+    // 文字列中の大文字の前にスペースを追加してラベルにする
+    const label = name.replace(/.([A-Z])/g, (s) => {
+      return `${s.charAt(0)} ${s.slice(1, s.length)}`
+    })
+    return { name, label }
+  })
+
+  // ".add('full', "のようなケースもある（e.g. MessageScreen.stories.tsx）
+  const matchAddNames = storiesCode.matchAll(/\.add\('(.*?)',\s/g)
+  const items2 = [...matchAddNames].map((result) => {
+    // UpperCamel caseにする
+    const name = result[1]
+      .split(' ')
+      .map((word) => {
+        return word.charAt(0).toUpperCase() + word.slice(1, word.length)
+      })
+      .join('')
+    return { name, label: result[1] }
+  })
+
+  // "AccordionStyle.storyName = 'Accordion style'" のような表示名の定義があればラベルとして利用する
+  const storyLabels: { [key: string]: string } = {}
+  const matchStoryLabels = storiesCode.matchAll(/(\S*)\.storyName\s=\s'(.*)'/g)
+  Array.from(matchStoryLabels).forEach((result) => {
+    storyLabels[result[1]] = result[2]
+  })
+
+  const storyItems: StoryItem[] = [...items1, ...items2].map((item) => {
+    // iframeのURL用にケバブケースの名前を作る
+    const kebab =
+      parentCode === '' // 階層あり・なしの場合分け
+        ? item.name
+            .replace(/([A-Z])/g, (s) => {
+              return '-' + s.charAt(0).toLowerCase()
+            })
+            .replace(/^[a-z]+$/, (s) => `-${s.charAt(0)}`)
+            .replace(/^_/, '') // コンポーネントとStoryが同名の場合に、頭に'_'がついていることがあるので、削除
+        : storyName.replace(/^.*\//, '').replace(/([A-Z])/g, (s) => {
+            return '-' + s.charAt(0).toLowerCase()
+          })
+
+    return {
+      name: item.name,
+      label: storyLabels[item.name] || item.name,
+      iframeName: kebab,
+    }
+  })
+
+  return {
+    code: storiesCode,
+    storyItems,
+    groupPath,
+  }
+}

--- a/src/gatsby-node/index.ts
+++ b/src/gatsby-node/index.ts
@@ -5,9 +5,11 @@ import { createFilePath } from 'gatsby-source-filesystem'
 
 import { AIRTABLE_CONTENTS } from '../constants/airtable'
 
+import { fetchStoryData } from './fetchStoryData'
+
 import type { airtableContents } from '../constants/airtable'
 
-export const onCreateNode: GatsbyNode['onCreateNode'] = ({ actions, node, getNode }) => {
+export const onCreateNode: GatsbyNode['onCreateNode'] = async ({ actions, node, getNode }) => {
   const { createNodeField } = actions
 
   if (node.internal.type === 'Mdx') {
@@ -31,6 +33,18 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = ({ actions, node, getNod
       node,
       value: fileNameArray.join('/'),
     })
+
+    const frontmatter = node.frontmatter as typeof node & {
+      storyName: string
+    }
+    if (frontmatter && frontmatter.storyName) {
+      const storyData = await fetchStoryData(frontmatter.storyName)
+      createNodeField({
+        name: 'storyData',
+        node,
+        value: storyData,
+      })
+    }
   }
 }
 
@@ -48,6 +62,9 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions, graphql,
               slug
               category
               hierarchy
+            }
+            frontmatter {
+              storyName
             }
           }
         }


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1182

## やったこと
`/products/components/`以下の、各smarthr-uiコンポーネントのページで、ビルド時にサーバー側でできる処理はサーバー側へ移し、クライアントではiframe部分のタブ切り替えのみを行うようにしました。

具体的には、
- gatsby-nodeの`onCreateNode`で、GitHubからsmarthr-uiの*.stories.tsx をfetch
  - fetchしたコードをパースしてStoryの名前やStorybookのURLに必要なパスなどを取得しておく
- ComponentStoryでは、useStaticQueryを使ってGraphQLでStoryの情報を取得

という流れになっています。

## やらなかったこと
現状ではタブ切り替え以外のレンダリングはSSGになっていて、ビルド時に全UIコンポーネント分の`*.stories.tsx`へのfetchが行われます（キャッシュは効くようです）。

ビルド時間がそこまで増えたようには感じませんが、DSGにしてビルド時のレンダリングをスキップこともできそうです。

### 気になっている点
- gatsby-nodeからは`<ComponentStory>`コンポーネントに渡しているpropsは見えないので、frontmatterに`storyName`を追加しました。（先日`smarthr-ui`を削除したばかりなのですが…）
- gatsby-node`onCreateNode`は前のページの処理が終わる前に次々呼ばれている→コードの`fetch`も複数同時に行われてそうです。
  - ビルド時間の短縮にはなってそう
  - GitHubへのfetchが数秒間に50件くらい発生してそう（ローカルでやっていた限りは問題は起きなかったです）
  - リクエスト先はAPIではなく、`https://raw.githubusercontent.com/kufu/smarthr-ui/v26.0.0/src/components/Dropdown/Dropdown.stories.tsx`のようなWebページそのもの（＝rate limitはない？）
- fetchしてきたコードをパースする処理は、`<ComponentStory>`コンポーネントから移動しましたが、ひとまず`src/gatsby-node/fetchStoryData.ts`に置いてあります。`src/gatsby-node/index.ts`からしか`import`しませんが、ここに置くのでいいでしょうか？

## 動作確認
https://deploy-preview-514--smarthr-design-system.netlify.app/products/components/accordion-panel/
https://deploy-preview-514--smarthr-design-system.netlify.app/products/components/dropdown/
https://deploy-preview-514--smarthr-design-system.netlify.app/products/components/dropdown/dropdown-menu-button/

開発ツールなどで、ブラウザからは`*.stories.tsx`のfetchが行われていないのが確認できます。

## キャプチャ
見た目や機能に影響はありません。