### PR TITLE
ウェブアクセシビリティ方針を新しいミッションに準じたものに

### DIFF
--- a/content/articles/accessibility/policy.mdx
+++ b/content/articles/accessibility/policy.mdx
@@ -1,22 +1,22 @@
 ---
 title: 'ウェブアクセシビリティ方針'
-description: 'SmartHRのウェブアクセシビリティ方針です。社会の非合理を作り出さず、一人でも多くの人が価値ある仕事に取り組めるようなプロダクトを目標にしています。'
+description: 'SmartHRのウェブアクセシビリティ方針です。真に「誰もが」その人らしく働くことを実現するプロダクトを目標にしています。'
 order: 1
 ---
 
 import { Table, Text, Td, Th } from 'smarthr-ui'
 
-import { TableWrapper } from '@Components/contents/shared/TableWrapper'
+## より良く働きたいすべての人のために
 
-## 社会の非合理をつくりださない
+SmartHRは「[well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会を作る。](https://smarthr.co.jp/about/)」というミッションを掲げ、働くすべての人を後押しするプラットフォームをつくっています。
 
-SmartHRは「[社会の非合理を、ハックする。](https://smarthr.co.jp/about/)」というミッションを掲げ、働くすべての人を後押しするプラットフォームをつくっています。
+このミッションの実現には、真に「誰もが」SmartHRにアクセスできなければなりません。
 
-そのため働く人の権利や仕事の楽しさについて考え、1人でも多くの人が価値ある仕事に取り組めるようなプロダクトを目標にアクセシビリティの向上に取り組んでいます。
+そのため、SmartHRはアクセシビリティの向上に取り組んでいます。
 
 <!-- textlint-disable -->
 
-具体的には「JIS X 8341-3:2016 高齢者・障害者等配慮設計指針－情報通信における機器、ソフトウェア及びサービス－第3部：ウェブコンテンツ」、に加えて「Web Content Accessibility Guidelines 2.1」に対応することを目標としています。
+具体的には「JIS X 8341-3:2016 高齢者・障害者等配慮設計指針－情報通信における機器、ソフトウェア及びサービス－第3部：ウェブコンテンツ」、に加えて「Web Content Accessibility Guidelines 2.1」に対応すること、またさまざまな特性を持つユーザーが実際に利用できることを目標としています。
 
 <!-- textlint-enable -->
 
@@ -65,45 +65,43 @@ SmartHRは「[社会の非合理を、ハックする。](https://smarthr.co.jp/
 
 ### SmartHR UIのスケジュール
 
-<TableWrapper>
-  <Table>
-    <thead>
-      <tr>
-        <Th>
-          時期
-        </Th>
-        <Th>
-          目標
-        </Th>
-        <Th>
-          結果
-        </Th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <Td> <time datatime="2021-06" style="white-space: nowrap">2021年6月</time> </Td>
-        <Td> レベルA一部準拠 <div><small>開発中のコンポーネント、または試験開始時点で完成していなかったコンポーネントをのぞく</small></div> </Td>
-        <Td> レベルA一部準拠 </Td>
-      </tr>
-      <tr>
-        <Td> <time datatime="2021-12" style="white-space: nowrap">2021年12月</time> </Td>
-        <Td> レベルA準拠 </Td>
-        <Td> レベルA一部準拠 </Td>
-      </tr>
-      <tr>
-        <Td> <time datatime="2022-06" style="white-space: nowrap">2022年6月</time> </Td>
-        <Td> JIS X 8341-3:2016 レベルAと追加する達成基準に準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
-        <Td></Td>
-      </tr>
-      <tr>
-        <Td> <time datatime="2022-12" style="white-space: nowrap">2022年12月</time> </Td>
-        <Td> JIS X 8341-3:2016 レベルAAに準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
-        <Td></Td>
-      </tr>
-    </tbody>
-  </Table>
-</TableWrapper>
+<Table>
+  <thead>
+    <tr>
+      <Th>
+        時期
+      </Th>
+      <Th>
+        目標
+      </Th>
+      <Th>
+        結果
+      </Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td> <time datatime="2021-06" style="white-space: nowrap">2021年6月</time> </Td>
+      <Td> レベルA一部準拠 <div><small>開発中のコンポーネント、または試験開始時点で完成していなかったコンポーネントをのぞく</small></div> </Td>
+      <Td> レベルA一部準拠 </Td>
+    </tr>
+    <tr>
+      <Td> <time datatime="2021-12" style="white-space: nowrap">2021年12月</time> </Td>
+      <Td> レベルA準拠 </Td>
+      <Td> レベルA一部準拠 </Td>
+    </tr>
+    <tr>
+      <Td> <time datatime="2022-06" style="white-space: nowrap">2022年6月</time> </Td>
+      <Td> JIS X 8341-3:2016 レベルAと追加する達成基準に準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
+      <Td></Td>
+    </tr>
+    <tr>
+      <Td> <time datatime="2022-12" style="white-space: nowrap">2022年12月</time> </Td>
+      <Td> JIS X 8341-3:2016 レベルAAに準拠、およびWCAG 2.1 レベルAの達成基準に適合 </Td>
+      <Td></Td>
+    </tr>
+  </tbody>
+</Table>
 
 ### SmartHR 製品の目標とスケジュール
 
@@ -113,46 +111,44 @@ SmartHRは「[社会の非合理を、ハックする。](https://smarthr.co.jp/
 
 ## 試験結果
 
-<TableWrapper>
-  <Table>
-    <thead>
-      <tr>
-        <Th>試験年月</Th>
-        <Th>試験対象</Th>
-        <Th>達成した等級</Th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <Td>
-          <a href="../test/202105/">
-            <time datatime="2021-05" style={{ whiteSpace: "no-wrap" }}>2021年5月</time>
-          </a>
-        </Td>
-        <Td>
-          SmartHR UIのコンポーネント
-          <small>（開発中のコンポーネントを除く）</small>
-        </Td>
-        <Td>
-          レベルA一部準拠
-        </Td>
-      </tr>
-      <tr>
-        <Td>
-          <a href="../test/202112/">
-            <time datatime="2021-12" style={{ whiteSpace: "no-wrap" }}>2021年12月</time>
-          </a>
-        </Td>
-        <Td>
-          SmartHR UIのコンポーネント
-        </Td>
-        <Td>
-          レベルA一部準拠
-        </Td>
-      </tr>
-    </tbody>
-  </Table>
-</TableWrapper>
+<Table>
+  <thead>
+    <tr>
+      <Th>試験年月</Th>
+      <Th>試験対象</Th>
+      <Th>達成した等級</Th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <Td>
+        <a href="../test/202105/">
+          <time datatime="2021-05" style={{ whiteSpace: "no-wrap" }}>2021年5月</time>
+        </a>
+      </Td>
+      <Td>
+        SmartHR UIのコンポーネント
+        <small>（開発中のコンポーネントを除く）</small>
+      </Td>
+      <Td>
+        レベルA一部準拠
+      </Td>
+    </tr>
+    <tr>
+      <Td>
+        <a href="../test/202112/">
+          <time datatime="2021-12" style={{ whiteSpace: "no-wrap" }}>2021年12月</time>
+        </a>
+      </Td>
+      <Td>
+        SmartHR UIのコンポーネント
+      </Td>
+      <Td>
+        レベルA一部準拠
+      </Td>
+    </tr>
+  </tbody>
+</Table>
 
 ## 問い合わせ先
 


### PR DESCRIPTION
## 課題・背景

ウェブアクセシビリティ方針のページで参照してたコーポレートミッションが古かったので、新しいミッションを参照しつつ、方針も新しくした

## やったこと

- あたらしいミッションを受けてリライト
- 具体的に目指すものに、「さまざまな特性を持つユーザーが実際に利用できること」を追加

## 動作確認

- ファイルでの確認で十分だよ。