### PR TITLE
トップページのナビゲーションのレイアウトを修正

### DIFF
--- a/src/components/index/ContentNavigation/Category.tsx
+++ b/src/components/index/ContentNavigation/Category.tsx
@@ -133,7 +133,8 @@ const ThumbnailImageWrapper = styled.div`
 `
 
 const NavigationLinks = styled.ul`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 24px;
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## 課題・背景
トップページのナビゲーションで、3列になっている部分がありますが、画面幅が1300px以下あたりからリンクが3つある場合と1つの場合で画像のサイズがずれてきてしまいます。
以前はどのカテゴリも3つ画像があったようですが、今は2つや1つの箇所もあるので、調整しました。

## やったこと
トップページの、各カテゴリへのリンクが並んでいるナビゲーション部分のCSSを変更しました。`flex`→ `grid`にして、常に3カラム分を確保しています。

## 動作確認
https://deploy-preview-611--smarthr-design-system.netlify.app/

## キャプチャ
画面幅1200pxでのキャプチャです

|Before|After|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7822534/229739300-7c4c8fb9-6c44-422d-9dc9-7389f12bebbf.png" width="350" alt> | <img src="https://user-images.githubusercontent.com/7822534/229739362-9e7d19bf-e3f5-4f38-bd1e-7a3fbfa49539.png" width="350" alt> |
