### PR TITLE
Airtableコンテンツのモックデータを調整

### DIFF
--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -137,7 +137,7 @@ export const IdiomaticUsageTable: FC<Props> = ({ type }) => {
                       </tr>
                     </thead>
                     <tbody>
-                      {indexedUsageData[char].map((prop, index) => {
+                      {indexedUsageData[char]?.map((prop, index) => {
                         const matchReason = idiomaticUsageReason.find(
                           (reason) => prop.reason && prop.reason.includes(reason.recordId ?? ''),
                         )

--- a/src/constants/airtable.ts
+++ b/src/constants/airtable.ts
@@ -35,8 +35,9 @@ export const AIRTABLE_MOCK_DATA = AIRTABLE_CONTENTS.map((content) => {
       ng_example: '表記のNG事例',
       ok_example: '表記のOK事例',
       expected: '-',
-      reason: 'recMOCKDATA',
-      data: '-',
+      reason: () => {
+        return ['理由1', '理由2']
+      },
       order: 0,
     },
   }


### PR DESCRIPTION
## 課題・背景
ローカル環境でAirtable関連の環境変数がセットされていない場合には、モックデータを使うようになっていますが、Airtable上のコンテンツの一部が.mdxファイルに移ったり、あ行・か行…で分割して表示するようになった影響で、モックデータでは正常にビルドできなくなっていたので、調整しました。

## やったこと
- モックデータの更新
- データをあ行、か行…に分けた際に、該当の項目がないとエラーになっていたので、対応
  - これは、本番データでも起こり得るかもしれません（現状は全ての行カテゴリに項目があるので問題は起きていませんが） 

## 動作確認
本環境でのビルドには影響しません。

## キャプチャ
モックデータでビルドした場合は以下のようになります。
<img src="https://github.com/kufu/smarthr-design-system/assets/7822534/f346ba9f-5f38-4189-8457-00efc6470cef" alt width="500">

