### PR TITLE
リンク切れとリンクチェッカーの修正対応

### DIFF
--- a/content/articles/operational-guideline/figma-operation.mdx
+++ b/content/articles/operational-guideline/figma-operation.mdx
@@ -37,7 +37,7 @@ order: 5
 - [Figmaの使い方 | Docbase](https://smarthr-inc.docbase.io/posts/1306505)
 - [Figmaがもっと便利で効率的になるプラグイン集 | Docbase](https://smarthr-inc.docbase.io/posts/1909725)
 - [デザインデータ設計ガイド](/products/design-process/design-data/design-guide/)
-- [Figmaライブラリ](/products/resource/components/#h2-1)
+- [Figmaライブラリ](/products/resource/#h2-1)
 
 ## 利用上のルール
 

--- a/content/articles/products/components/notification-bar.mdx
+++ b/content/articles/products/components/notification-bar.mdx
@@ -81,7 +81,7 @@ export const AnimateNotificationBar = () => {
 
 ### レイアウト
 
-非推奨ですが[LineClamp](/products/components/line-clamp)コンポーネントも使えます。
+非推奨ですが[LineClamp](/products/components/line-clamp/)コンポーネントも使えます。
 
 ```tsx editable codeBlock
 <Stack style={{width: '100%', background: '#f8f7f6', padding: '8px'}}>
@@ -139,14 +139,14 @@ export const AnimateNotificationBar = () => {
 #### アプリケーション全体にメッセージを表示する
 
 アプリケーション全体にメッセージを表示している例です。  
-アプリケーション内で画面を切り替えてもメッセージが表示され続けることを表すため、[Header](/products/components/header)よりも上に配置します。また、必ず見てもらいたいメッセージなので`bold={true}`にしています。
+アプリケーション内で画面を切り替えてもメッセージが表示され続けることを表すため、[Header](/products/components/header/)よりも上に配置します。また、必ず見てもらいたいメッセージなので`bold={true}`にしています。
 
 ![NotificationBarを使ってアプリケーション全体へメッセージを表示している例](./images/notification-bar-static1.png)
 
 #### ページにメッセージを表示する
 
 ページ内にメッセージを表示している例です。  
-「ダッシュボード」の配下のみに関わる情報であることを表すために、[AppNavi](/products/components/app-navi)の下にNotificationBarを配置します。
+「ダッシュボード」の配下のみに関わる情報であることを表すために、[AppNavi](/products/components/app-navi/)の下にNotificationBarを配置します。
 
 ![NotificationBarを使ってページ内にメッセージを表示している例](./images/notification-bar-static2.png)
 

--- a/scripts/linkChecker.ts
+++ b/scripts/linkChecker.ts
@@ -1,9 +1,10 @@
 import fs from 'fs/promises'
 import path from 'path'
+
 import glob from 'glob'
 
 const CONTENT_PATH = path.join(__dirname, '../content/articles/**/*.mdx')
-const IMAGE_PATH = path.join(__dirname, '../content/articles/**/*.+(png|jpg|jpeg)')
+const IMAGE_PATH = path.join(__dirname, '../content/articles/**/*.+(png|jpg|jpeg|gif)')
 const DOWNLOAD_PATH = path.join(__dirname, '../static/**/*')
 
 const IGNORE_LIST = ['URL', '#ページ内リンク']
@@ -30,7 +31,7 @@ const collectExistLinks = async () => {
         linkList.push({
           link: link[1].split(' ')[0], // "![sample image](./images/sample.jpg '#width=300px')"のような表記が可能なので
           filePath: file,
-          pagePath: pagePath,
+          pagePath,
           lineNo: index + 1,
           type: /^!/.test(link[0]) ? 'image' : 'link',
         })

--- a/static/_redirects
+++ b/static/_redirects
@@ -51,3 +51,4 @@
 /products/components/dropdown-button /products/components/dropdown/dropdown-menu-button
 /products/design-patterns/dropdown-button /products/components/dropdown/dropdown-menu-button
 /products/components/dropdown/dropdown-button /products/components/dropdown/dropdown-menu-button
+/products/resource/components /products/resource


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1202

## やったこと
以下の3種類の問題がありました

- 末尾スラッシュが漏れていたもの
  - →追加しました
- GIF画像
  - リンクチェッカーが`.gif`拡張子に対応していなかったので、修正しました。
  - また、スクリプト内でLinterに引っかかったところも合わせて修正しています。
- 移動したページを参照していたもの
  - リンク先の変更・リダイレクト設定の追加を行いました。

→ リンクチェックでは何も検知しなくなりました。

## 動作確認
- https://deploy-preview-552--smarthr-design-system.netlify.app/products/components/notification-bar/ →ページ内のリンク3箇所に末尾「/」を追加（挙動は変わりません）
  - `LineClampコンポーネントも使えます `
  - `Headerよりも上に配置します`
  - `AppNaviの下に`

- f987abe83f98d515fc173316a3cd815cef926359 で、`/products/resource/components/`がなくなった対応
  - https://deploy-preview-552--smarthr-design-system.netlify.app/operational-guideline/figma-operation/#h2-2 → `Figmaライブラリ`のリンク先を修正
  - リダイレクトを追加：https://deploy-preview-552--smarthr-design-system.netlify.app/products/resource/components/

## キャプチャ
リンク先の変更のみなので、見た目上の変化はありません。