### PR TITLE
globパッケージのアップデートに対応

### DIFF
--- a/scripts/exportUIProps.ts
+++ b/scripts/exportUIProps.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises'
 import path from 'path'
-import glob from 'glob'
+
+import { glob } from 'glob'
 import * as docgen from 'react-docgen-typescript'
 
 const SRC_PATH = path.join(__dirname, '../node_modules/smarthr-ui/lib/**/**.d.ts')
@@ -11,40 +12,40 @@ const propsNameRegExp = /.*(?=Props|TypeLiteral$)/
 const IGNORE_DECLARATIONS = ['ElementProps', 'StyleProps']
 const excludeDeclarationsRegExp = new RegExp(`^(?!.*(${IGNORE_DECLARATIONS.join('|')})).*$`)
 
-glob(SRC_PATH, async (err, files) => {
-  if (err) {
+glob(SRC_PATH).then(
+  async (files) => {
+    const targets = files.filter((file) => excludeFilesRegExp.test(file))
+    const fileParser = docgen.withCompilerOptions(
+      { esModuleInterop: true },
+      {
+        shouldExtractValuesFromUnion: true,
+        propFilter: {
+          skipPropsWithName: ['as', 'id', 'inputMode', 'is'],
+        },
+      },
+    )
+    const docs = fileParser.parse(targets).map(({ props, ...other }) => {
+      const fileteredProps = Object.keys(props).flatMap((name) => {
+        const propItem = props[name]
+        const declarations = propItem.declarations
+
+        if (!declarations) {
+          return propItem
+        }
+
+        const declarationName = declarations[0].name
+        return propsNameRegExp.test(declarationName) && excludeDeclarationsRegExp.test(declarationName) ? propItem : []
+      })
+
+      return {
+        ...other,
+        props: fileteredProps,
+      }
+    })
+    await fs.writeFile('smarthr-ui-props.json', JSON.stringify(docs))
+  },
+  (err) => {
     console.error(err)
     process.exitCode = 1
-  }
-
-  const targets = files.filter((file) => excludeFilesRegExp.test(file))
-  const fileParser = docgen.withCompilerOptions(
-    { esModuleInterop: true },
-    {
-      shouldExtractValuesFromUnion: true,
-      propFilter: {
-        skipPropsWithName: ['as', 'id', 'inputMode', 'is'],
-      },
-    },
-  )
-  const docs = fileParser.parse(targets).map(({ props, ...other }) => {
-    const fileteredProps = Object.keys(props).flatMap((name) => {
-      const propItem = props[name]
-      const declarations = propItem.declarations
-
-      if (!declarations) {
-        return propItem
-      }
-
-      const declarationName = declarations[0].name
-      return propsNameRegExp.test(declarationName) && excludeDeclarationsRegExp.test(declarationName) ? propItem : []
-    })
-
-    return {
-      ...other,
-      props: fileteredProps,
-    }
-  })
-
-  await fs.writeFile('smarthr-ui-props.json', JSON.stringify(docs))
-})
+  },
+)

--- a/scripts/linkChecker.ts
+++ b/scripts/linkChecker.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import path from 'path'
 
-import glob from 'glob'
+import { glob } from 'glob'
 
 const CONTENT_PATH = path.join(__dirname, '../content/articles/**/*.mdx')
 const IMAGE_PATH = path.join(__dirname, '../content/articles/**/*.+(png|jpg|jpeg|gif)')
@@ -14,7 +14,7 @@ type LinkItem = { link: string; filePath: string; pagePath: string; lineNo: numb
 const collectExistLinks = async () => {
   const existPathList: string[] = []
   const linkList: LinkItem[] = []
-  for await (const file of await glob.sync(CONTENT_PATH)) {
+  for (const file of await glob(CONTENT_PATH)) {
     // ビルド後のパス
     const pagePath = file
       .replace(/^.*\/content\/articles/, '')
@@ -49,14 +49,14 @@ const collectExistLinks = async () => {
   }
 
   // 画像ファイル
-  for await (const file of await glob.sync(IMAGE_PATH)) {
+  for (const file of await glob(IMAGE_PATH)) {
     //ビルド後のパスを配列に入れておく
     const filePath = file.replace(/^.*\/content\/articles/, '')
     existPathList.push(filePath)
   }
 
   // ダウンロード用のファイル
-  for await (const file of await glob.sync(DOWNLOAD_PATH)) {
+  for (const file of await glob(DOWNLOAD_PATH)) {
     //ビルド後のパスを配列に入れておく
     const filePath = file.replace(/^.*\/static/, '')
     existPathList.push(filePath)


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1210

## やったこと
globパッケージを使用している、以下の2つのスクリプトを修正し、エラーなく実行できることを確認しました。
- /scripts/exportUIProps.ts
- /scripts/linkChecker.ts

具体的には、globのAPIがcallback関数を指定するのではなくPromiseを返す実装に変わったので、その対応をしました。

## やらなかったこと
`exportUIProps.ts`を実行すると、`smarthr-ui-props.json`が書き出されますが、コミットには含めていません。
- ローカルのファイルパスなどを含むため、大量のdiffが出てしまうので。
- propsの一覧などは同じ内容が書き出されるので、ビルド後のComponentPropsTableには変化がないことを確認しました。

含めたほうが良ければ追加します。

## 動作確認
```
yarn export:ui-props
npx ts-node scripts/linkChecker.ts
```

## キャプチャ
見た目上の変化はありません。