### PR TITLE
[影トークン] セマンティクストークンの表に利用コンポーネントを追加、レイヤー順序との関係を廃止

### DIFF
--- a/content/articles/products/design-tokens/shadow.mdx
+++ b/content/articles/products/design-tokens/shadow.mdx
@@ -55,20 +55,10 @@ CSSでは`box-shadow`や`drop-shadow`を指しています。
 `LAYER0`は影なし。
 色は[透明色](/products/design-tokens/color/#h3-6)を使用しています。
 
-| トークン名 | 値（`box-shadow`） |
+| トークン名 | 値（`box-shadow`） | 利用コンポーネント例 |
 | :--- | :--- | :--- |
 | `LAYER0` | none |
-| `LAYER1` | 0 1px 2px 0 [`TRANSPARENCY_30`](/products/design-tokens/color/#h3-6) |
-| `LAYER2` | 0 2px 4px 1px [`TRANSPARENCY_30`](/products/design-tokens/color/#h3-6) |
-| `LAYER3` | 0 4px 8px 2px [`TRANSPARENCY_30`](/products/design-tokens/color/#h3-6) |
-| `LAYER4` | 0 8px 16px 4px [`TRANSPARENCY_30`](/products/design-tokens/color/#h3-6) |
-
-## レイヤー順序との関係
-高低差と[レイヤー順序](/products/design-tokens/z-index/)は原則連動します。
-
-| レイヤー順序 | 影 | 利用コンポーネント |
-| :--- | :--- | :--- | :--- |
-| - | `LAYER1` | [AppNavi](/products/components/app-navi/)<br />[Base](/products/components/base/#h3-0) |
-| `FIXED_MENU` | `LAYER2` | [RightFixedNote](/products/components/right-fixed-note/) |
-| `OVERLAP_BASE`<br />`OVERLAP` | `LAYER3` | [BottomFixedArea](/products/components/bottom-fixed-area/)<br />[Calendar](/products/components/calendar/)<br />[CompactInformationPanel](/products/components/compact-information-panel/)<br />[DialogBase](/products/components/base/#h3-1)<br />[Dropdown](/products/components/dropdown/)<br />[FloatArea](/products/components/float-area/)<br />[InformationPanel](/products/components/information-panel/) |
-| `FLASH_MESSAGE` | `LAYER4` | [FlashMessage](/products/components/flash-message/) |
+| `LAYER1` | 0 1px 2px 0 [`TRANSPARENCY_30`](/products/design-tokens/color/#h3-6) | [AppNavi](/products/components/app-navi/)<br />[Base](/products/components/base/#h3-0) |
+| `LAYER2` | 0 2px 4px 1px [`TRANSPARENCY_30`](/products/design-tokens/color/#h3-6) | [RightFixedNote](/products/components/right-fixed-note/)（左方向）<br />[Tooltip](/products/components/tooltip/) |
+| `LAYER3` | 0 4px 8px 2px [`TRANSPARENCY_30`](/products/design-tokens/color/#h3-6) | [BottomFixedArea](/products/components/bottom-fixed-area/)（上方向）<br />[Calendar](/products/components/calendar/)<br />[CompactInformationPanel](/products/components/compact-information-panel/)<br />[DialogBase](/products/components/base/#h3-1)<br />[Dropdown](/products/components/dropdown/)<br />[FloatArea](/products/components/float-area/)<br />[InformationPanel](/products/components/information-panel/) |
+| `LAYER4` | 0 8px 16px 4px [`TRANSPARENCY_30`](/products/design-tokens/color/#h3-6) | [FlashMessage](/products/components/flash-message/) |

--- a/content/articles/products/design-tokens/shadow.mdx
+++ b/content/articles/products/design-tokens/shadow.mdx
@@ -22,7 +22,9 @@ export const ShadowSample = ({depth = 1}) => {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        boxShadow: `${depth === 0 ? 'none' : `0 ${depth}px ${depth * 2}px ${((depth / 2) >= 1) ? (depth / 2) : 0}px ${defaultColor.TRANSPARENCY_30}`}`,
+        boxShadow: `${depth === 0
+          ? 'none'
+          : `0 ${2 ** (depth - 1)}px ${2 ** depth}px ${((depth - 1) >= 0) ? (2 ** (depth - 2)) : 0}px ${defaultColor.TRANSPARENCY_30}`}`,
       }}
     >LAYER{depth}</div>
   )
@@ -47,6 +49,7 @@ CSSでは`box-shadow`や`drop-shadow`を指しています。
   <ShadowSample depth={0} />
   <ShadowSample depth={1} />
   <ShadowSample depth={2} />
+  <ShadowSample depth={3} />
   <ShadowSample depth={4} />
 </ComponentPreview>
 


### PR DESCRIPTION
## 課題・背景

- #604 の続き

## やったこと

影のトークンの「レイヤー順序との関係」が実装とズレており、原則連動しているとはいえないため、実態に合わせて表現を見直しました。
- 「レイヤー順序との関係」を廃止
- セマンティクストークンに利用コンポーネントを追加

<!--
- 〇〇に追記
- 〇〇ページを追加

## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認

- Previewでみてね。

<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
- 
-->
## キャプチャ

|Before|After|
| --- | --- |
| <img width="770" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/64398878/33f0bcd1-2d95-4a1d-91ef-dccd8655c455"> | <img width="750" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/64398878/1a28bcd2-573e-43a0-b600-2c99751d473d"> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
