### PR TITLE
コンポーネント一覧でのリンク切れの修正

### DIFF
--- a/plugins/gatsby-source-component-captures/fetchComponentCaptures.ts
+++ b/plugins/gatsby-source-component-captures/fetchComponentCaptures.ts
@@ -2,6 +2,7 @@ const STORYBOOK_URL = 'https://story.smarthr-ui.dev'
 
 type Story = {
   kind: string
+  importPath: string
   tags: string[]
 }
 
@@ -10,12 +11,34 @@ type StoryKind = {
   iframeUrl: string
   thumbnailFileName: string
   displayName: string
+  componentPath: string
   numberOfStories: number
 }
 
 export type StoryGroup = {
   groupName: string
   storyKinds: StoryKind[]
+}
+
+const convertKebab = (target: string) => {
+  return target
+    .replace('SmartHR', 'smarthr') // 特殊なケース
+    .replace(/[^a-zA-Z0-9-]/g, '') // 全角文字などの半角英数字以外を除去
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase()
+}
+
+const convertComponentPath = (importPath: string, displayName: string) => {
+  const matches = importPath.match(/\.\/src\/components\/(.*)\.stories\.tsx/)
+  if (!matches) return ''
+  const componentDirPath = matches[1]
+    .split('/')
+    .slice(0, -2)
+    .map((item) => convertKebab(item))
+    .join('/')
+  const componentPathName = convertKebab(displayName)
+  return componentDirPath === '' ? componentPathName : `${componentDirPath}/${componentPathName}`
 }
 
 export const fetchComponentCaptures = async () => {
@@ -25,13 +48,14 @@ export const fetchComponentCaptures = async () => {
 
   const storyGroups: StoryGroup[] = []
   Object.keys(storiesMap).forEach((id) => {
-    const { kind, tags } = storiesMap[id]
+    const { kind, tags, importPath } = storiesMap[id]
     if (tags.includes('docs')) return // ドキュメントはコンポーネント一覧として表示しない
 
     const groupName = kind.split('/')[0]
     const displayName = kind.split('/')[1]
-    const iframeUrl = `${STORYBOOK_URL}/iframe.html?id=${encodeURIComponent(id)}&viewMode=story&shortcuts=false&singleStory=true`
     const thumbnailFileName = `${groupName}-${displayName}.png`
+    const iframeUrl = `${STORYBOOK_URL}/iframe.html?id=${encodeURIComponent(id)}&viewMode=story&shortcuts=false&singleStory=true`
+    const componentPath = convertComponentPath(importPath, displayName)
 
     // Groupが存在しない場合は新規作成
     const storyGroup = storyGroups.find((item) => item.groupName === groupName)
@@ -44,6 +68,7 @@ export const fetchComponentCaptures = async () => {
             iframeUrl,
             thumbnailFileName,
             displayName,
+            componentPath,
             numberOfStories: 1,
           },
         ],
@@ -59,6 +84,7 @@ export const fetchComponentCaptures = async () => {
         iframeUrl,
         thumbnailFileName,
         displayName,
+        componentPath,
         numberOfStories: 1,
       })
       return

--- a/plugins/gatsby-source-component-captures/fetchComponentCaptures.ts
+++ b/plugins/gatsby-source-component-captures/fetchComponentCaptures.ts
@@ -57,6 +57,11 @@ export const fetchComponentCaptures = async () => {
     const iframeUrl = `${STORYBOOK_URL}/iframe.html?id=${encodeURIComponent(id)}&viewMode=story&shortcuts=false&singleStory=true`
     const componentPath = convertComponentPath(importPath, displayName)
 
+    // 下記のものはSDSにページが無いので排除する
+    // TODO: 修正のための一時的な対応で、動的にSDSにコンポーネント用ページが存在するか判定するように修正する（もしくはSDSにもページを追加する）
+    if (groupName === 'Experimental（実験的）') return
+    if (['Balloon', 'SpreadsheetTable', 'FormControl', 'Fieldset', 'RadioButtonPanel', 'SideMenu'].includes(displayName)) return
+
     // Groupが存在しない場合は新規作成
     const storyGroup = storyGroups.find((item) => item.groupName === groupName)
     if (!storyGroup) {

--- a/plugins/gatsby-source-component-captures/gatsby-node.ts
+++ b/plugins/gatsby-source-component-captures/gatsby-node.ts
@@ -39,6 +39,7 @@ exports.createSchemaCustomization = async ({ actions }: { actions: Actions }) =>
       iframeUrl: String!
       thumbnailFileName: String!
       displayName: String!
+      componentPath: String!
       numberOfStories: Int!
     }
   `)

--- a/src/components/ComponentCaptures/ComponentCaptures.tsx
+++ b/src/components/ComponentCaptures/ComponentCaptures.tsx
@@ -1,6 +1,6 @@
 import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import { graphql, useStaticQuery } from 'gatsby'
-import React, { FC, useCallback } from 'react'
+import React, { FC } from 'react'
 import styled from 'styled-components'
 
 const query = graphql`
@@ -14,6 +14,7 @@ const query = graphql`
           iframeUrl
           thumbnailFileName
           displayName
+          componentPath
           numberOfStories
         }
       }
@@ -24,14 +25,6 @@ const query = graphql`
 // 一覧表示するサムネイル用画像は、`ts-node ./scripts/component-thumbnails/componentThumbnails.ts`を実行して生成します
 export const ComponentCaptures: FC = () => {
   const { allComponentCapture } = useStaticQuery<Queries.ComponentCaptureDataQuery>(query)
-  const convertKebab = useCallback((target: string) => {
-    return target
-      .replace(/[^a-zA-Z0-9-]/g, '') // 全角文字などの半角英数字以外を除去
-      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-      .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
-      .toLowerCase()
-  }, [])
-
   return (
     <Wrapper>
       {allComponentCapture.nodes.map((node) => (
@@ -41,7 +34,7 @@ export const ComponentCaptures: FC = () => {
             {node.storyKinds.map((storyKind) => {
               return storyKind.iframeUrl ? (
                 <li key={storyKind.iframeUrl}>
-                  <a href={`${convertKebab(storyKind.displayName)}/`}>
+                  <a href={`/products/components/${storyKind.componentPath}/`}>
                     <div>
                       {/* この画像はリンクテキストと同等の内容なので、altは空が適切 */}
                       {/* eslint-disable-next-line smarthr/a11y-image-has-alt-attribute */}


### PR DESCRIPTION
## 課題・背景

コンポーネント一覧で各項目にコンポーネントページへのリンクが貼られていたが、一部のコンポーネントでリンク切れになっていたので修正しました。

## やったこと

- 階層の深いコンポーネントページのパスが間違っていたので修正
- Storybookには存在するが、SDSに存在しないコンポーネントを表示しないように修正

## やらなかったこと

## 動作確認

## キャプチャ

下記のSDSに存在しないコンポーネントは表示しないようにしました。

- Balloon
- SpreadsheetTable
- FormControl
- Fieldset
- RadioButtonPanel
- SideMenu