### PR TITLE
GitHub Actionsでビルドする際にNetlify上の環境変数を参照する

### DIFF
--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -1,4 +1,4 @@
-name: Deploy to netlify
+name: (Test) Deploy to netlify
 
 on:
   workflow_dispatch:
@@ -17,13 +17,10 @@ jobs:
       - name: Create .env file
         run: |
           touch .env
-          echo -e "AIRTABLE_API_KEY=${{ secrets.AIRTABLE_API_KEY }}" >> .env
-          echo -e "AIRTABLE_BASE_ID=${{ secrets.AIRTABLE_BASE_ID }}" >> .env
-          echo -e "GATSBY_ALGOLIA_ADMIN_API_KEY=${{ secrets.GATSBY_ALGOLIA_ADMIN_API_KEY }}" >> .env
-          echo -e "GATSBY_ALGOLIA_APP_ID=${{ secrets.GATSBY_ALGOLIA_APP_ID }}" >> .env
-          echo -e "GATSBY_ALGOLIA_INDEX_NAME=${{ secrets.GATSBY_ALGOLIA_INDEX_NAME }}" >> .env
-          echo -e "GATSBY_ALGOLIA_SEARCH_API_KEY=${{ secrets.GATSBY_ALGOLIA_SEARCH_API_KEY }}" >> .env
-          echo -e "GATSBY_CLOUDINARY_CLOUD_NAME=${{ secrets.GATSBY_CLOUDINARY_CLOUD_NAME }}" >> .env
+          npx netlify-cli env:list --plain >> .env
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-engines
@@ -31,7 +28,12 @@ jobs:
       - run: yarn clean
       - run: yarn build
 
-      - run: npx netlify-cli deploy --prod --dir=./public
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      - name: 生成されたpublicディレクトリを確認
+        uses: actions/upload-artifact@v2
+        with:
+          path: public
+
+      # - run: npx netlify-cli deploy --prod --dir=./public
+      #   env:
+      #     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      #     NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -28,12 +28,8 @@ jobs:
       - run: yarn clean
       - run: yarn build
 
-      - name: 生成されたpublicディレクトリを確認
-        uses: actions/upload-artifact@v2
-        with:
-          path: public
-
+      - run: npx netlify-cli deploy --dir=./public
       # - run: npx netlify-cli deploy --prod --dir=./public
-      #   env:
-      #     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      #     NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -1,4 +1,4 @@
-name: (Test) Deploy to netlify
+name: Deploy to netlify
 
 on:
   workflow_dispatch:
@@ -28,8 +28,7 @@ jobs:
       - run: yarn clean
       - run: yarn build
 
-      - run: npx netlify-cli deploy --dir=./public
-      # - run: npx netlify-cli deploy --prod --dir=./public
+      - run: npx netlify-cli deploy --prod --dir=./public
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1190

## やったこと
`netlify-cli`コマンドで、Netlifyに保存している環境変数を取得できるので、GitHub Actionsでビルドする際にもそれを利用するように変更しました。この仕組みであれば、環境変数の定義はNetlify上（と、ローカルの`.env`ファイル）のみでOKになります。

具体的には、`netlify-cli env:list --plain`コマンドで取得した環境変数一覧を、`.env`ファイルに保存しています（これまでは、GitHub secretsを`.env`に保存する仕組みでした）。

## やらなかったこと
このGitHubリポジトリに保存されているsecretの削除は行なっていないため、削除後に念のためActionsからのNetlifyデプロイを確認するほうが良いかもしれません。

## 動作確認
### 動作確認①
GitHub Actions上でビルドし、`public`ディレクトリをartifactとしてダウンロードして確認しました。
→正しくサイトが構築できていました（Airtableのコンテンツが表示されている、検索ができる、Gotcha画像が表示できている等）。
Actionsのログ：https://github.com/kufu/smarthr-design-system/actions/runs/4131341296

### 動作確認②
GitHub Actions上でビルドし、`netlify-cli`の`deploy`コマンドを、`--prod`を除いて実行しました（デフォルトで`prod=false`になるため）。
→デプロイプレビューが作られましたが、こちらも正しくサイトが構築できていました。
Deployのログ：https://app.netlify.com/sites/smarthr-design-system/deploys/63e48ca62eec594862bf22c7
Deploy preview：https://63e48ca62eec594862bf22c7--smarthr-design-system.netlify.app/
Actionsのログ：https://github.com/kufu/smarthr-design-system/actions/runs/4131411851

---
**動作確認後に`--prod`オプションは元に戻したので、この`topic/use-netlify-secrets`ブランチでActionsを実行すると本番にデプロイされる状態になっています。**