### PR TITLE
ComponentStory内のリンク・プルダウンの不具合を修正

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -153,7 +153,7 @@ export const ComponentStory: FC<Props> = ({ name }) => {
       <StyledUl>
         <li>
           <TextLink
-            href={`https://${getCommitHash()}--${SHRUI_CHROMATIC_ID}.chromatic.com/?${storyData.groupPath}`}
+            href={`https://${getCommitHash()}--${SHRUI_CHROMATIC_ID}.chromatic.com/?path=/story/${storyData.groupPath}`}
             target="_blank"
           >
             Storybook

--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -144,8 +144,16 @@ export const ComponentStory: FC<Props> = ({ name }) => {
           value={displayVersion}
           hasBlank={true}
           //存在しないバージョンでエラーになるの場合は「-」を表示する（空白文字だとデフォルトの「選択してください」になるため）
+          //プルダウンに存在しないが、コード表示はできるバージョン（例：v25.0.0）の場合は、そのバージョンを表示する
           decorators={{
-            blankLabel: () => (showError || !isStoryLoaded ? '-' : `v${displayVersion}`),
+            blankLabel: () =>
+              showError ||
+              !isStoryLoaded ||
+              versionOptions.find((option) => {
+                return option.value === displayVersion
+              })
+                ? '-'
+                : `v${displayVersion}`,
           }}
           error={showError}
         />


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1193

## やったこと
`/products/components/` 以下のページにSmartHR UIのバージョン切り替え機能を追加しましたが、以下の実装・考慮漏れがあったので修正しました。

- Storybookへのリンク（iframeではない）URLの修正
- プルダウンに元からあるバージョンを表示中は、`blankLabel`はバージョン名ではなく「-」にする（重複してしまうので）

## 動作確認
https://deploy-preview-582--smarthr-design-system.netlify.app/products/components/tooltip/
https://deploy-preview-582--smarthr-design-system.netlify.app/products/components/tooltip/?v=25.0.0

※存在しないバージョン（またはでたらめな文字列など）の場合はこれまでどおり「-」、Chromaticに存在しないがコードは存在するバージョン（例えば「v25.0.0」）の場合もこれまでどおりそのバージョンを表示します。

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/225823417-3f1f7a74-1a17-4861-8e57-35d541b641a9.png" alt width="350"> | <img src="https://user-images.githubusercontent.com/7822534/225823291-b9ff1aa9-4416-4bd3-b5a5-dcc9b23957c6.png" alt width="350"> |
