### PR TITLE
コードブロックに横スクロールを追加

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -104,7 +104,9 @@ export const ComponentStory: FC<Props> = ({ name }) => {
         </>
       )}
       <CodeWrapper>
-        <CodeBlock className="tsx">{code}</CodeBlock>
+        <CodeBlock className="tsx" isStorybook={true}>
+          {code}
+        </CodeBlock>
       </CodeWrapper>
     </>
   )
@@ -142,11 +144,4 @@ const StoryLoader = styled(Loader)`
 const CodeWrapper = styled.div`
   position: relative;
   border: solid 1px ${CSS_COLOR.LIGHT_GREY_1};
-  > * {
-    margin: 0;
-    height: 300px;
-    border: 0;
-    overflow: scroll;
-    resize: vertical;
-  }
 `

--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -142,12 +142,11 @@ const StoryLoader = styled(Loader)`
 const CodeWrapper = styled.div`
   position: relative;
   border: solid 1px ${CSS_COLOR.LIGHT_GREY_1};
-  > pre {
+  > * {
     margin: 0;
     height: 300px;
     border: 0;
-    overflow: hidden;
-    overflow-y: scroll;
+    overflow: scroll;
     resize: vertical;
   }
 `

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -151,7 +151,8 @@ const LinkWrapper = styled.div`
   text-align: right;
 `
 
-const PreContainer = styled.pre`
+const PreContainer = styled.div`
+  font-family: monospace;
   position: relative;
   margin-block: 16px 0;
   padding: 2.75rem 1.5rem 1.5rem;

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -19,6 +19,7 @@ type Props = {
   children: string
   className?: Language
   editable?: boolean
+  isStorybook?: boolean
   withStyled?: boolean
   renderingComponent?: string
   componentTitle?: string
@@ -54,6 +55,7 @@ export const CodeBlock: FC<Props> = ({
   children,
   className,
   editable = false,
+  isStorybook = false,
   scope,
   withStyled = false,
   renderingComponent,
@@ -109,11 +111,13 @@ export const CodeBlock: FC<Props> = ({
                 {/* @ts-ignore -- LivePreviewの型定義が正しくないようなので、エラーを無視。https://github.com/FormidableLabs/react-live/pull/304 */}
                 <LivePreview Component={React.Fragment} />
               </ComponentPreview>
-              <StyledLiveEditorContainer>
-                <CopyButton text={code} />
-                {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
-                <LiveEditor padding={0} />
-              </StyledLiveEditorContainer>
+              <CodeWrapper>
+                <StyledLiveEditorContainer>
+                  <CopyButton text={code} />
+                  {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
+                  <LiveEditor padding={0} />
+                </StyledLiveEditorContainer>
+              </CodeWrapper>
               <LiveError />
             </LiveProvider>
           )}
@@ -125,18 +129,20 @@ export const CodeBlock: FC<Props> = ({
   return (
     <Highlight {...defaultProps} code={code} language={language as Language} theme={theme}>
       {({ style, tokens, getLineProps, getTokenProps }): ReactNode => (
-        <PreContainer>
-          <CopyButton text={code} />
-          <pre className={className} style={style}>
-            {tokens.map((line, i) => (
-              <div {...getLineProps({ line, key: i })} key={i}>
-                {line.map((token, key) => (
-                  <span {...getTokenProps({ token, key })} key={key} />
-                ))}
-              </div>
-            ))}
-          </pre>
-        </PreContainer>
+        <CodeWrapper>
+          <PreContainer isStorybook={isStorybook}>
+            <CopyButton text={code} />
+            <pre className={className} style={style}>
+              {tokens.map((line, i) => (
+                <div {...getLineProps({ line, key: i })} key={i}>
+                  {line.map((token, key) => (
+                    <span {...getTokenProps({ token, key })} key={key} />
+                  ))}
+                </div>
+              ))}
+            </pre>
+          </PreContainer>
+        </CodeWrapper>
       )}
     </Highlight>
   )
@@ -151,13 +157,17 @@ const LinkWrapper = styled.div`
   text-align: right;
 `
 
-const PreContainer = styled.div`
-  font-family: monospace;
+const CodeWrapper = styled.div`
   position: relative;
+`
+
+const PreContainer = styled.div<{ isStorybook?: boolean }>`
+  font-family: monospace;
   margin-block: 16px 0;
   padding: 2.75rem 1.5rem 1.5rem;
   border: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
   background-color: ${CSS_COLOR.SEMANTICS_COLUMN};
+  overflow-x: scroll;
 
   & > button {
     position: absolute;
@@ -165,10 +175,25 @@ const PreContainer = styled.div`
     right: 1.5rem;
   }
 
-  /* pre内のコードやLiveEditorのtextareaなどの文字を強制的に折り返すようにする */
+  /* preのデフォルトは display: block; で幅100%になるが、100%を超えられるように上書き(祖先要素には横スクロールを適用) */
+  pre {
+    width: fit-content;
+  }
+
+  /* LiveEditor内で preに white-space: pre-wrap; が適用されているため、文字を強制的に折り返すようにする */
   * {
     word-break: break-all;
   }
+
+  ${({ isStorybook }) =>
+    isStorybook &&
+    `
+      margin: 0;
+      height: 300px;
+      border: 0;
+      overflow: scroll;
+      resize: vertical;
+    `};
 `
 
 const StyledLiveEditorContainer = styled(PreContainer)`


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1204

## やったこと
コードブロックの内容が、記事表示エリアの幅より広い場合に横スクロールするようにしました。

### プレーンなコードブロック（編集できない）の場合
例：https://deploy-preview-556--smarthr-design-system.netlify.app/products/contents/help-center/review/#h3-2

コードの内容に長いテキストがある場合は横スクロールします。
その際、右上のコピーボタンは固定にしたいため、親階層に`<div>`をひとつ追加しています。
https://github.com/kufu/smarthr-design-system/blob/400b5a9ec5f2343cc81710e2ac1c735f1afb6d52/src/components/article/CodeBlock/CodeBlock.tsx#L132

### Storybookのコードの場合
例：https://deploy-preview-556--smarthr-design-system.netlify.app/products/components/accordion-panel/

基本的にはプレーンなコードブロックと同じです。以前は、`<ComponentStory>`コンポーネント側から、`> * {...}`のような形で`<CodeBlock>`内のCSSを上書きしていましたが、`isStorybook`というpropsを渡して`<CodeBlock>`内でCSSを出し分けるように変更しました。
https://github.com/kufu/smarthr-design-system/blob/400b5a9ec5f2343cc81710e2ac1c735f1afb6d52/src/components/article/CodeBlock/CodeBlock.tsx#L188-L196

### LiveEditorの場合
例：https://deploy-preview-556--smarthr-design-system.netlify.app/products/components/button/#h3-0

LiveEditorは、react-live内で`pre`要素に`white-space: pre-wrap;`が適用されており、コードが長い場合には折り返されるので、横スクロールが発生することはありません（＝このPRは表示に影響しません）。
`white-space: nowrap !important;`で上書きすることはできそうですが、コードを編集することを考えると、今のまま改行されていて良いような気もします。どうでしょうか？

### その他
表示に影響はありませんが、元のコードでは出力されるHTMLが`pre > pre > code`のようになっており、`pre`要素の入れ子はHTMLとして正しくないので、外側は`div`に変更しました（https://github.com/kufu/smarthr-design-system/pull/556/commits/00e9ba8650d9682291e3f1cf9857ddc7298d934f ）。

## 動作確認
https://deploy-preview-556--smarthr-design-system.netlify.app/products/contents/help-center/review/#h3-2
https://deploy-preview-556--smarthr-design-system.netlify.app/products/components/accordion-panel/
https://deploy-preview-556--smarthr-design-system.netlify.app/products/components/button/#h3-0

## キャプチャ

（差がわかりやすいようSP幅で表示しています）

**プレーンなコードブロック**
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/222362342-90e7531c-4430-46e6-bfaf-398047392891.png" width="390" alt="横スクロールしないスクリーンショット"> | <img src="https://user-images.githubusercontent.com/7822534/222362351-a94c5de3-2017-4d57-b3e0-adf8ebe1eb6a.png" width="390" alt="横スクロール実装後のスクリーンショット"> |

**Storybookのコードブロック**
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/222362937-66f13f79-f9e0-4099-adf6-ab7528e0c36e.png" width="390" alt="横スクロールしないスクリーンショット"> | <img src="https://user-images.githubusercontent.com/7822534/222362944-e3d90226-bc76-4d4e-9958-f31aa5a7b7ca.png" width="390" alt="横スクロール実装後のスクリーンショット"> |
