### PR TITLE
SmartHR UI Iconのsizeプロパティを削除

### DIFF
--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -89,7 +89,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     horizontal="left"
     vertical="bottom">
     <Cluster align="center" gap={0.25}>
-      <FaArrowAltCircleUpIcon color="TEXT_LINK" size={16} />
+      <FaArrowAltCircleUpIcon color="TEXT_LINK" />
       <Text color="TEXT_LINK">left & bottom</Text>
     </Cluster>
   </DynamicTooltip>
@@ -100,7 +100,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     horizontal="center"
     vertical="bottom">
     <Cluster align="center" gap={0.25}>
-      <FaArrowAltCircleUpIcon color="TEXT_LINK" size={16} />
+      <FaArrowAltCircleUpIcon color="TEXT_LINK" />
       <Text color="TEXT_LINK">center & bottom</Text>
     </Cluster>
   </DynamicTooltip>
@@ -111,7 +111,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     horizontal="right"
     vertical="bottom">
     <Cluster align="center" gap={0.25}>
-      <FaArrowAltCircleUpIcon color="TEXT_LINK" size={16} />
+      <FaArrowAltCircleUpIcon color="TEXT_LINK" />
       <Text color="TEXT_LINK">right & bottom</Text>
     </Cluster>
   </DynamicTooltip>
@@ -125,7 +125,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     horizontal="left"
     vertical="top">
     <Cluster align="center" gap={0.25}>
-      <FaArrowAltCircleDownIcon color="TEXT_LINK" size={16} />
+      <FaArrowAltCircleDownIcon color="TEXT_LINK" />
       <Text color="TEXT_LINK">left & top</Text>
     </Cluster>
   </DynamicTooltip>
@@ -136,7 +136,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     horizontal="center"
     vertical="top">
     <Cluster align="center" gap={0.25}>
-      <FaArrowAltCircleDownIcon color="TEXT_LINK" size={16} />
+      <FaArrowAltCircleDownIcon color="TEXT_LINK" />
       <Text color="TEXT_LINK">center & top</Text>
     </Cluster>
   </DynamicTooltip>
@@ -147,7 +147,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     horizontal="right"
     vertical="top">
     <Cluster align="center" gap={0.25}>
-      <FaArrowAltCircleDownIcon color="TEXT_LINK" size={16} />
+      <FaArrowAltCircleDownIcon color="TEXT_LINK" />
       <Text color="TEXT_LINK">right & top</Text>
     </Cluster>
   </DynamicTooltip>
@@ -161,7 +161,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     horizontal="left"
     vertical="middle">
     <Cluster align="center" gap={0.25}>
-      <FaArrowAltCircleRightIcon color="TEXT_LINK" size={16} />
+      <FaArrowAltCircleRightIcon color="TEXT_LINK" />
       <Text color="TEXT_LINK">left & middle</Text>
     </Cluster>
   </DynamicTooltip>
@@ -171,7 +171,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     horizontal="right"
     vertical="middle">
     <Cluster align="center" gap={0.25}>
-      <FaArrowAltCircleLeftIcon color="TEXT_LINK" size={16} />
+      <FaArrowAltCircleLeftIcon color="TEXT_LINK" />
       <Text color="TEXT_LINK">right & middle</Text>
     </Cluster>
   </DynamicTooltip>
@@ -187,7 +187,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     horizontal="auto"
     vertical="auto">
     <Cluster align="center" gap={0.25}>
-      <FaArrowAltCircleDownIcon color="TEXT_LINK" size={16} />
+      <FaArrowAltCircleDownIcon color="TEXT_LINK" />
       <Text color="TEXT_LINK">auto & auto</Text>
     </Cluster>
   </DynamicTooltip>
@@ -218,7 +218,7 @@ export const DynamicTooltip = ({children, ...props}) => {
     vertical="bottom">
       <Cluster align="center" gap={0.25}>
         <Text color="TEXT_LINK">テキスト</Text>
-        <FaInfoCircleIcon color="TEXT_LINK" size={16} />
+        <FaInfoCircleIcon color="TEXT_LINK" />
       </Cluster>
   </DynamicTooltip>
 </ComponentPreview>
@@ -234,14 +234,14 @@ export const DynamicTooltip = ({children, ...props}) => {
     triggerType="icon"
     horizontal="left"
     vertical="bottom">
-      <FaUserAltIcon color="TEXT_LINK" size={16} />
+      <FaUserAltIcon color="TEXT_LINK" />
   </DynamicTooltip>
   <DynamicTooltip
     message="書類の名称"
     triggerType="icon"
     horizontal="left"
     vertical="bottom">
-      <FaFileIcon color="TEXT_LINK" size={16} />
+      <FaFileIcon color="TEXT_LINK" />
   </DynamicTooltip>
 </ComponentPreview>
 
@@ -259,7 +259,7 @@ export const DynamicTooltip = ({children, ...props}) => {
       triggerType="icon"
       horizontal="left"
       vertical="bottom">
-        <FaInfoCircleIcon color="TEXT_GREY" size={16} />
+        <FaInfoCircleIcon color="TEXT_GREY" />
     </DynamicTooltip>
   </Cluster>
   <Cluster align="center" gap={0.25}>
@@ -269,7 +269,7 @@ export const DynamicTooltip = ({children, ...props}) => {
       triggerType="icon"
       horizontal="left"
       vertical="bottom">
-        <FaInfoCircleIcon color="TEXT_GREY" size={16} />
+        <FaInfoCircleIcon color="TEXT_GREY" />
     </DynamicTooltip>
   </Cluster>
 </ComponentPreview>
@@ -285,7 +285,7 @@ export const DynamicTooltip = ({children, ...props}) => {
       triggerType="icon"
       horizontal="left"
       vertical="bottom">
-        <WarningIcon color="WARNING" size={16} />
+        <WarningIcon color="WARNING" />
     </DynamicTooltip>
     <Text color="TEXT_LINK">テキスト</Text>
   </Cluster>
@@ -295,7 +295,7 @@ export const DynamicTooltip = ({children, ...props}) => {
       triggerType="icon"
       horizontal="left"
       vertical="bottom">
-        <FaInfoCircleIcon color="DANGER" size={16} />
+        <FaInfoCircleIcon color="DANGER" />
     </DynamicTooltip>
     <Text color="TEXT_LINK">テキスト</Text>
   </Cluster>

--- a/src/components/article/CodeBlock/CopyButton.tsx
+++ b/src/components/article/CodeBlock/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { CSS_COLOR } from '@Constants/style'
+import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import React, { FC, useState } from 'react'
 import { FaCheckIcon, FaCopyIcon } from 'smarthr-ui'
 import styled from 'styled-components'
@@ -21,7 +21,7 @@ export const CopyButton: FC<CopyButtonProps> = ({ text }) => {
       title={`${text}をクリップボードにコピーする`}
       disabled={copied}
     >
-      {copied ? <FaCheckIcon size={20} /> : <FaCopyIcon size={20} />}
+      {copied ? <FaCheckIcon /> : <FaCopyIcon />}
     </StyledButton>
   )
 }
@@ -34,4 +34,5 @@ const StyledButton = styled.button`
   color: ${CSS_COLOR.TEXT_GREY};
   background: transparent;
   cursor: pointer;
+  font-size: ${CSS_FONT_SIZE.PX_20};
 `

--- a/src/components/article/FragmentTitle/FragmentTitle.tsx
+++ b/src/components/article/FragmentTitle/FragmentTitle.tsx
@@ -1,3 +1,4 @@
+import { CSS_FONT_SIZE } from '@Constants/style'
 import React, { FC } from 'react'
 import { FaLinkIcon } from 'smarthr-ui'
 import styled from 'styled-components'
@@ -14,7 +15,7 @@ export const FragmentTitle: FC<Props> = ({ tag = 'h2', id, children }) => {
   return (
     <Wrapper as={tag} id={id}>
       <a href={`#${id}`}>
-        <FaLinkIcon size={16} className="icon" />
+        <FaLinkIcon className="icon" />
         {children}
       </a>
     </Wrapper>
@@ -32,6 +33,7 @@ const Wrapper = styled.div`
     margin: auto;
     left: -24px;
     visibility: hidden;
+    font-size: ${CSS_FONT_SIZE.PX_16};
   }
 
   a {

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
+import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import { SidebarScrollContext } from '@Context/SidebarScrollContext'
 import { useLocation } from '@reach/router'
 import { Link } from 'gatsby'
@@ -79,7 +79,7 @@ export const Sidebar: FC<Props> = ({ path, nestedSidebarItems }) => {
                         aria-expanded={path.includes(depth2Item.link)}
                         onClick={onClickCaret}
                       >
-                        <FaChevronDownIcon size={14} alt={path.includes(depth2Item.link) ? '閉じる' : '開く'} />
+                        <FaChevronDownIcon alt={path.includes(depth2Item.link) ? '閉じる' : '開く'} />
                       </CaretButton>
                     )}
                   </Depth2Item>
@@ -99,7 +99,7 @@ export const Sidebar: FC<Props> = ({ path, nestedSidebarItems }) => {
                                 aria-expanded={path.includes(depth3Item.link)}
                                 onClick={onClickCaret}
                               >
-                                <FaChevronDownIcon size={14} alt={path.includes(depth3Item.link) ? '閉じる' : '開く'} />
+                                <FaChevronDownIcon alt={path.includes(depth3Item.link) ? '閉じる' : '開く'} />
                               </CaretButton>
                             )}
                           </Depth3Item>
@@ -248,6 +248,7 @@ const CaretButton = styled.button`
   background: none;
   color: ${CSS_COLOR.TEXT_GREY};
   cursor: pointer;
+  font-size: ${CSS_FONT_SIZE.PX_14};
 
   &:hover {
     background-color: ${CSS_COLOR.LIGHT_GREY_1};

--- a/src/components/search/Search/SearchBox.tsx
+++ b/src/components/search/Search/SearchBox.tsx
@@ -46,7 +46,7 @@ const SearchBox: FC<SearchBoxProvided & Props> = ({ refine, isAvailable }) => {
         <p id="desc-for-search-input">例：Button、画面キャプチャ、用字用語、須磨英知など</p>
         <Input
           width="100%"
-          prefix={<FaSearchIcon size={24} aria-label="検索" />}
+          prefix={<StyledSearchIcon aria-label="検索" />}
           value={searchState}
           onChange={onSearchStateChange}
           autoFocus // eslint-disable-line jsx-a11y/no-autofocus
@@ -88,6 +88,10 @@ const InputOuter = styled.div`
     border-radius: 12px;
     font-size: 1.5rem;
   }
+`
+
+const StyledSearchIcon = styled(FaSearchIcon)`
+  font-size: ${CSS_FONT_SIZE.PX_24};
 `
 
 const WarningMessage = styled.div`

--- a/src/components/shared/Header/Header.tsx
+++ b/src/components/shared/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
+import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import { LoginContext } from '@Context/LoginContext'
 import { useLocation } from '@reach/router'
 import { Link as LinkComponent } from 'gatsby'
@@ -68,7 +68,7 @@ export const Header: FC<Props> = ({ isIndex = false }) => {
                 aria-haspopup="true"
                 aria-controls="panel-menu"
               >
-                <FaBarsIcon size={24} />
+                <FaBarsIcon />
               </StyledOpenButton>
               {typeof window !== 'undefined' ? (
                 <Dialog
@@ -313,6 +313,7 @@ const StyledOpenButton = styled.button`
   border: 0;
   background: transparent;
   cursor: pointer;
+  font-size: ${CSS_FONT_SIZE.PX_24};
 `
 
 const Dialog = styled(shrDialog)`

--- a/src/components/shared/Private/Private.tsx
+++ b/src/components/shared/Private/Private.tsx
@@ -59,10 +59,10 @@ export const Private: FC<Props> = ({ path }) => {
     // ログイン済みの時の表示
     <AuthView>
       <AuthViewTitle>
-        <FaLockIcon size={16} />
+        <StyledLockIcon size={16} />
         <span>SmartHR社従業員限定コンテンツ</span>
         <Tooltip>
-          <FaExclamationCircleIcon size={14} />
+          <StyledExclamationIcon />
           <p className="message">制作パートナー・グループ会社への共有は可能ですが、SNS等へのシェアはしないでください。</p>
         </Tooltip>
       </AuthViewTitle>
@@ -151,6 +151,14 @@ const AuthViewTitle = styled.h2`
   display: flex;
   align-items: center;
   gap: 0.5rem;
+`
+
+const StyledLockIcon = styled(FaLockIcon)`
+  font-size: ${CSS_FONT_SIZE.PX_16};
+`
+
+const StyledExclamationIcon = styled(FaExclamationCircleIcon)`
+  font-size: ${CSS_FONT_SIZE.PX_14};
 `
 
 const Tooltip = styled.div`


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1229

## やったこと
TSXコンポーネント内で`<Icon size={}>`のように使われてる箇所は、CSSで`font-size`を指定するように変更しました。

MDXコンポーネント内で使われているケースは[content/articles/products/components/tooltip.mdx](https://github.com/kufu/smarthr-design-system/compare/fix/remove-icon-size-prop?expand=1#diff-3c9999d5b7461f40f0bbe4c642b10cdfa8eaeeb0e225603867911229299d56a5)のみでしたが、こちらは`size={16}`でちょうどフォントサイズと同じになっていたので、size propsの削除だけを行いました。明示的に`style={{fontSize: '16px'}}`としても良いかもしれません。

## 動作確認
変更したページ例：

https://deploy-preview-623--smarthr-design-system.netlify.app/ SP表示時のハンバーガーアイコン
https://deploy-preview-623--smarthr-design-system.netlify.app/search/ テキストボックス左端の虫眼鏡アイコン
https://deploy-preview-623--smarthr-design-system.netlify.app/basics/ 左サイドバーメニューのキャレットボタン
https://deploy-preview-623--smarthr-design-system.netlify.app/basics/logos/#h2-0 見出しにホバーした時のリンクアイコン
https://deploy-preview-623--smarthr-design-system.netlify.app/basics/illustration/smarthr-co/ ログイン中の限定コンテンツ先頭のオレンジのテキスト（鍵アイコンと「!」アイコン）
https://deploy-preview-623--smarthr-design-system.netlify.app/products/components/accordion-panel/ iframeの下のコードのコピーボタン
https://deploy-preview-623--smarthr-design-system.netlify.app/products/components/tooltip/#h3-2 囲みで例示されている部分のアイコン

## キャプチャ
見た目上の変化はありません。