### PR TITLE
react-liveの型定義を更新

### DIFF
--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -5,7 +5,7 @@ import Highlight, { Language, defaultProps } from 'prism-react-renderer'
 import github from 'prism-react-renderer/themes/github'
 import vscode from 'prism-react-renderer/themes/vsDark'
 import React, { CSSProperties, FC, ReactNode, useState } from 'react'
-import { LiveEditor, LiveError, LivePreview, LiveProvider, LiveProviderProps } from 'react-live'
+import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live'
 import * as ui from 'smarthr-ui'
 import { Gap, SeparateGap } from 'smarthr-ui/lib/components/Layout/type'
 import styled, { ThemeProvider, css } from 'styled-components'
@@ -14,6 +14,8 @@ import styled, { ThemeProvider, css } from 'styled-components'
 import { ComponentPreview } from '../../ComponentPreview'
 
 import { CopyButton } from './CopyButton'
+
+type LiveProviderProps = React.ComponentProps<typeof LiveProvider>
 
 type Props = {
   children: string

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -110,7 +110,6 @@ export const CodeBlock: FC<Props> = ({
               transformCode={transformCode}
             >
               <ComponentPreview gap={gap} align={align} layout={layout}>
-                {/* @ts-ignore -- LivePreviewの型定義が正しくないようなので、エラーを無視。https://github.com/FormidableLabs/react-live/pull/304 */}
                 <LivePreview Component={React.Fragment} />
               </ComponentPreview>
               <CodeWrapper>


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system/pull/647

react-liveのメジャーアップデートに伴い、typescriptでエラーが出ていたので、型定義を更新しました。（このアップデートではreact-live自体がTSで書かれるようになったようです。）

`LiveProviderProps`という型をimportして利用していましたが、exportされなくなったようで、
```tsx
'"react-live"' has no exported member named 'LiveProviderProps'
```
というエラーと、この型が存在しないことに起因するエラーが2つ出ていました。

## やったこと
`LiveProvider`コンポーネントは引き続きexportされているので、そのPropsの型を参照するようにしました。
```tsx
type LiveProviderProps = React.ComponentProps<typeof LiveProvider>
```

また、以前に型エラー回避のために追加していた `@ts-ignore`が不要になっていたので削除しました。react-liveのTS化に伴い解決したようです。（おそらくこのあたり：https://github.com/FormidableLabs/react-live/blob/b3c8d0052051bc031f10a79338da14d05d7fa49e/src/components/Live/LivePreview.tsx#L12-L15 ）

## 動作確認
型定義のみなので、ビルド後のコードには影響しないはずです。
ライブエディタがあるページは念のため確認しました、例えば、
https://deploy-preview-650--smarthr-design-system.netlify.app/products/design-patterns/upward-navigation/
https://deploy-preview-650--smarthr-design-system.netlify.app/products/components/button/#h2-0
