### PR TITLE
ComponentStoryコンポーネントのレイアウト・スタイル調整

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -13,7 +13,6 @@ import {
   TabBar,
   TabItem,
   TextLink,
-  defaultColor,
 } from 'smarthr-ui'
 import packageInfo from 'smarthr-ui/package.json'
 import styled from 'styled-components'
@@ -144,8 +143,8 @@ export const ComponentStory: FC<Props> = ({ name }) => {
   }
 
   return (
-    <>
-      <StyledCluster align="center" justify="space-between" gap={1}>
+    <StoryWrapper>
+      <Cluster align="center" justify="space-between" gap={1}>
         <Cluster align="center" as="label">
           <span>SmartHR UI</span>
           <Select
@@ -189,7 +188,7 @@ export const ComponentStory: FC<Props> = ({ name }) => {
             GitHub
           </AnchorButton>
         </Cluster>
-      </StyledCluster>
+      </Cluster>
       {showError && (
         <ErrorPanel title="指定されたバージョンのコンポーネント情報を取得できませんでした" type="error" togglable={false}>
           通信状況に問題が発生しているか、次のような理由が考えられます。
@@ -247,14 +246,14 @@ export const ComponentStory: FC<Props> = ({ name }) => {
           </CodeWrapper>
         </>
       )}
-    </>
+    </StoryWrapper>
   )
 }
 
-const StyledCluster = styled(Cluster)`
+const StoryWrapper = styled.div`
   margin-block: 48px 0;
   padding: 16px 24px;
-  background-color: ${defaultColor.COLUMN};
+  background-color: ${CSS_COLOR.LIGHT_GREY_3};
 `
 
 const ErrorPanel = styled(InformationPanel)`
@@ -281,6 +280,7 @@ const StoryIframe = styled.iframe`
   width: 100%;
   height: 100%;
   border: 0;
+  background-color: ${CSS_COLOR.WHITE};
 `
 
 const StoryLoader = styled(Loader)`

--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -3,7 +3,18 @@ import { CSS_COLOR } from '@Constants/style'
 import { useLocation } from '@reach/router'
 import { graphql, navigate, useStaticQuery } from 'gatsby'
 import React, { FC, useCallback, useEffect, useState } from 'react'
-import { Cluster, InformationPanel, Loader, Select, TabBar, TabItem, TextLink } from 'smarthr-ui'
+import {
+  AnchorButton,
+  Cluster,
+  FaExternalLinkAltIcon,
+  InformationPanel,
+  Loader,
+  Select,
+  TabBar,
+  TabItem,
+  TextLink,
+  defaultColor,
+} from 'smarthr-ui'
 import packageInfo from 'smarthr-ui/package.json'
 import styled from 'styled-components'
 
@@ -134,45 +145,51 @@ export const ComponentStory: FC<Props> = ({ name }) => {
 
   return (
     <>
-      <StyledCluster align="center" as="label">
-        <span>SmartHR UI</span>
-        <Select
-          width="170px"
-          name="version"
-          options={versionOptions}
-          onChangeValue={onChangeVersion}
-          value={displayVersion}
-          hasBlank={true}
-          //存在しないバージョンでエラーになるの場合は「-」を表示する（空白文字だとデフォルトの「選択してください」になるため）
-          //プルダウンに存在しないが、コード表示はできるバージョン（例：v25.0.0）の場合は、そのバージョンを表示する
-          decorators={{
-            blankLabel: () =>
-              showError ||
-              !isStoryLoaded ||
-              versionOptions.find((option) => {
-                return option.value === displayVersion
-              })
-                ? '-'
-                : `v${displayVersion}`,
-          }}
-          error={showError}
-        />
-      </StyledCluster>
-      <StyledUl>
-        <li>
-          <TextLink
+      <StyledCluster align="center" justify="space-between" gap={1}>
+        <Cluster align="center" as="label">
+          <span>SmartHR UI</span>
+          <Select
+            width="9rem"
+            name="version"
+            size="s"
+            options={versionOptions}
+            onChangeValue={onChangeVersion}
+            value={displayVersion}
+            hasBlank={true}
+            //存在しないバージョンでエラーになるの場合は「-」を表示する（空白文字だとデフォルトの「選択してください」になるため）
+            //プルダウンに存在しないが、コード表示はできるバージョン（例：v25.0.0）の場合は、そのバージョンを表示する
+            decorators={{
+              blankLabel: () =>
+                showError ||
+                !isStoryLoaded ||
+                versionOptions.find((option) => {
+                  return option.value === displayVersion
+                })
+                  ? '-'
+                  : `v${displayVersion}`,
+            }}
+            error={showError}
+          />
+        </Cluster>
+        <Cluster>
+          <AnchorButton
             href={`https://${getCommitHash()}--${SHRUI_CHROMATIC_ID}.chromatic.com/?path=/story/${storyData.groupPath}`}
             target="_blank"
+            size="s"
+            suffix={<FaExternalLinkAltIcon />}
           >
             Storybook
-          </TextLink>
-        </li>
-        <li>
-          <TextLink href={`${SHRUI_GITHUB_PATH}v${displayVersion}/src/components/${name}`} target="_blank">
-            ソースコード（GitHub）
-          </TextLink>
-        </li>
-      </StyledUl>
+          </AnchorButton>
+          <AnchorButton
+            href={`${SHRUI_GITHUB_PATH}v${displayVersion}/src/components/${name}`}
+            target="_blank"
+            size="s"
+            suffix={<FaExternalLinkAltIcon />}
+          >
+            GitHub
+          </AnchorButton>
+        </Cluster>
+      </StyledCluster>
       {showError && (
         <ErrorPanel title="指定されたバージョンのコンポーネント情報を取得できませんでした" type="error" togglable={false}>
           通信状況に問題が発生しているか、次のような理由が考えられます。
@@ -235,16 +252,9 @@ export const ComponentStory: FC<Props> = ({ name }) => {
 }
 
 const StyledCluster = styled(Cluster)`
-  margin-block: 20px;
-`
-
-const StyledUl = styled.ul`
-  list-style: none;
-  margin-block: 16px 0;
-  padding: 0;
-  > li {
-    line-height: 2;
-  }
+  margin-block: 48px 0;
+  padding: 16px 24px;
+  background-color: ${defaultColor.COLUMN};
 `
 
 const ErrorPanel = styled(InformationPanel)`
@@ -256,7 +266,7 @@ const ErrorPanel = styled(InformationPanel)`
 `
 
 const Tab = styled(TabBar)`
-  margin-block: 48px 0;
+  margin-block: 16px 0;
   flex-wrap: wrap;
   gap: 4px 0;
 `

--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -265,7 +265,7 @@ const ErrorPanel = styled(InformationPanel)`
 `
 
 const Tab = styled(TabBar)`
-  margin-block: 16px 0;
+  margin-block: 24px 0;
   flex-wrap: wrap;
   gap: 4px 0;
 `

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -127,7 +127,7 @@ export const CodeBlock: FC<Props> = ({
   }
 
   return (
-    <Highlight {...defaultProps} code={code} language={language as Language} theme={theme}>
+    <Highlight {...defaultProps} code={code} language={language as Language} theme={isStorybook ? vscode : theme}>
       {({ style, tokens, getLineProps, getTokenProps }): ReactNode => (
         <CodeWrapper>
           <PreContainer isStorybook={isStorybook}>
@@ -164,9 +164,8 @@ const CodeWrapper = styled.div`
 const PreContainer = styled.div<{ isStorybook?: boolean }>`
   font-family: monospace;
   margin-block: 16px 0;
-  padding: 2.75rem 1.5rem 1.5rem;
   border: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
-  background-color: ${CSS_COLOR.SEMANTICS_COLUMN};
+  background-color: ${CSS_COLOR.LIGHT_GREY_3};
   overflow-x: scroll;
 
   & > button {
@@ -177,7 +176,10 @@ const PreContainer = styled.div<{ isStorybook?: boolean }>`
 
   /* preのデフォルトは display: block; で幅100%になるが、100%を超えられるように上書き(祖先要素には横スクロールを適用) */
   pre {
-    width: fit-content;
+    width: max-content;
+    margin: 0;
+    padding: 2.75rem 1.5rem 1.5rem;
+    box-sizing: border-box;
   }
 
   /* LiveEditor内で preに white-space: pre-wrap; が適用されているため、文字を強制的に折り返すようにする */
@@ -199,7 +201,13 @@ const PreContainer = styled.div<{ isStorybook?: boolean }>`
 const StyledLiveEditorContainer = styled(PreContainer)`
   overflow: auto;
   margin: 0;
+
+  /* LiveEditor内のpreにはpaddingの一括指定しかできないので親要素で設定 */
+  padding: 2.75rem 1.5rem 1.5rem;
   border-width: 0 1px 1px;
   background-color: ${CSS_COLOR.TEXT_BLACK};
   max-height: 40em;
+  pre {
+    width: fit-content;
+  }
 `

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -177,6 +177,7 @@ const PreContainer = styled.div<{ isStorybook?: boolean }>`
   /* preのデフォルトは display: block; で幅100%になるが、100%を超えられるように上書き(祖先要素には横スクロールを適用) */
   pre {
     width: max-content;
+    min-width: 100%;
     margin: 0;
     padding: 2.75rem 1.5rem 1.5rem;
     box-sizing: border-box;


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1212

## やったこと
バージョン切り替えやリンク部分は https://github.com/kufu/smarthr-design-system/pull/581 のdraftのコミットを持ってきました（コンフリクトがあり一部編集しています）

また、背景色の追加と、コードブロックのカラーテーマをダークに変更しました。
その際、以下の調整をしています。
- iframe部分の背景色を `#FFF`に（設定しないと周囲と同じライトグレーになるため）
- コードブロック部分のpaddingなどを調整（ダークテーマにしても端が白くなってしまうなどしたため）

## 動作確認
https://deploy-preview-592--smarthr-design-system.netlify.app/products/components/accordion-panel/

`<CodeBlock>`コンポーネントを使用しているが、今回の調整対象ではない箇所（CSSが影響を受けているのでデグレがないか確認）：
- LiveEditor（元からダークテーマ）
  - https://deploy-preview-592--smarthr-design-system.netlify.app/products/design-patterns/upward-navigation/#h2-1
- mdのコードフェンス記法
  - https://deploy-preview-592--smarthr-design-system.netlify.app/products/design-process/review/#h3-5

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/226775845-83359bc8-6655-4920-ae91-774fc57f4eab.png" alt width="350"> | <img src="https://user-images.githubusercontent.com/7822534/226775755-56e921a9-ffc8-40a0-ac95-39b06177cb03.png" alt width="350"> |