### PR TITLE
テーブルセルにグローバルにmin-widthを適用

### DIFF
--- a/src/components/shared/GlobalStyle/GlobalStyle.tsx
+++ b/src/components/shared/GlobalStyle/GlobalStyle.tsx
@@ -41,5 +41,6 @@ export const GlobalStyle = createGlobalStyle`
   table td {
     box-sizing: border-box;
     padding: 0.5rem 1rem;
+    min-width: 7em; /* 5em+padding */
   }
 `


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1185

## やったこと
`table th, table td` にグローバルに `min-width: 7em;`の指定を追加しました。
左右`1em`ずつpaddingが効いている（+`box-sizing: border-box;`の指定がある）ので、実質`5em`分のコンテンツ表示領域を確保することになります。

## やらなかったこと
個別のテーブルに対してのスタイル指定（上書き）は追加していません（すでに指定されていたものはそのままです）。

## 動作確認
SP表示などで、日本語が1〜2文字で折り返されて縦書きのようになるケースはなくなりました。逆に、1〜2文字しか入らないセル（「○」「A」など）については、これまでよりやや幅が広くなってしまっています。

## キャプチャ

### 改善したと思われる例
（いずれもスマートフォン表示）

https://deploy-preview-553--smarthr-design-system.netlify.app/basics/icons/
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/221762843-fb2017e4-7e1b-44c0-b17f-ba0e49a0b83e.png" width="300" alt="現在のアイコンページのスクリーンショット"> | <img src="https://user-images.githubusercontent.com/7822534/221762783-1b88c252-f132-4e5c-9ad7-0e2c20e9fb5e.png" width="300" alt="PRプレビューでのアイコンページのスクリーンショット"><br>右にスクロール時↓<br><img src="https://user-images.githubusercontent.com/7822534/221762982-6a4f1d8d-51c8-4242-86e0-162319ba99ce.png" width="300" alt="PRプレビューでのアイコンページのスクリーンショット"> |

https://deploy-preview-553--smarthr-design-system.netlify.app/communication/capture/kit/
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/221763294-6ef0df12-623b-48b8-b633-052f4c00dc29.png" width="300" alt="現在のキャプチャページのスクリーンショット"> | <img src="https://user-images.githubusercontent.com/7822534/221763378-05ad22fa-7ba5-4ba8-a84d-bb94525b7ec9.png" width="300" alt="PRプレビューでのキャプチャページのスクリーンショット"> |


### 個別に調整すべき？
- https://deploy-preview-553--smarthr-design-system.netlify.app/products/components/dropdown/dropdown-menu-button/#h2-1
- https://deploy-preview-553--smarthr-design-system.netlify.app/basics/illustration/user-co-other/#h2-0
- https://deploy-preview-553--smarthr-design-system.netlify.app/accessibility/test/202105/#h2-1
- https://deploy-preview-553--smarthr-design-system.netlify.app/accessibility/test/202112/#h2-2

いずれも、スマートフォン表示などでは幅が狭いほうが見やすいかもしれません。

上の2つは、マークダウンのテーブルなので、独自のスタイルを追加するには、HTMLで書くか、コンポーネント化する必要がありそうです。

下2つのアクセシビリティ試験結果のページは、SmartHR UIの`Th` `Td`コンポーネントですが、各セルにインラインで`style={{}}`を指定するか、tableにクラスを追加するか、でしょうか。
（MDX v2であれば、JSが書けるので `StyledTd = styled(Td)...`）のようなことができるかもしれませんが、v1なので。）
