### PR TITLE
TSのバージョンアップに伴い、CDNのパスを修正

### DIFF
--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -91,7 +91,7 @@ export const CodeBlock: FC<Props> = ({
         )}
         <ThemeProvider theme={smarthrTheme}>
           {/* ライブエディタ内のコードのトランスパイルに使用するTS（容量が大きいためCDNを利用） */}
-          <Script src="https://unpkg.com/typescript@latest/lib/typescriptServices.js" onLoad={() => setTsLoaded(true)} />
+          <Script src="https://unpkg.com/typescript@latest/lib/typescript.js" onLoad={() => setTsLoaded(true)} />
           {tsLoaded && (
             <LiveProvider
               code={code}


### PR DESCRIPTION
## 課題・背景
LiveEditorでコードとコンポーネントのプレビューを表示するページがありますが、CDNで読み込んでいるTypeScriptのJSのパスが変わったため、レンダリングできていませんでした。（TS5のリリースが3日ほど前なので、おそらくそれ以降の現象と思われます）

例：
https://smarthr.design/products/components/button/#h2-0
https://smarthr.design/products/design-patterns/select-company-account/#h2-2

<img src="https://user-images.githubusercontent.com/7822534/226310543-f6684d42-8e47-4304-9fd0-007e28e465c7.png" width="650" alt>


## やったこと
取り急ぎ、TS5でも存在しているファイル名に変更しました。

## やらなかったこと
応急処置的な修正なので、パス内の `@latest`をバージョン固定にする、ソースを`public`ディレクトリに入れてこちら側でホスティングするなど、別の方法を検討したほうが良いかもしれません。
（`import`してしまうと、Gatsbyのバンドルサイズが跳ね上がるため、必要なページのみクライアントで読み込みたいです。）

## 動作確認
https://deploy-preview-591--smarthr-design-system.netlify.app/products/components/button/#h2-0
https://deploy-preview-591--smarthr-design-system.netlify.app/products/design-patterns/select-company-account/#h2-2

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/226309936-54e84fa8-b953-46f2-a79c-f72fbaa1d1ad.png" width="300" alt> | <img src="https://user-images.githubusercontent.com/7822534/226310211-2af001d1-fb2f-482c-a825-07c08df23c52.png" width="300" alt> |
