### PR TITLE
prism-react-rendererのメジャーアップデートに対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "postcss-syntax": "^0.36.2",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "2.8.8",
-    "prism-react-renderer": "^1.3.5",
+    "prism-react-renderer": "^2.0.4",
     "remark-emoji": "^2.2.0",
     "smarthr-normalize-css": "^1.1.0",
     "stylelint": "^15.6.3",

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -1,10 +1,8 @@
 import { PATTERNS_STORYBOOK_URL } from '@Constants/application'
 import { CSS_COLOR } from '@Constants/style'
 import { Script } from 'gatsby'
-import Highlight, { Language, defaultProps } from 'prism-react-renderer'
-import github from 'prism-react-renderer/themes/github'
-import vscode from 'prism-react-renderer/themes/vsDark'
-import React, { CSSProperties, FC, ReactNode, useState } from 'react'
+import { Highlight, themes } from 'prism-react-renderer'
+import React, { CSSProperties, FC, useState } from 'react'
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live'
 import * as ui from 'smarthr-ui'
 import { Gap, SeparateGap } from 'smarthr-ui/lib/components/Layout/type'
@@ -19,7 +17,7 @@ type LiveProviderProps = React.ComponentProps<typeof LiveProvider>
 
 type Props = {
   children: string
-  className?: Language
+  className?: string
   editable?: boolean
   isStorybook?: boolean
   withStyled?: boolean
@@ -32,7 +30,7 @@ type Props = {
   }
 
 const theme = {
-  ...github,
+  ...themes.github,
   ...{
     plain: {
       backgroundColor: CSS_COLOR.SEMANTICS_COLUMN,
@@ -97,10 +95,10 @@ export const CodeBlock: FC<Props> = ({
           {tsLoaded && (
             <LiveProvider
               code={code}
-              language={language as Language}
+              language={language}
               scope={{ ...React, ...ui, styled, css, ...scope }}
               theme={{
-                ...vscode,
+                ...themes.vsDark,
                 plain: {
                   color: CSS_COLOR.LIGHT_GREY_3,
                   backgroundColor: CSS_COLOR.TEXT_BLACK,
@@ -128,8 +126,8 @@ export const CodeBlock: FC<Props> = ({
   }
 
   return (
-    <Highlight {...defaultProps} code={code} language={language as Language} theme={isStorybook ? vscode : theme}>
-      {({ style, tokens, getLineProps, getTokenProps }): ReactNode => (
+    <Highlight code={code} language={language} theme={isStorybook ? themes.vsDark : theme}>
+      {({ style, tokens, getLineProps, getTokenProps }) => (
         <CodeWrapper>
           <PreContainer isStorybook={isStorybook}>
             <CopyButton text={code} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -12629,18 +12629,13 @@ prh@^5.4.4:
     diff "^4.0.1"
     js-yaml "^3.9.1"
 
-prism-react-renderer@*:
+prism-react-renderer@*, prism-react-renderer@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-2.0.4.tgz#df607d5ee1fdaeabf792b021bb7a91f7bd603a6f"
   integrity sha512-1fcayBPhlGWLjKHeZMA2eJbvLsq1YJsoP3CUOF0BNlobw4knAYS6EWHYawywaZ5zoIxYkgxuqrrkCj7b+135ow==
   dependencies:
     "@types/prismjs" "^1.26.0"
     clsx "^1.2.1"
-
-prism-react-renderer@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz#786bb69aa6f73c32ba1ee813fbe17a0115435085"
-  integrity sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==
 
 probe-image-size@^7.2.3:
   version "7.2.3"


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system/pull/646

## やったこと
prism-react-rendererがv1→v2になったので、breaking changeに対応しました。

renovateが作ったPRでは、モジュールがimportできずにビルドエラーになっていましたが、その他にprism-react-rendererがTS化したことで型の不整合が起きていた点も調整しています。

## 動作確認
`<CodeBlock>`コンポーネントで使用しているので、例えば以下のようなStorybookのプレビュー、LiveEditor、静的なコード表示が関係しますが、見た目や動作に影響は出ていません。

https://deploy-preview-718--smarthr-design-system.netlify.app/products/components/button/
https://deploy-preview-718--smarthr-design-system.netlify.app/operational-guideline/page-template/style-template/#h2-4

## キャプチャ
見た目への影響はありません。
