### PR TITLE
コンポーネントの非推奨のpropに警告アイコンを表示するように改修

### DIFF
--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -75,7 +75,7 @@ export const ComponentPropsTable: FC<Props> = ({ name, showTitle }) => {
               <PropName>
                 <span>{prop.name}</span>
                 {prop.required && <StatusLabel type="red">必須</StatusLabel>}
-                {prop.description.includes('@deprecated') && <WarningIcon />}
+                {prop.description.includes('@deprecated') && <WarningIcon alt="非推奨" />}
               </PropName>
               <PropTypes>
                 {prop.type.name === 'enum' ? (

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -1,7 +1,7 @@
 import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import { marked } from 'marked'
 import React, { FC } from 'react'
-import { StatusLabel, Text } from 'smarthr-ui'
+import { StatusLabel, Text, WarningIcon } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import uiProps from '../../../smarthr-ui-props.json'
@@ -75,6 +75,7 @@ export const ComponentPropsTable: FC<Props> = ({ name, showTitle }) => {
               <PropName>
                 <span>{prop.name}</span>
                 {prop.required && <StatusLabel type="red">必須</StatusLabel>}
+                {prop.description.includes('@deprecated') && <WarningIcon />}
               </PropName>
               <PropTypes>
                 {prop.type.name === 'enum' ? (
@@ -112,6 +113,8 @@ const PropContent = styled.div`
   }
 `
 const PropName = styled.div`
+  display: flex;
+  align-items: center;
   font-weight: bold;
 
   > span {


### PR DESCRIPTION
## 課題・背景

closes https://github.com/kufu/smarthr-design-system-issues/issues/1227

## やったこと

propの説明に`@deprecated`が含まれていれば、prop名の横に警告アイコンを表示する

## やらなかったこと


## 動作確認
- https://deploy-preview-622--smarthr-design-system.netlify.app/products/components/input/#h2-0
- 説明の途中に@deprecatedがある：https://deploy-preview-622--smarthr-design-system.netlify.app/products/components/combo-box/#props-MultiComboBox

## キャプチャ

|Before|After|
| --- | --- |
| <img width="745" alt="image" src="https://user-images.githubusercontent.com/1369376/231923680-1f086fa5-37ea-4e5a-9679-8b19bcd90f49.png"> | <img width="745" alt="image" src="https://user-images.githubusercontent.com/1369376/231923729-39a8a410-a31e-48cf-9477-9241d4a325a7.png"> |
