### PR TITLE
Font Awesomeのタイポを修正

### DIFF
--- a/content/articles/basics/icons/creation-guideline.mdx
+++ b/content/articles/basics/icons/creation-guideline.mdx
@@ -14,20 +14,20 @@ order: 4
 - マスターデータの更新はすべて @omame が担当しますので、アイコン作成後にお声かけください。
 
 ## 概要
-- **アイコンは、基本的にFont Awsome(Freeプラン)から選定します。適したアイコンがない場合は、トンマナを合わせてオリジナルで作成します。**これは、アイコンのデザイントンマナをプロダクトで数多く利用しているFont Awsomeに合わせて統一することで、サービス全体で一環した印象を保つためです。
+- **アイコンは、基本的にFont Awesome(Freeプラン)から選定します。適したアイコンがない場合は、トンマナを合わせてオリジナルで作成します。**これは、アイコンのデザイントンマナをプロダクトで数多く利用しているFont Awesomeに合わせて統一することで、サービス全体で一環した印象を保つためです。
 - 既存アイコンがFont Awesomeか、オリジナルかは[アイコン | Figma](https://www.figma.com/file/wTjPGUsrbI0OqSLIEtwvvG/%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%EF%BC%88Communication%EF%BC%89?node-id=610%3A347)に記載しています。
 - アイコンはoutlineとsolidの2種類を用意します。
 
 ## 1.Font Awesomeを利用する方法
-- outline・solidどちらも、Font Awosome のFreeプランから選定して、利用してください。
+- outline・solidどちらも、Font Awesome のFreeプランから選定して、利用してください。
 - solidがFreeプランに含まれていても、outline（Font Awesome内での表記はRegular）は別プランの場合があります。その場合は以下のルールで作成してください。
 
 | 事例 | 作成方法 |
 | --- | --- |
 |outline（Regular）がsolidを反転した形状 | outline、solidどちらもオリジナルで作成 |
-|outline（Regular）がsolidの反転とは違う形状 | solidはFontAwesomeを利用。outlineはsolidを反転する形でオリジナルで作成 |
+|outline（Regular）がsolidの反転とは違う形状 | solidはFont Awesomeを利用。outlineはsolidを反転する形でオリジナルで作成 |
 
-※FontAwesome ver 6.0.0 時点
+※Font Awesome ver 6.0.0 時点
 
 ## 2.オリジナルで作成する方法
 オリジナルで作成する場合は、Font Awesomeアイコンのトーンに合わせ、並んだときに違和感のないよう作成してください。  


### PR DESCRIPTION
## 課題・背景
Design System内における「Font Awesome」のタイポを修正する。
正式な表記は「Font Awesome」（FとAは大文字、Font と Awesome の間はスペース有り）なのですが、
Design System内にある、正式な表記以外のタイポを修正しました。
https://github.com/kufu/smarthr-design-system-issues/issues/1235

## やったこと
- Design System内における「Font Awesome」以外のタイポを「Font Awesome」に修正する。

## やらなかったこと
とくになし

## 動作確認
アイコン>[作成ガイドライン](https://deploy-preview-657--smarthr-design-system.netlify.app/basics/icons/creation-guideline/)の
- 概要セクションに2つ
https://deploy-preview-657--smarthr-design-system.netlify.app/basics/icons/creation-guideline/#h2-1

- [1.Font Awesomeを利用する方法]に3つ
https://deploy-preview-657--smarthr-design-system.netlify.app/basics/icons/creation-guideline/#h2-2

## キャプチャ

|Before|After|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/101125529/236738626-476a8957-0e3a-4e94-ba68-366d7010f3da.png) | <img width="786" alt="スクリーンショット_2023-05-08_14_06_53" src="https://user-images.githubusercontent.com/101125529/236739312-ad47852c-6190-42b6-b700-70db623f214b.png"> |
| ![image](https://user-images.githubusercontent.com/101125529/236738661-c6dbce69-ca57-44f0-bace-8ba8556d99c8.png) | <img width="772" alt="スクリーンショット_2023-05-08_14_11_08" src="https://user-images.githubusercontent.com/101125529/236739444-c7d711fe-16c0-4ad5-8047-f2348200ee37.png"> |
