### PR TITLE
SmartHR UIのStorybook v6 → v7 アップデートのため*stories.tsxのパーサーを調整

### DIFF
--- a/src/lib/fetchStoryData.ts
+++ b/src/lib/fetchStoryData.ts
@@ -74,10 +74,16 @@ export const fetchStoryData = async (storyName: string, version: string) => {
     storyLabels[result[1]] = result[2]
   })
 
+  // "Default.storyName = 'SearchInput'" のような記述がある場合はURLに必要なので取得しておく（Storybook v6まで）
+  const matchDefaultNames = storiesCode.matchAll(/Default\.storyName\s=\s'(.*)'/g)
+  let defaultName: string | null = null
+  Array.from(matchDefaultNames).forEach((result) => {
+    defaultName = result[1]
+  })
+
   const storyItems: StoryItem[] = [...items1, ...items2].map((item) => {
     // iframeのURL用にケバブケースの名前を作る
-    const childName = parentCode === '' ? item.name : storyName.replace(/^.*\//, '') //親階層がある場合は削除
-    const kebab = childName
+    const kebab = (defaultName || item.name)
       .replace(/(_?[A-Z])/g, (s) => {
         return '-' + s.replace('_', '').charAt(0).toLowerCase() // 大文字→ハイフン＋小文字に変換、大文字の前に'_'があるケースもある
       })


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1236

## やったこと
階層になっているページ（`dropdown/dropdown-menu-button`・`dropdown/filter-dropdown`・`input/search-input`）でのStory名の決め方を、より厳密なものにしました。

これまでは、階層になっているものは例外的にStoryName（frontmatterで指定しているもの）を使ってURL作る、ということをやっていましたが、v7からはそのような例外処理が不要になっていましたので、「階層があれば」ではなく、「UIのコード中の`Default.storyName = '...'`の部分があれば」その名前を使う、という条件分岐に変更しました。

v7対応のコードからは`Default.storyName = '...'`の記述はなくなっているので、上記の条件分岐では常に`false`になります。（ですので、このコードはバージョン切り替えでStorybookがv6のUIバージョンが指定された場合の後方互換用になるはずです。）

## 動作確認
影響があるのは以下の3ページです：
https://deploy-preview-660--smarthr-design-system.netlify.app/products/components/dropdown/dropdown-menu-button/
https://deploy-preview-660--smarthr-design-system.netlify.app/products/components/dropdown/filter-dropdown/
https://deploy-preview-660--smarthr-design-system.netlify.app/products/components/input/search-input/

v7では以下のようなURLになります（ローカルで確認済み）：
https://deploy-preview-3294--smarthr-ui.netlify.app/iframe.html?args=&id=buttons（ボタン）-dropdown--dropdown-menu-story&viewMode=story
https://deploy-preview-3294--smarthr-ui.netlify.app/?path=/story/buttons（ボタン）-dropdown--filter-dropdown-story
（←現状のままでも`-dropdown--filter-dropdown`となり、Storybook側が`-story`を補ってリダイレクトするようで、v7でもエラーにはならないが、このほうが正しい。）
https://deploy-preview-3294--smarthr-ui.netlify.app/?path=/story/forms（フォーム）-input--default

また、念のため全部のコンポーネント・Storyについてiframeの表示がエラーになっていないことを確認しました。


## キャプチャ
見た目の変化はありません。
