### PR TITLE
コンポーネントに複数Propsが存在する場合、ページインデックスに反映されていなかった問題を修正

### DIFF
--- a/src/components/article/IndexNav/IndexNav.tsx
+++ b/src/components/article/IndexNav/IndexNav.tsx
@@ -4,22 +4,41 @@ import React, { FC } from 'react'
 import styled from 'styled-components'
 
 type Props = {
-  headings: Array<{ value: string; recordId: string; depth: number }> | null
+  headings: Array<{ value: string; recordId: string; depth: number; fragmentId: string }> | null
 }
 export const IndexNav: FC<Props> = ({ headings }) => {
   if (headings === null) return null
 
-  const nestedHeadings: Array<{ value: string; recordId: string; children: Array<{ value: string }>; depth: number }> = []
+  const nestedHeadings: Array<{
+    value: string
+    recordId: string
+    children: Array<{ value: string; fragmentId?: string }>
+    depth: number
+    fragmentId: string
+  }> = []
   headings.forEach((heading) => {
     if (heading.depth > 3) return
     if (heading.depth === 1)
-      nestedHeadings.push({ value: heading.value, recordId: heading.recordId || '', children: [], depth: 1 })
+      nestedHeadings.push({
+        value: heading.value,
+        recordId: heading.recordId || '',
+        children: [],
+        depth: 1,
+        fragmentId: heading.fragmentId || '',
+      })
     if (heading.depth === 2)
-      nestedHeadings.push({ value: heading.value, recordId: heading.recordId || '', children: [], depth: 2 })
+      nestedHeadings.push({
+        value: heading.value,
+        recordId: heading.recordId || '',
+        children: [],
+        depth: 2,
+        fragmentId: heading.fragmentId || '',
+      })
     if (heading.depth === 3) {
       // 親となる第2階層がない場合、仮の親となるアイテムをpushする。
-      if (!nestedHeadings[nestedHeadings.length - 1]) nestedHeadings.push({ value: '', recordId: '', children: [], depth: 0 })
-      nestedHeadings[nestedHeadings.length - 1].children.push({ value: heading.value })
+      if (!nestedHeadings[nestedHeadings.length - 1])
+        nestedHeadings.push({ value: '', recordId: '', children: [], depth: 0, fragmentId: '' })
+      nestedHeadings[nestedHeadings.length - 1].children.push({ value: heading.value, fragmentId: heading.fragmentId || '' })
     }
   })
 
@@ -30,7 +49,8 @@ export const IndexNav: FC<Props> = ({ headings }) => {
       <ul>
         {nestedHeadings.map((depth2Item, depth2Index) => {
           /* Airtable由来のコンテンツではrecord_idをアンカーとして使用する */
-          const depth2Id = depth2Item.recordId === '' ? `h2-${depth2Index}` : `${depth2Item.recordId}-0`
+          const recordId = depth2Item.recordId === '' ? `h2-${depth2Index}` : `${depth2Item.recordId}-0`
+          const depth2Id = depth2Item.fragmentId !== '' ? depth2Item.fragmentId : recordId
           return (
             <li key={depth2Id}>
               {(() => {
@@ -56,7 +76,7 @@ export const IndexNav: FC<Props> = ({ headings }) => {
               })()}
               <ul>
                 {depth2Item.children.map((depth3Item) => {
-                  const depth3Id = `h3-${depth3Index}`
+                  const depth3Id = depth3Item.fragmentId !== '' ? depth3Item.fragmentId : `h3-${depth3Index}`
                   depth3Index += 1
                   return (
                     <li key={depth3Id}>

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -64,6 +64,7 @@ export const query = graphql`
     mdx(id: { eq: $id }) {
       id
       body
+      rawBody
       headings {
         depth
         value
@@ -126,7 +127,7 @@ const Article: FC<Props> = ({ data }) => {
     return null
   }
 
-  const { frontmatter, headings, fields } = article
+  const { frontmatter, headings, fields, rawBody } = article
   const slug = fields?.slug || ''
 
   const title = frontmatter?.title || ''
@@ -143,6 +144,7 @@ const Article: FC<Props> = ({ data }) => {
         recordId: edge.node.data?.record_id ?? '',
         name: edge.node.data?.name ?? '',
         order: edge.node.data?.order ?? Number.MAX_SAFE_INTEGER,
+        fragmentId: '',
       }
     })
 
@@ -170,11 +172,34 @@ const Article: FC<Props> = ({ data }) => {
           value: heading?.value ?? '',
           depth: heading?.depth ?? -1,
           recordId: '',
+          fragmentId: '',
         }
       })
       ?.filter(({ depth }) => depth <= INDEXED_DEPTH) ?? []
 
   const headingList = [...airTableHeadings, ...mdxHeadings]
+
+  // コンポーネントのページのPropsをheadingListに追加する
+  if (fields?.hierarchy && /^products\/components/.test(fields?.hierarchy)) {
+    // ページ内の全ての<ComponentPropsTable name="{対象}" showTitle />から、name属性の値を取り出す
+    const regex = /<ComponentPropsTable(?:\s+[^>]*?)?(?:\s+name="([^"]+)")(?:\s+[^>]*?)?(?:\s+showTitle(?:={true})?)\s*\/?>/gms
+    const propsHeadingList = []
+    let match
+    while ((match = regex.exec(rawBody)) !== null) {
+      propsHeadingList.push(match[1])
+    }
+    const propsIndex = headingList.findIndex((item) => item.value === 'Props')
+    if (propsIndex > -1 && propsHeadingList.length > 0) {
+      propsHeadingList.forEach((heading, index) => {
+        headingList.splice(propsIndex + index + 1, 0, {
+          value: `${heading} props`,
+          depth: 3,
+          recordId: '',
+          fragmentId: `props-${heading}`,
+        })
+      })
+    }
+  }
 
   //
   // サイドバー、「前へ」「次へ」コンポーネントのための配列作成


### PR DESCRIPTION
## 課題・背景

closes https://github.com/kufu/smarthr-design-system-issues/issues/1223

## やったこと

- コンポーネントのページ右のページインデックスに項目別にPropsを表示するようにした

## やらなかったこと

## 動作確認
- https://deploy-preview-620--smarthr-design-system.netlify.app/products/components/accordion-panel/

## キャプチャ

|Before|After|
| --- | --- |
| <img width="587" alt="image" src="https://user-images.githubusercontent.com/1369376/231616679-776943b4-55d0-49f9-802d-1ee429161800.png"> | <img width="587" alt="image" src="https://user-images.githubusercontent.com/1369376/231616639-52dd4f11-667b-45bf-a0a2-4bdb2e628be9.png"> |

