### PR TITLE
StorybookのURLチェッカーのPuppeteerを新しいモードに変更

### DIFF
--- a/scripts/content-checker/storybookUrlChecker.ts
+++ b/scripts/content-checker/storybookUrlChecker.ts
@@ -69,7 +69,7 @@ const checkStorybook = async (pageList: PageItem[]) => {
   const errorList: string[] = []
 
   const browser = await puppeteer.launch({
-    headless: true,
+    headless: 'new',
   })
   const page = await browser.newPage()
 


### PR DESCRIPTION
## 課題・背景
- https://github.com/kufu/smarthr-design-system/pull/641
- https://github.com/kufu/smarthr-design-system/actions/runs/4847899821

GitHub Actionsで実行した際、Puppeteerのwaringメッセージが出ており、現在のheadlessモードの実装が近く非推奨になるので、新しいモードを試すように、となっている。Warningも実行結果のサマリーに出力されてしまい邪魔なので、対応する。

## やったこと

StorybookチェッカーはPuppeteerの基本的な機能しか使っておらず、新しいモードでも問題なく動作したので、切り替えました。
ドキュメント：https://developer.chrome.com/articles/new-headless/

## 動作確認
ローカル環境ではスクリプトが問題なく実行できることを確認しました。

## キャプチャ
SDS本体への影響はありません。