### PR TITLE
リンクチェックの結果をサマリーに出力するように変更

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,29 +25,24 @@ jobs:
       - id: linkCheck
         name: Execute link checker
         #リンクエラーが見つかるとスクリプトはexit(1)で終了するが、このactionは中止しない。
-        continue-on-error: true
-        # linkChecker.tsを実行し、`console.error()`の内容をerrors.txtに出力する
-        # link-check-issue.jsonを作成し、タイトル（Link check failed + 日付）と本文（`console.error()`の中身）を出力する
+        # linkChecker.tsを実行し、`console.log()`と`console.error()`の内容をファイルに出力する
         run: |
-          npx ts-node scripts/linkChecker.ts 2> errors.txt || true
+          npx ts-node scripts/linkChecker.ts 1>output.txt 2> errors.txt || true
           echo errors=`cat errors.txt` >> $GITHUB_OUTPUT
+      - name: Output log to summary
+        # 実行結果をActionsのサマリーに出力
+        run: |
           today=$(date "+%Y-%m-%d")
-          echo "{\"title\": \"Link check failed ${today}\", \"body\": \"" >> link-check-issue.json
-          echo '```\r\n' >> link-check-issue.json
-          while read error; do
-            echo "$error" >> link-check-issue.json
-            echo '\r\n' >> link-check-issue.json
-          done <errors.txt
-          echo '```"}' >> link-check-issue.json
-      # GitHub issueを作成する
-      - name: Create an issue
-        # 前のstepでエラーがあった場合のみ作成
+          echo "### Link check ${today}" >> $GITHUB_STEP_SUMMARY
+          while read output; do
+            echo "$output" >> $GITHUB_STEP_SUMMARY
+          done <output.txt
+      - name: Output errors to summary
+        # 前のstepでエラーがあった場合はエラーも出力
         if: steps.linkCheck.outputs.errors != ''
         run: |
-            curl \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{secrets.CREATE_ISSUE_TOKEN}}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/kufu/smarthr-design-system-issues/issues \
-            -d @link-check-issue.json
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          while read error; do
+            echo "$error" >> $GITHUB_STEP_SUMMARY
+          done <errors.txt
+          echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1181

issue作成がうまくいかないので、ひとまず実行結果を手動で確認できるようにしました。

## やったこと
リンクチェックの実行結果と、あればエラー出力を、Actionsのサマリーに出力するようにしました。

## やらなかったこと
issue作成や通知についてはこのPRでは対応していません。

## 動作確認
このPRのブランチから手動で実行してみました
https://github.com/kufu/smarthr-design-system/actions/runs/4279281141

## キャプチャ
**リンク切れがない場合の出力例**
![image](https://user-images.githubusercontent.com/7822534/221482018-0737b73d-0e96-4a87-98f7-0668de5facb8.png)

**リンク切れがあった場合の出力例**
![image](https://user-images.githubusercontent.com/7822534/221482058-72366394-3b2f-4b3d-b71e-17a7d2382e6a.png)
