### PR TITLE
scroll-margin-topの調整

### DIFF
--- a/src/components/article/FragmentTitle/FragmentTitle.tsx
+++ b/src/components/article/FragmentTitle/FragmentTitle.tsx
@@ -24,7 +24,7 @@ export const FragmentTitle: FC<Props> = ({ tag = 'h2', id, children }) => {
 
 const Wrapper = styled.div`
   position: relative;
-  scroll-margin-top: 20px;
+  scroll-margin-top: 80px;
 
   .icon {
     position: absolute;


### PR DESCRIPTION
## 課題・背景

scroll-margin-topはもともとは200px以上マージンが取られていたので、もう少し取るように修正した

## やったこと

scroll-margin-topを20pxから80pxに調整

## やらなかったこと

## 動作確認

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |
