### PR TITLE
Propsテーブルのレイアウトの改修

### DIFF
--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -74,7 +74,7 @@ export const ComponentPropsTable: FC<Props> = ({ name, showTitle }) => {
             <PropContent key={prop.name}>
               <PropName>
                 {prop.name}
-                {prop.required && <RequiredMark>*</RequiredMark>}
+                {prop.required && <RequiredMark>必須</RequiredMark>}
               </PropName>
               <PropTypes>
                 {prop.type.name === 'enum' ? (
@@ -116,7 +116,12 @@ const PropName = styled.div`
   font-weight: bold;
 `
 const RequiredMark = styled.span`
+  margin-left: 4px;
+  font-size: ${CSS_FONT_SIZE.PX_12};
   color: #bb1212;
+  &::before {
+    content: '*';
+  }
 `
 const PropTypes = styled.div`
   display: flex;

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -134,4 +134,8 @@ const TypeTag = styled.span<{ color: string }>`
   border-radius: 8px;
   background-color: ${(props) => props.color};
 `
-const PropDescription = styled.div``
+const PropDescription = styled.div`
+  p {
+    margin-block-start: 0;
+  }
+`

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -101,16 +101,12 @@ export const ComponentPropsTable: FC<Props> = ({ name, showTitle }) => {
 
 const Wrapper = styled.div`
   border: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
-  border-radius: 4px;
   margin-top: 20px;
 `
 const PropContent = styled.div`
   display: grid;
   gap: 8px;
   padding: 8px 24px;
-  &:last-child {
-    border-bottom-left-radius: 4px;
-  }
   &:not(:last-child) {
     border-bottom: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
   }

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -62,40 +62,40 @@ export const ComponentPropsTable: FC<Props> = ({ name, showTitle }) => {
     return <Text as={'p'}>Propsは設定されていません。</Text>
   }
   return (
-    <Wrapper>
+    <>
       {showTitle && (
-        <PropTitle>
-          <FragmentTitle tag="h3" id={fragmentId(name)}>
-            {name} props
-          </FragmentTitle>
-        </PropTitle>
+        <FragmentTitle tag="h3" id={fragmentId(name)}>
+          {name} props
+        </FragmentTitle>
       )}
-      <>
-        {propsData.map((prop) => (
-          <PropContent key={prop.name}>
-            <PropName>
-              {prop.name}
-              {prop.required && <RequiredMark>*</RequiredMark>}
-            </PropName>
-            <PropTypes>
-              {prop.type.name === 'enum' ? (
-                prop.type.value &&
-                prop.type.value.map((item, y) => {
-                  return (
-                    <TypeTag key={y} color={pickTypeColor(item.value)}>
-                      {item.value}
-                    </TypeTag>
-                  )
-                })
-              ) : (
-                <TypeTag color={pickTypeColor(prop.type.name)}>{prop.type.name}</TypeTag>
-              )}
-            </PropTypes>
-            <PropDescription dangerouslySetInnerHTML={{ __html: marked.parse(prop.description) }} />
-          </PropContent>
-        ))}
-      </>
-    </Wrapper>
+      <Wrapper>
+        <>
+          {propsData.map((prop) => (
+            <PropContent key={prop.name}>
+              <PropName>
+                {prop.name}
+                {prop.required && <RequiredMark>*</RequiredMark>}
+              </PropName>
+              <PropTypes>
+                {prop.type.name === 'enum' ? (
+                  prop.type.value &&
+                  prop.type.value.map((item, y) => {
+                    return (
+                      <TypeTag key={y} color={pickTypeColor(item.value)}>
+                        {item.value}
+                      </TypeTag>
+                    )
+                  })
+                ) : (
+                  <TypeTag color={pickTypeColor(prop.type.name)}>{prop.type.name}</TypeTag>
+                )}
+              </PropTypes>
+              <PropDescription dangerouslySetInnerHTML={{ __html: marked.parse(prop.description) }} />
+            </PropContent>
+          ))}
+        </>
+      </Wrapper>
+    </>
   )
 }
 
@@ -104,19 +104,10 @@ const Wrapper = styled.div`
   border-radius: 4px;
   margin-top: 20px;
 `
-const PropTitle = styled.div`
-  border-top-left-radius: 4px;
-  padding: 8px 32px;
-  background: ${CSS_COLOR.LIGHT_GREY_2};
-  && h3 {
-    margin: 0;
-    font-size: 18px;
-  }
-`
 const PropContent = styled.div`
   display: grid;
   gap: 8px;
-  padding: 8px 32px;
+  padding: 8px 24px;
   &:last-child {
     border-bottom-left-radius: 4px;
   }

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -125,7 +125,7 @@ const RequiredMark = styled.span`
 const PropTypes = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 8px;
 `
 const TypeTag = styled.span<{ color: string }>`
   font-size: ${CSS_FONT_SIZE.PX_14};

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -131,7 +131,7 @@ const TypeTag = styled.span<{ color: string }>`
   background-color: ${(props) => props.color};
 `
 const PropDescription = styled.div`
-  p {
+  && p {
     margin-block-start: 0;
   }
 `

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -105,8 +105,8 @@ const Wrapper = styled.div`
 `
 const PropContent = styled.div`
   display: grid;
-  gap: 8px;
-  padding: 8px 24px;
+  gap: 16px;
+  padding: 16px 24px;
   &:not(:last-child) {
     border-bottom: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
   }

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -1,4 +1,4 @@
-import { CSS_COLOR } from '@Constants/style'
+import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import { marked } from 'marked'
 import React, { FC } from 'react'
 import { Text } from 'smarthr-ui'
@@ -124,7 +124,7 @@ const PropTypes = styled.div`
   gap: 4px;
 `
 const TypeTag = styled.span<{ color: string }>`
-  font-size: 0.8rem;
+  font-size: ${CSS_FONT_SIZE.PX_14};
   color: ${CSS_COLOR.WHITE};
   padding: 4px 8px;
   border-radius: 8px;

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -112,7 +112,6 @@ const PropContent = styled.div`
   }
 `
 const PropName = styled.div`
-  padding-top: 8px;
   font-weight: bold;
 `
 const RequiredMark = styled.span`

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -42,7 +42,7 @@ const pickType = (typeValue: string): keyof typeof TYPE_COLOR => {
   if (typeValue === 'number') return 'number'
   if (typeValue === 'true' || typeValue === 'false') return 'boolean'
   if (/^".*"$/g.test(typeValue)) return 'literal'
-  if (/^\(.*\)\s*=>\s*.+$/g.test(typeValue)) return 'func'
+  if (/^\(.*\)\s*=>\s*.+$/g.test(typeValue)) return 'func' // 予約語を避けるため、これのみ省略
   return 'other'
 }
 

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -1,7 +1,7 @@
 import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import { marked } from 'marked'
 import React, { FC } from 'react'
-import { Text } from 'smarthr-ui'
+import { StatusLabel, Text } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import uiProps from '../../../smarthr-ui-props.json'
@@ -73,8 +73,8 @@ export const ComponentPropsTable: FC<Props> = ({ name, showTitle }) => {
           {propsData.map((prop) => (
             <PropContent key={prop.name}>
               <PropName>
-                {prop.name}
-                {prop.required && <RequiredMark>必須</RequiredMark>}
+                <span>{prop.name}</span>
+                {prop.required && <StatusLabel type="red">必須</StatusLabel>}
               </PropName>
               <PropTypes>
                 {prop.type.name === 'enum' ? (
@@ -113,13 +113,9 @@ const PropContent = styled.div`
 `
 const PropName = styled.div`
   font-weight: bold;
-`
-const RequiredMark = styled.span`
-  margin-left: 4px;
-  font-size: ${CSS_FONT_SIZE.PX_12};
-  color: #bb1212;
-  &::before {
-    content: '*';
+
+  > span {
+    margin-right: 8px;
   }
 `
 const PropTypes = styled.div`

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -100,7 +100,7 @@ export const ComponentPropsTable: FC<Props> = ({ name, showTitle }) => {
 }
 
 const Wrapper = styled.div`
-  border: 1px solid ${CSS_COLOR.LIGHT_GREY_4};
+  border: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
   border-radius: 4px;
   margin-top: 20px;
 `
@@ -112,7 +112,7 @@ const PropContent = styled.div`
     border-bottom-left-radius: 4px;
   }
   &:not(:last-child) {
-    border-bottom: 1px solid ${CSS_COLOR.LIGHT_GREY_4};
+    border-bottom: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
   }
 `
 const PropName = styled.div`


### PR DESCRIPTION
## 課題・背景

https://github.com/kufu/smarthr-design-system-issues/issues/1221

## やったこと

- プロダクト/コンポーネント配下の各ページのPropsテーブルを見やすいレイアウトに改修

## やらなかったこと

## 動作確認
- https://deploy-preview-619--smarthr-design-system.netlify.app/products/components/accordion-panel/#h2-0
- 比較用：https://smarthr.design/products/components/accordion-panel/#h2-0

## キャプチャ

|Before|After|
| --- | --- |
| <img width="795" alt="image" src="https://user-images.githubusercontent.com/1369376/230803566-9bae2cf6-4f4e-4557-8084-f3fa17f8daff.png"> | <img width="795" alt="image" src="https://user-images.githubusercontent.com/1369376/230803550-6a3e4be7-d186-4f06-a295-41b5be8ae42b.png"> |
