### PR TITLE
コンポーネント一覧に表示するサムネイルをmdxファイルの有無で判定されるように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "format": "eslint --fix 'src/**/*.ts{,x}'",
     "format:text": "textlint --fix 'content/**/*.md{,x}'",
     "export:zip-images": "ts-node scripts/zipImages.ts",
+    "generate:thumbnails": "ts-node scripts/component-thumbnails/componentThumbnails.ts",
     "postinstall": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
## 課題・背景

https://github.com/kufu/smarthr-design-system/pull/727 に関連。

## やったこと

https://smarthr.design/products/components/ のページにコンポーネントのサムネイルの一覧とリンクを配置していますが、これらの情報はStorybook上から取得していました。
このとき、Storybookには存在するがSDS側にページ(mdx)として存在しないコンポーネントがあり、応急処置として直接それらのコンポーネント名をハードコーディングして除外していましたが、正式な処理としてmdxファイルの存在の有無で除外するようにしました。

## やらなかったこと

## 動作確認

https://deploy-preview-734--smarthr-design-system.netlify.app/products/components/

## キャプチャ

現時点でResponseMessageというSDSにはページの存在しないコンポーネントが一覧に表示されようとしてしまっています。
この修正PRのプレビューでは除外されています。

|Before|After|
| --- | --- |
| <img width="665" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/1369376/6786f499-7f4f-4690-b987-c0f101503749"> | <img width="665" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/1369376/a788a104-cbb3-423a-b738-b0cd1633f581"> |
