### PR TITLE
問い合わせ先の詳細一覧を削除

### DIFF
--- a/content/articles/contact.mdx
+++ b/content/articles/contact.mdx
@@ -7,24 +7,12 @@ order: 9
 SmartHR Design Systemに関して気づいたことがありましたら、いつでもお問い合わせ・フィードバックをください。
 
 ## お問い合わせ・フィードバック先
-- 株式会社SmartHR： smarthr-design-system@smarthr.co.jp
-- 社内Slack： `#design_system_相談`
-- Twitter： https://twitter.com/SHRDesignSystem
+- SmartHR社内Slack
+    -  `#design_system_相談`
+- メール
+    - smarthr-design-system@smarthr.co.jp
+- Twitter
+    - https://twitter.com/SHRDesignSystem
+    - リプライやDMでご連絡ください。
 
-### そのほかのお問い合わせ・フィードバック先
-以下のコンテンツは、別の方法でもお問い合わせ・フィードバックできます。
-
-#### 基本要素
-- [ロゴ・モーションロゴ・サウンドロゴのお問い合わせ](/basics/logos/#h2-3)
-- [イラストレーションのフィードバック](/basics/illustration/#h2-3)
-- [印刷ガイドラインのフィードバック](/basics/colors/printguideline/#h2-3)
-
-#### アクセシビリティ
-- [アクセシビリティ方針のお問い合わせ](/accessibility/policy/#h2-5)
-
-#### プロダクト
-- [ユーザビリティテストのフィードバック](/products/design-process/usability-test/#h2-3)
-
-#### コミュニケーション
-- [ジングルムービーのフィードバック](/communication/photography/jingle-movie/#h2-3)
-- [画面キャプチャのフィードバック](/communication/capture/#h2-1)
+また、各コンテンツページにも詳しいお問い合わせ・フィードバック先が掲載されています。


### PR DESCRIPTION
## 課題・背景
問い合わせポータルページには、問い合わせ先一覧を掲載していたのですが、
各コンテンツページによって問い合わせ先がそれぞれ異なり、運用が複雑になってきました。
そのため一覧を削除し、簡易にしました。

issue：https://app.asana.com/0/1204801913310809/1204841238502480/f

<!--
issueをリンクしてね
-->

## やったこと

-

<!--
- 〇〇に追記
- 〇〇ページを追加

## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認
https://deploy-preview-765--smarthr-design-system.netlify.app/contact/
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
- 
-->
## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
