### PR TITLE
アイコンページの表記ズレを修正

### DIFF
--- a/content/articles/basics/icons/index.mdx
+++ b/content/articles/basics/icons/index.mdx
@@ -47,8 +47,7 @@ SmartHRサービス全体で利用するアイコンです。
 | SmartHRオプション機能 | 通勤経路検索 | ![通勤経路検索アイコン](./images/icons/outline/Black/通勤経路検索.png) |  |
 | SmartHRオプション機能 | 配置シミュレーション | ![配置シミュレーションアイコン](./images/icons/outline/Black/配置シミュレーション.png) |  |
 | 仕様・サービス | サービス連携 | ![サービス連携アイコン](./images/icons/outline/Black/サービス連携.png) |  |
-| 仕様・サービス | 多言語化対応 | ![多言語化対応アイコン](./images/icon
-s/outline/Black/多言語化対応.png) |  |
+| 仕様・サービス | 多言語化対応 | ![多言語化対応アイコン](./images/icons/outline/Black/多言語化対応.png) |  |
 | 仕様・サービス | SAML/SSO認証 | ![SAML/SSO認証アイコン](./images/icons/旧デザイン/Black/SAML_SSO認証（旧デザインのため非推奨）.png) | 旧デザインのため、利用は非推奨です。 |
 | 仕様・サービス | API連携 | ![API連携アイコン](./images/icons/outline/Black/API連携.png) |  |
 | 仕様・サービス | 履歴閲覧・編集 | ![履歴閲覧・編集アイコン](./images/icons/outline/Black/履歴閲覧・編集.png) |  |


### PR DESCRIPTION
## 課題・背景
アイコンのページに表記ズレがあったので修正しました

## やったこと
- 表記ズレの修正


## やらなかったこと
- とくになし

## 動作確認
ちょっとまってくださいね


## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

