### PR TITLE
StorybookのURLが正しく設定できていないUIコンポーネントを修正

### DIFF
--- a/src/lib/fetchStoryData.ts
+++ b/src/lib/fetchStoryData.ts
@@ -76,18 +76,12 @@ export const fetchStoryData = async (storyName: string, version: string) => {
 
   const storyItems: StoryItem[] = [...items1, ...items2].map((item) => {
     // iframeのURL用にケバブケースの名前を作る
-    const kebab =
-      parentCode === '' // 階層あり・なしの場合分け
-        ? item.name
-            .replace(/([A-Z])/g, (s) => {
-              return '-' + s.charAt(0).toLowerCase()
-            })
-            .replace(/^[a-z]+$/, (s) => `-${s.charAt(0)}`)
-            .replace(/^_/, '') // コンポーネントとStoryが同名の場合に、頭に'_'がついていることがあるので、削除
-        : storyName.replace(/^.*\//, '').replace(/([A-Z])/g, (s) => {
-            return '-' + s.charAt(0).toLowerCase()
-          })
-
+    const childName = parentCode === '' ? item.name : storyName.replace(/^.*\//, '') //親階層がある場合は削除
+    const kebab = childName
+      .replace(/(_?[A-Z])/g, (s) => {
+        return '-' + s.replace('_', '').charAt(0).toLowerCase() // 大文字→ハイフン＋小文字に変換、大文字の前に'_'があるケースもある
+      })
+      .replace(/^[^-]/, (s) => `-${s.charAt(0)}`) // 先頭に'-'がない場合はつける
     return {
       name: item.name,
       label: storyLabels[item.name] || item.name,


### PR DESCRIPTION
## 課題・背景
https://pxgrid.slack.com/archives/C018J0A6DCH/p1682053310369069

[/products/components/](https://smarthr.design/products/components/)以下の各ページを調べたところ、下記の2ページでStorybookのURLが正しくなく、エラー表示になっていました。

- [Dialog](https://smarthr.design/products/components/dialog/) → ActionDialog_With_Trigger タブ
- [Icon](https://smarthr.design/products/components/icon/) → アイコンの生成 タブ

## やったこと
各ストーリーの名前・URLはSmartHR UIのコード（`*.stories.tsx`）から取得しており、ビルド時に`gatsby-node`内で処理していますが、名前が日本語で始まるケースや`_`が入るケースに対応できていなかったため、文字列を変換する正規表現などを修正しました。

## 動作確認
https://deploy-preview-634--smarthr-design-system.netlify.app/products/components/dialog/
https://deploy-preview-634--smarthr-design-system.netlify.app/products/components/icon/

他のコンポーネントにも影響する部分のため、すべてのコンポーネントページ・タブについて確認しましたが、エラー表示はありませんでした。（以前から未対応の`BaseColumn`を除く）