### PR TITLE
scroll-margin-topの値を調整

### DIFF
--- a/src/components/article/FragmentTitle/FragmentTitle.tsx
+++ b/src/components/article/FragmentTitle/FragmentTitle.tsx
@@ -23,7 +23,7 @@ export const FragmentTitle: FC<Props> = ({ tag = 'h2', id, children }) => {
 
 const Wrapper = styled.div`
   position: relative;
-  scroll-margin-top: 225px;
+  scroll-margin-top: 20px;
 
   .icon {
     position: absolute;


### PR DESCRIPTION
## 課題・背景

closes https://github.com/kufu/smarthr-design-system-issues/issues/1228

## やったこと

ページ内アンカーなどで移動した際に、スクロール位置がずれている問題を修正

## やらなかったこと

## 動作確認

## キャプチャ

|Before|After|
| --- | --- |
| <img width="770" alt="image" src="https://user-images.githubusercontent.com/1369376/231914370-f7dcab7e-03d4-4237-a45e-0f6195f78cd4.png"> | <img width="770" alt="image" src="https://user-images.githubusercontent.com/1369376/231914391-e614b128-1a9a-4682-9ce6-432b0593d5ae.png"> |
