### PR TITLE
TableWrapperにセルの幅指定のpropsを追加

### DIFF
--- a/content/articles/accessibility/test/202105/index.mdx
+++ b/content/articles/accessibility/test/202105/index.mdx
@@ -60,7 +60,7 @@ import { TableWrapper } from '@Components/contents/shared/TableWrapper'
 
 達成基準のリンクは<abbr title="Web Contents Accessibility Guidelines">WCAG</abbr> 2.0解説書へのリンクです。
 
-<TableWrapper>
+<TableWrapper type="narrow">
   <Table>
     <thead>
       <tr>

--- a/content/articles/accessibility/test/202112/index.mdx
+++ b/content/articles/accessibility/test/202112/index.mdx
@@ -67,7 +67,7 @@ import { TableWrapper } from '@Components/contents/shared/TableWrapper'
 
 達成基準のリンクは<abbr title="Web Contents Accessibility Guidelines">WCAG</abbr> 2.0解説書へのリンクです。
 
-<TableWrapper>
+<TableWrapper type="narrow">
   <Table>
     <thead>
       <tr>

--- a/src/components/contents/shared/TableWrapper.tsx
+++ b/src/components/contents/shared/TableWrapper.tsx
@@ -1,15 +1,26 @@
 import React, { FC } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 type Props = {
+  type?: 'narrow' | ''
   mdTable?: boolean
   children: React.ReactNode
 }
 
-export const TableWrapper: FC<Props> = ({ mdTable = false, children }) => {
-  return <Wrapper>{mdTable ? <table>{children}</table> : children}</Wrapper>
+export const TableWrapper: FC<Props> = ({ type = '', mdTable = false, children }) => {
+  return <Wrapper $type={type}>{mdTable ? <table>{children}</table> : children}</Wrapper>
 }
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{
+  $type: string
+}>`
   overflow-x: auto;
+  ${({ $type }) =>
+    $type === 'narrow' &&
+    css`
+      table th,
+      table td {
+        min-width: 2em;
+      }
+    `}
 `


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1209

## やったこと
アクセシビリティ試験結果のテーブルは、セルの中身が「A」など短いテキストの列があり、グローバルに指定している`min-width: 7em;`（5em+左右paddingが1emずつ）より幅を狭めたいので、個別のスタイルを適用しました。

具体的には、テーブルの親要素になる`TableWrapper`コンポーネントに、`type="narrow"`というpropsを渡せるようにして、`narrow`が指定された場合は、内包するテーブルの`th,td`に`min-width: 2em;`を指定しています。

## やらなかったこと
マークダウン記法のテーブルにも、セルの中身が短いテキストものがあり、同様に幅指定を縮めたいところなのですが、マークダウンではpropsが渡せないため、対応できていません。

グローバルな指定をSP表示で狭めると、今度は`min-width: 7em;`の指定で改善していたページ（例えば：https://deploy-preview-553--smarthr-design-system.netlify.app/basics/icons/ ）の表示が元に戻ってしまい、悩ましいです。

## 動作確認
https://deploy-preview-580--smarthr-design-system.netlify.app/accessibility/test/202105/
https://deploy-preview-580--smarthr-design-system.netlify.app/accessibility/test/202112/

## キャプチャ
|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/225804006-9b133ddd-7584-4799-b711-7b930b871efb.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/225804315-28c87163-badf-4f7b-a2c3-13f7864c5042.png" width="350" alt> |
