### PR TITLE
AlgoliaのKEYが設定されていない場合にメッセージを表示

### DIFF
--- a/src/components/search/Search/SearchBox.tsx
+++ b/src/components/search/Search/SearchBox.tsx
@@ -54,9 +54,7 @@ const SearchBox: FC<SearchBoxProvided & Props> = ({ refine, isAvailable }) => {
           aria-describedby="desc-for-search-input"
           name="query"
         />
-        {!isAvailable && searchState && process.env.BRANCH !== 'main' && (
-          <WarningMessage>検索処理を実行するにはAlgoliaのAPIキーの設定が必要です</WarningMessage>
-        )}
+        {!isAvailable && searchState && <WarningMessage>検索処理を実行するにはAlgoliaのAPIキーの設定が必要です</WarningMessage>}
       </InputOuter>
 
       {/* 検索結果 */}

--- a/src/components/search/Search/SearchBox.tsx
+++ b/src/components/search/Search/SearchBox.tsx
@@ -1,4 +1,4 @@
-import { CSS_FONT_SIZE } from '@Constants/style'
+import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import { useLocation } from '@reach/router'
 import { navigate } from 'gatsby'
 import React, { useEffect, useState } from 'react'
@@ -12,7 +12,9 @@ import { SearchResultOuter } from './SearchResultOuter'
 import type { FC } from 'react'
 import type { SearchBoxProvided } from 'react-instantsearch-core'
 
-const SearchBox: FC<SearchBoxProvided> = ({ refine }) => {
+type Props = { isAvailable: boolean }
+
+const SearchBox: FC<SearchBoxProvided & Props> = ({ refine, isAvailable }) => {
   const [searchState, setSearchState] = useState<string | undefined>()
 
   // クエリ付きURLでアクセスされた場合
@@ -42,7 +44,6 @@ const SearchBox: FC<SearchBoxProvided> = ({ refine }) => {
       {/* 検索インプット部分 */}
       <InputOuter>
         <p id="desc-for-search-input">例：Button、画面キャプチャ、用字用語、須磨英知など</p>
-
         <Input
           width="100%"
           prefix={<FaSearchIcon size={24} aria-label="検索" />}
@@ -53,6 +54,9 @@ const SearchBox: FC<SearchBoxProvided> = ({ refine }) => {
           aria-describedby="desc-for-search-input"
           name="query"
         />
+        {!isAvailable && searchState && process.env.BRANCH !== 'main' && (
+          <WarningMessage>検索処理を実行するにはAlgoliaのAPIキーの設定が必要です</WarningMessage>
+        )}
       </InputOuter>
 
       {/* 検索結果 */}
@@ -86,4 +90,12 @@ const InputOuter = styled.div`
     border-radius: 12px;
     font-size: 1.5rem;
   }
+`
+
+const WarningMessage = styled.div`
+  margin-block: 16px;
+  padding: 16px;
+  background-color: ${CSS_COLOR.CAUTION_LIGHT};
+  color: ${CSS_COLOR.CAUTION_HEAVY};
+  text-align: center;
 `

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -27,7 +27,7 @@ const SearchPage: FC = () => {
         <Main>
           <PageTitle id="label-for-search-input">SmartHR Design Systemを検索</PageTitle>
           <Search className="ais-SearchBox__root">
-            <InstantSearch indexName="content" searchClient={searchClient}>
+            <InstantSearch indexName={process.env.GATSBY_ALGOLIA_INDEX_NAME || ''} searchClient={searchClient}>
               <CustomSearchBox
                 isAvailable={process.env.GATSBY_ALGOLIA_APP_ID && process.env.GATSBY_ALGOLIA_SEARCH_API_KEY ? true : false}
               />

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -28,7 +28,9 @@ const SearchPage: FC = () => {
           <PageTitle id="label-for-search-input">SmartHR Design Systemを検索</PageTitle>
           <Search className="ais-SearchBox__root">
             <InstantSearch indexName="content" searchClient={searchClient}>
-              <CustomSearchBox />
+              <CustomSearchBox
+                isAvailable={process.env.GATSBY_ALGOLIA_APP_ID && process.env.GATSBY_ALGOLIA_SEARCH_API_KEY ? true : false}
+              />
             </InstantSearch>
           </Search>
         </Main>


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1166

## やったこと

- 環境変数の `GATSBY_ALGOLIA_APP_ID`と`GATSBY_ALGOLIA_SEARCH_API_KEY` のいずれか（または両方）が `undefined`の状態で検索クエリを入力した場合に、警告メッセージを表示します。
- 本番環境（`process.env.BRANCH === 'main'`）の場合は、~~メッセージは表示しません。~~ これまでどおりビルド時にgatsby-plugin-algoliaのエラーで、ビルドが止まります。
  
また、`/src/pages/search.tsx`内で、Algoliaのindex名（`content`）がベタ書きされていたので、環境変数を参照するように変更しました（環境変数には元から `GATSBY_ALGOLIA_INDEX_NAME`として定義されています）→ https://github.com/kufu/smarthr-design-system/pull/531/commits/b90368f28b80228a223eeb16c45f40b205d3baa6

## やらなかったこと
react-instantsearch-domライブラリの`<InstantSearch>`コンポーネントまわりの動作は変わっていないので、引き続きKEYがなくてもリクエストは飛んでいます（＝エラーレスポンスが返るので、コンソールにはエラーが出ます）。

KEYがない場合にコンポーネント自体をレンダリングしない、というのは可能ですが、検索入力のテキストボックスも表示されなくなりそうです。

## 動作確認
https://deploy-preview-531--smarthr-design-system.netlify.app/search/
（KEYがあるのでメッセージは出ませんが、検索機能に影響がないことは確認できるかと思います。）

## キャプチャ
![image](https://user-images.githubusercontent.com/7822534/218409951-ed586891-cd93-4d27-9831-e8c351f9f532.png)
