### PR TITLE
Airtableのキーが未設定の場合にモックデータを使ってビルドする

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv'
 import emoji from 'remark-emoji'
 
 import { algoliaConfig } from './gatsby-plugin-algolia-config'
-import { AIRTABLE_CONTENTS } from './src/constants/airtable'
+import { AIRTABLE_CONTENTS, AIRTABLE_MOCK_DATA } from './src/constants/airtable'
 
 import type { GatsbyConfig } from 'gatsby'
 
@@ -133,20 +133,34 @@ const config: GatsbyConfig = {
         remarkPlugins: [emoji],
       },
     },
-    {
-      resolve: 'gatsby-source-airtable',
-      options: {
-        apiKey: process.env.AIRTABLE_API_KEY, // may instead specify via env, see below
-        concurrency: 5, // default, see using markdown and attachments for more information
-        tables: AIRTABLE_CONTENTS.map((item) => {
-          return {
-            baseId: process.env.AIRTABLE_BASE_ID,
-            tableName: item.tableName,
-            tableView: `design system表示用`,
-          }
-        }),
-      },
-    },
+    // AIRTABLEキーが設定されているか、本番環境の場合はgatsby-source-airtable、それ以外ではモックデータを利用する
+    ...((process.env.AIRTABLE_API_KEY && process.env.AIRTABLE_BASE_ID) || process.env.BRANCH === 'main'
+      ? [
+          {
+            resolve: 'gatsby-source-airtable',
+            options: {
+              apiKey: process.env.AIRTABLE_API_KEY, // may instead specify via env, see below
+              concurrency: 5, // default, see using markdown and attachments for more information
+              tables: AIRTABLE_CONTENTS.map((item) => {
+                return {
+                  baseId: process.env.AIRTABLE_BASE_ID,
+                  tableName: item.tableName,
+                  tableView: `design system表示用`,
+                }
+              }),
+            },
+          },
+        ]
+      : [
+          {
+            resolve: `gatsby-source-mock`,
+            options: {
+              schema: AIRTABLE_MOCK_DATA,
+              count: AIRTABLE_MOCK_DATA.length,
+              type: 'Airtable',
+            },
+          },
+        ]),
   ],
 }
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "gatsby-remark-images": "^6.25.0",
     "gatsby-remark-relative-images": "^2.0.2",
     "gatsby-source-filesystem": "^4.25.0",
+    "gatsby-source-mock": "^1.2.1",
     "glob": "^8.1.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.1",

--- a/src/components/contents/AppWriting/AppWriting.tsx
+++ b/src/components/contents/AppWriting/AppWriting.tsx
@@ -1,3 +1,4 @@
+import { CSS_COLOR } from '@Constants/style'
 import { graphql, useStaticQuery } from 'gatsby'
 import { marked } from 'marked'
 import React, { FC } from 'react'
@@ -44,6 +45,9 @@ export const AppWriting: FC = () => {
 
   return (
     <>
+      {appWritingData[0].recordId?.includes('MOCKDATA') && (
+        <WarningMessage>このページを正しく表示するにはAirtableのAPIキーの設定が必要です</WarningMessage>
+      )}
       {appWritingData.map(({ name, description, discussion, source, recordId }, index) => {
         const generateFragmentId = (suffixId: string) => {
           return recordId ? `${recordId}-${suffixId}` : `${index}-${suffixId}`
@@ -91,4 +95,11 @@ const Wrapper = styled.div``
 const StyledText = styled(Text)`
   white-space: pre-wrap;
   overflow-wrap: break-word;
+`
+const WarningMessage = styled.div`
+  margin-block: 16px;
+  padding: 16px;
+  background-color: ${CSS_COLOR.CAUTION_LIGHT};
+  color: ${CSS_COLOR.CAUTION_HEAVY};
+  text-align: center;
 `

--- a/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
+++ b/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
@@ -1,3 +1,4 @@
+import { CSS_COLOR } from '@Constants/style'
 import { graphql, useStaticQuery } from 'gatsby'
 import { marked } from 'marked'
 import React, { FC } from 'react'
@@ -44,6 +45,9 @@ export const BasicConceptTable: FC = () => {
 
   return (
     <>
+      {basicConceptData[0].recordId?.includes('MOCKDATA') && (
+        <WarningMessage>このページを正しく表示するにはAirtableのAPIキーの設定が必要です</WarningMessage>
+      )}
       {basicConceptData.map(({ name, description, discussion, source, recordId }, index) => {
         const generateFragmentId = (suffixId: string) => {
           return recordId ? `${recordId}-${suffixId}` : `${index}-${suffixId}`
@@ -90,4 +94,11 @@ const Wrapper = styled.div``
 const StyledText = styled(Text)`
   white-space: pre-wrap;
   overflow-wrap: break-word;
+`
+const WarningMessage = styled.div`
+  margin-block: 16px;
+  padding: 16px;
+  background-color: ${CSS_COLOR.CAUTION_LIGHT};
+  color: ${CSS_COLOR.CAUTION_HEAVY};
+  text-align: center;
 `

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -1,3 +1,4 @@
+import { CSS_COLOR } from '@Constants/style'
 import { Link, graphql, useStaticQuery } from 'gatsby'
 import { marked } from 'marked'
 import React, { FC } from 'react'
@@ -95,6 +96,9 @@ export const IdiomaticUsageTable: FC<Props> = ({ type }) => {
 
   return (
     <>
+      {idiomaticUsageData[0].recordId?.includes('MOCKDATA') && (
+        <WarningMessage>このページを正しく表示するにはAirtableのAPIキーの設定が必要です</WarningMessage>
+      )}
       {type === 'data' && (
         <Wrapper>
           <Table>
@@ -223,4 +227,11 @@ const ReasonTd = styled(Td)`
 const StyledText = styled(Text)`
   white-space: pre-wrap;
   overflow-wrap: break-word;
+`
+const WarningMessage = styled.div`
+  margin-block: 16px;
+  padding: 16px;
+  background-color: ${CSS_COLOR.CAUTION_LIGHT};
+  color: ${CSS_COLOR.CAUTION_HEAVY};
+  text-align: center;
 `

--- a/src/constants/airtable.ts
+++ b/src/constants/airtable.ts
@@ -33,3 +33,23 @@ export const AIRTABLE_CONTENTS: airtableContents[] = [
     sort: 'AIRTABLE',
   },
 ]
+
+export const AIRTABLE_MOCK_DATA = AIRTABLE_CONTENTS.map((content) => {
+  return {
+    table: content.tableName,
+    data: {
+      record_id: 'recMOCKDATA',
+      name: '項目名',
+      description: '項目の説明文',
+      discussion: '項目の議事録',
+      source: '項目の出典',
+      label: '項目のラベル',
+      ng_example: '表記のNG事例',
+      ok_example: '表記のOK事例',
+      expected: '-',
+      reason: 'recMOCKDATA',
+      data: '-',
+      order: 0,
+    },
+  }
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7022,6 +7022,11 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
+faker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -7825,6 +7830,13 @@ gatsby-source-filesystem@^4.25.0:
     pretty-bytes "^5.4.1"
     valid-url "^1.0.9"
     xstate "4.32.1"
+
+gatsby-source-mock@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/gatsby-source-mock/-/gatsby-source-mock-1.2.1.tgz#831f8f457a02954674c1db979668b8b0abc0ea55"
+  integrity sha512-UwmNLBUxoGf2dT5uvsoPCtKY9dNp300STMxCMn9geCcpxQgJH5YfDjhBOaKDjxmoLMpV4r4kI7K1C/oWbNDXzA==
+  dependencies:
+    faker "^5.5.3"
 
 gatsby-telemetry@^3.25.0:
   version "3.25.0"


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1167

## やったこと
`AIRTABLE_API_KEY`・`AIRTABLE_BASE_ID`のいずれかが環境変数に設定されていない場合、gatsby-source-airtableプラグインの代わりにgatsby-source-mockプラグインを有効にして、モックデータでビルドできるようにしました。
ただし、mainブランチの場合（`process.env.BRANCH`が`main`の場合）はKEYの有無にかかわらずgatsby-source-airtableを有効にします（KEYがなければこれまでと同様にビルドエラーになります）。

また、モックデータを利用している場合は、Airtableコンテンツを表示するページにメッセージを表示します。

関連するコンポーネントは以下です。
`/src/components/contents/AppWriting/AppWriting.tsx`（UIテキスト）
`/src/components/contents/BasicConceptTable/BasicConceptTable.tsx`（ライティングスタイル）
`/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx`（用字用語：一覧、用字用語：理由）

## 動作確認
https://deploy-preview-534--smarthr-design-system.netlify.app/products/contents/writing-style/
https://deploy-preview-534--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/
https://deploy-preview-534--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/usage/
https://deploy-preview-534--smarthr-design-system.netlify.app/products/contents/app-writing/

## キャプチャ
![image](https://user-images.githubusercontent.com/7822534/218686748-9e557f09-fa57-4e5f-b380-ce9b6dfb4d1d.png)
