### PR TITLE
RadioButtonとSelectの使い分けを記述

### DIFF
--- a/content/articles/products/components/radio-button.mdx
+++ b/content/articles/products/components/radio-button.mdx
@@ -8,6 +8,25 @@ import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 
 <ComponentStory name="RadioButton" />
 
+## 使いどころ
+
+複数の選択肢から1つだけ選択する場合に使います。
+
+同様に[Select](../select/)も、複数から1つを選択するコンポーネントです。  
+それぞれの特長を考慮して、使い分けましょう。
+
+### RadioButtonとSelectの特長と使い分け
+
+それぞれの特長は以下の通りです。状況に応じて適切なコンポーネントを使いましょう。
+
+| | RadioButton | Select |
+| --- | --- | --- |
+| 選択肢 | 最初から表示されている | 格納されていて見えない |
+| メリット | Selectよりも、ひと手間少なく選択できる | RadioButtonに比べ、たくさんの項目を少しのスペースに表示できる |
+
+「選択肢の数が少ない場合」、「選択肢を連続して選択する場合」は、RaddioButtonを使うとよいでしょう。  
+「選択肢の数が多い場合」、「限られたスペースに表示する場合」は、Selectを使うとよいでしょう。
+
 ## Props
 
 <ComponentPropsTable name="RadioButton" />

--- a/content/articles/products/components/select.mdx
+++ b/content/articles/products/components/select.mdx
@@ -8,6 +8,25 @@ import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 
 <ComponentStory name="Select" />
 
+## 使いどころ
+
+複数の選択肢から1つだけ選択する場合に使います。
+
+同様に[RadioButton](../radio-button/)も、複数から1つを選択するコンポーネントです。  
+それぞれの特長を考慮して、使い分けましょう。
+
+### SelectとRadioButtonの特長と使い分け
+
+それぞれの特長は以下の通りです。状況に応じて適切なコンポーネントを使いましょう。
+
+| | Select | RadioButton | 
+| --- | --- | --- |
+| 選択肢 | 格納されていて見えない | 最初から表示されている | 
+| メリット | RadioButtonに比べ、たくさんの項目を少しのスペースに表示できる | Selectよりも、ひと手間少なく選択できる | 
+
+「選択肢の数が多い場合」、「限られたスペースに表示する場合」は、Selectを使うとよいでしょう。
+「選択肢の数が少ない場合」、「選択肢を連続して選択する場合」は、RaddioButtonを使うとよいでしょう。  
+
 ## Props
 
 <ComponentPropsTable name="Select" />


### PR DESCRIPTION
## 課題・背景

https://github.com/kufu/smarthr-design-system-issues/issues/1238

## やったこと

- RadioButton、Selectに「使いどころ」を追記
  - https://deploy-preview-736--smarthr-design-system.netlify.app/products/components/radio-button/
  - https://deploy-preview-736--smarthr-design-system.netlify.app/products/components/select/

### 参考にした資料

- [チェックボックス 対 ラジオボタン – U-Site](https://u-site.jp/alertbox/20040927)
  - RadioButton
    - 排他的な選択肢で、ユーザが 1 項目だけを選択しなければいけないときに使われる。
    - 全ての選択肢が常に表示されていて、ユーザが選択肢を見ながら考えやすい
- [選択式フォームをより使いやすくするポイント | knowledge / baigie](https://baigie.me/officialblog/2021/10/19/select_ui_usage/)
  - Select
    - 選択肢がリストに格納されるのでたくさんの選択肢を少しのスペースで配置できる
    - 選択肢が多い場合、一目で選択肢のすべてを確認することができず、一覧性が低い
    - RadioButtonと比べるとクリックが1回増えるため、反復作業にドロップダウンが使われていると、面倒さが増してしまう

## 動作確認

- Previewでみてね。

## 進め方

- たたき案をcommitし、#design_system_相談 で相談。
- フィードバックもらってfixさせる。 