### PR TITLE
markedの非推奨になった機能をオフに設定

### DIFF
--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -50,6 +50,8 @@ const pickTypeColor = (value: string): string => {
   return TYPE_COLOR[pickType(value)]
 }
 
+marked.setOptions({ headerIds: false, mangle: false })
+
 export const ComponentPropsTable: FC<Props> = ({ name, showTitle }) => {
   const data = uiProps.filter((uiProp) => {
     return uiProp.displayName === name

--- a/src/components/article/PageIndex/PageIndex.tsx
+++ b/src/components/article/PageIndex/PageIndex.tsx
@@ -55,7 +55,7 @@ export const PageIndex: FC<Props> = ({ path, excludes, heading = 'h2', children 
     .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
 
   const injectedDescriptions: { [key: string]: string } = {}
-  marked.setOptions({ breaks: true }) //改行の手前にスペース*2がなくても<br>に変換したいので
+  marked.setOptions({ breaks: true, headerIds: false, mangle: false }) //改行の手前にスペース*2がなくても<br>に変換したいので
   React.Children.toArray(children)
     .filter((child: any) => {
       // <Description>タグ以外は除外

--- a/src/components/contents/AppWriting/AppWriting.tsx
+++ b/src/components/contents/AppWriting/AppWriting.tsx
@@ -26,6 +26,9 @@ const query = graphql`
     }
   }
 `
+
+marked.setOptions({ headerIds: false, mangle: false })
+
 export const AppWriting: FC = () => {
   const data = useStaticQuery<Queries.AppWritingTableQuery>(query)
 

--- a/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
+++ b/src/components/contents/BasicConceptTable/BasicConceptTable.tsx
@@ -26,6 +26,9 @@ const query = graphql`
     }
   }
 `
+
+marked.setOptions({ headerIds: false, mangle: false })
+
 export const BasicConceptTable: FC = () => {
   const data = useStaticQuery<Queries.BasicConceptTableQuery>(query)
 

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -58,6 +58,8 @@ type Props = {
   type: 'data' | 'reason'
 }
 
+marked.setOptions({ headerIds: false, mangle: false })
+
 export const IdiomaticUsageTable: FC<Props> = ({ type }) => {
   const data = useStaticQuery<Queries.IdiomaticUsageTableQuery>(query)
 


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1251

## やったこと
markedがv5にメジャーアップデートされ、以下の機能がdeprecatedになったようです。

- 見出しタグにIDを振る（ https://www.npmjs.com/package/marked-gfm-heading-id ）
- メールアドレスをエンコードする（ https://www.npmjs.com/package/marked-mangle ）

これらは、デフォルトでは有効になっているものの、今後は削除される予定とのことで、有効にしたい場合は別途パッケージをインストール必要があるとのこと。

SDSでは、どちらも使っていないので、警告メッセージに従い、明示的に無効にするようにしました。
```
marked.setOptions({ headerIds: false, mangle: false })
```

### 懸念点
デフォルトで有効だったものが削除予定、という状況なので、警告が出るのは仕方がないとは思うのですが、警告を消すためにオプションを追加しているような状態なのが少々悩ましいです。

とはいえ、キャッシュがない状態のビルド時（Netlify上でのビルドも該当します）に、コンポーネントが呼ばれるたびに警告が2つずつ出力され、2000行以上になるので、消せるのであれば消したい気持ちもあります。

## 動作確認
Airtable由来のコンテンツやComponentPropsTable、PageIndexのマークダウン変換にmarkedを使っています。

https://deploy-preview-705--smarthr-design-system.netlify.app/products/contents/
https://deploy-preview-705--smarthr-design-system.netlify.app/products/contents/app-writing/
https://deploy-preview-705--smarthr-design-system.netlify.app/products/components/accordion-panel/


## キャプチャ
見た目や機能に変更はありません