### PR TITLE
SmartHR Mag.のサービス画面キャプチャを追加

### DIFF
--- a/content/articles/communication/capture/service-capture.mdx
+++ b/content/articles/communication/capture/service-capture.mdx
@@ -227,5 +227,10 @@ PARK onlineを代表する画面です。
 </Grid>
 
 
+## SmartHR Mag.
+
+[SmartHR Mag.のキャプチャ | Google ドライブ](https://drive.google.com/drive/u/1/folders/16v9NMGRSYBzPS0mSMYhlo2Wmqv6gA9FF)
+
+
 ## ライセンス情報
 本ページ内のコンテンツについては、[画面キャプチャのライセンス情報](/communication/capture/#h2-3)を参照のうえご利用ください。

--- a/content/articles/communication/capture/service-capture.mdx
+++ b/content/articles/communication/capture/service-capture.mdx
@@ -229,6 +229,7 @@ PARK onlineを代表する画面です。
 
 ## SmartHR Mag.
 ### トップページ
+
 SmartHR Mag.を代表する画面です。
 
 <a href="https://drive.google.com/drive/u/1/folders/16v9NMGRSYBzPS0mSMYhlo2Wmqv6gA9FF" target="_blank">SmartHR Mag.のキャプチャ | Google ドライブ</a>

--- a/content/articles/communication/capture/service-capture.mdx
+++ b/content/articles/communication/capture/service-capture.mdx
@@ -228,6 +228,8 @@ PARK onlineを代表する画面です。
 
 
 ## SmartHR Mag.
+### トップページ
+SmartHR Mag.を代表する画面です。
 
 <a href="https://drive.google.com/drive/u/1/folders/16v9NMGRSYBzPS0mSMYhlo2Wmqv6gA9FF" target="_blank">SmartHR Mag.のキャプチャ | Google ドライブ</a>
 

--- a/content/articles/communication/capture/service-capture.mdx
+++ b/content/articles/communication/capture/service-capture.mdx
@@ -229,7 +229,7 @@ PARK onlineを代表する画面です。
 
 ## SmartHR Mag.
 
-[SmartHR Mag.のキャプチャ | Google ドライブ](https://drive.google.com/drive/u/1/folders/16v9NMGRSYBzPS0mSMYhlo2Wmqv6gA9FF)
+<a href="https://drive.google.com/drive/u/1/folders/16v9NMGRSYBzPS0mSMYhlo2Wmqv6gA9FF" target="_blank">SmartHR Mag.のキャプチャ | Google ドライブ</a>
 
 
 ## ライセンス情報


### PR DESCRIPTION
## 課題・背景
SmartHR Mag.のサービス画面キャプチャを追加しました！
https://github.com/kufu/smarthr-design-system-issues/issues/1215

## やったこと
- サービス画面キャプチャページの下部にSmartHR Mag.のセクションを追加
- Google ドライブのリンクを設置

## やらなかったこと
とくになし

## 動作確認
https://deploy-preview-594--smarthr-design-system.netlify.app/communication/capture/service-capture/#h2-4

## キャプチャ
|Before|After|
| --- | --- |
| ![スクリーンショット 2023-03-24 18 58 24](https://user-images.githubusercontent.com/101125529/227491158-87975a4a-a887-4ea1-823c-81fd6570228a.png) | ![スクリーンショット 2023-03-24 19 20 59](https://user-images.githubusercontent.com/101125529/227495454-ce907320-42f7-4fcd-a73d-d30fda9546e2.png) |
