### PR TITLE
レンジ記法のstylelint無効と差し戻し

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -15,6 +15,7 @@
   ],
   "rules": {
     "value-list-comma-space-after": null,
-    "custom-property-no-missing-var-function": null
+    "custom-property-no-missing-var-function": null,
+    "media-feature-range-notation": null
   }
 }

--- a/src/components/ColorPalette/ColorPalette.tsx
+++ b/src/components/ColorPalette/ColorPalette.tsx
@@ -48,7 +48,7 @@ const Wrapper = styled.div`
   width: calc(25% - 24px);
   height: auto;
 
-  @media (width <= ${defaultBreakpoint.SP}px) {
+  @media (max-width: ${defaultBreakpoint.SP}px) {
     width: calc(50% - 24px);
   }
 `

--- a/src/components/ComponentPreview/ProductWrapper.tsx
+++ b/src/components/ComponentPreview/ProductWrapper.tsx
@@ -67,16 +67,16 @@ const padding = css(
   ({ theme: { space } }) => css`
     padding-inline: ${space(1.5)};
 
-    @media (width <= 1440px) {
+    @media (max-width: 1440px) {
       padding-inline: ${space(1.25)};
     }
-    @media (width <= 1024px) {
+    @media (max-width: 1024px) {
       padding-inline: ${space(1)};
     }
-    @media (width <= 768px) {
+    @media (max-width: 768px) {
       padding-inline: ${space(0.75)};
     }
-    @media (width <= 480px) {
+    @media (max-width: 480px) {
       padding-inline: ${space(0.5)};
     }
   `,

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -136,7 +136,7 @@ const Nav = styled.nav`
   padding-block: 120px 48px;
   overflow-y: auto;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     padding-block: 0;
     overflow-y: visible;
   }

--- a/src/components/index/ContentNavigation/Category.tsx
+++ b/src/components/index/ContentNavigation/Category.tsx
@@ -66,7 +66,7 @@ export const Category: FC<Props> = ({ data }) => {
 const NavigationContainer = styled.div`
   display: flex;
   gap: 40px;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     display: block;
     gap: 0;
   }
@@ -74,7 +74,7 @@ const NavigationContainer = styled.div`
 
 const NavigationText = styled.div`
   width: 320px;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     width: 100%;
   }
   h2 {
@@ -93,10 +93,10 @@ const NavigationText = styled.div`
 const NavigationLinksContainer = styled.div`
   width: 832px;
   max-width: 100%;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     margin-top: 40px;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     width: 100%;
   }
 `
@@ -127,7 +127,7 @@ const ThumbnailImageWrapper = styled.div`
     height: 100%;
     object-fit: cover;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     max-height: 100%;
   }
 `
@@ -139,11 +139,11 @@ const NavigationLinks = styled.ul`
   list-style: none;
   margin: 0;
   padding: 0;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     display: block;
   }
   > li {
-    @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
       &:not(:first-child) {
         margin-top: 24px;
       }
@@ -176,7 +176,7 @@ const NavigationLinks = styled.ul`
 const CategoryImageWrapper = styled.div`
   width: 100%;
   height: 144px;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     width: auto;
 
     /*
@@ -218,7 +218,7 @@ const CategoryImageWrapper = styled.div`
         transition: background-color 0.2s;
       }
     }
-    @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
       border-left: 0;
       border-right: 0;
       border-radius: 0;

--- a/src/components/index/ContentNavigation/ContentNavigation.tsx
+++ b/src/components/index/ContentNavigation/ContentNavigation.tsx
@@ -46,7 +46,7 @@ const IndexNavigationContainer = styled.ul`
       margin-top: 104px;
     }
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     margin: 80px 16px 0;
     > li:not(:first-child) {
       margin-top: 80px;

--- a/src/components/index/Faq/FaqItem.tsx
+++ b/src/components/index/Faq/FaqItem.tsx
@@ -36,7 +36,7 @@ const QuestionText = styled.h3`
   font-size: ${CSS_FONT_SIZE.PX_28};
   line-height: 1.5;
   font-weight: normal;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     font-size: ${CSS_FONT_SIZE.PX_24};
   }
 `

--- a/src/components/index/Faq/FaqList.tsx
+++ b/src/components/index/Faq/FaqList.tsx
@@ -58,7 +58,7 @@ const IndexFaqContainer = styled.div`
       padding: 0;
     }
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     margin-top: 120px;
     > ul {
       gap: 56px 40px;
@@ -69,7 +69,7 @@ const IndexFaqContainer = styled.div`
       }
     }
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     margin: 120px 16px 0;
     > ul > li {
       width: 100%;

--- a/src/components/index/Gotcha.tsx
+++ b/src/components/index/Gotcha.tsx
@@ -188,10 +188,10 @@ const Heading = styled.div`
   aspect-ratio: 1272 / 352;
   @supports not (aspect-ratio: 1272 / 352) {
     height: calc((100vw - 160px) / 1272 * 352);
-    @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
       height: calc((100vw - 32px) / 1272 * 352);
     }
-    @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
       height: calc(100vw / 1272 * 352);
     }
   }
@@ -216,7 +216,7 @@ const ImageContainer = styled.div`
     border-radius: 4px;
     box-sizing: border-box;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     border-radius: 0;
     &::after {
       border-radius: 0;
@@ -266,11 +266,11 @@ const GotchaButton = styled.button`
   left: 40px;
   font-weight: bold;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     bottom: -27px;
   }
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     right: 16px;
     left: auto;
   }
@@ -364,10 +364,10 @@ const GotchaLinks = styled.div`
   left: 40px;
   width: 20%;
   max-width: 232px;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     top: calc(100% + 46px);
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     width: auto;
     max-width: 100%;
     position: relative;
@@ -408,7 +408,7 @@ const Label = styled.p`
   color: ${CSS_COLOR.TEXT_GREY};
   font-weight: bold;
   font-size: ${CSS_FONT_SIZE.PX_12};
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     left: 32px;
     right: auto;
   }

--- a/src/components/index/Introduction/Introduction.tsx
+++ b/src/components/index/Introduction/Introduction.tsx
@@ -37,14 +37,14 @@ export const Introduction: FC = () => {
 const IntroductionContainer = styled.div`
   width: 70%;
   margin: 0 0 0 auto;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     box-sizing: border-box;
     width: 100%;
     max-width: 420px;
     padding: 0 16px;
     margin-left: 0;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_1}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_1}) {
     margin: 0;
   }
 `
@@ -59,7 +59,7 @@ const StyledHeading = styled.h1`
   > span {
     display: inline-block;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     font-size: ${CSS_FONT_SIZE.PX_48};
     line-height: 1.5;
   }
@@ -75,7 +75,7 @@ const StyledText = styled.p`
   > span {
     display: inline-block;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     font-size: ${CSS_FONT_SIZE.PX_16};
     line-height: 2;
     > span {
@@ -93,14 +93,14 @@ const IndexImageContainer = styled.div`
     max-width: 50%;
     height: auto;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     margin: 72px 0 120px;
     border-bottom: solid 1px ${CSS_COLOR.LIGHT_GREY_1};
     > img {
       max-width: 192px;
     }
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     margin: 80px 0 0;
     padding: 0;
     > img {

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -106,7 +106,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   gap: 1rem;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     padding: 1rem;
   }
 

--- a/src/components/search/Search/SearchResultOuter.tsx
+++ b/src/components/search/Search/SearchResultOuter.tsx
@@ -47,7 +47,7 @@ const SearchPanel = styled(Base)`
   padding: 8px;
   box-sizing: border-box;
 
-  @media (width <= ${defaultBreakpoint.SP}px) {
+  @media (max-width: ${defaultBreakpoint.SP}px) {
     left: 0;
     width: 100%;
   }

--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -159,11 +159,11 @@ const Wrapper = styled.footer<{ isArticlePage: boolean }>`
           border: none;
         `}
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     padding-inline: 48px;
   }
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     padding-inline: 16px;
   }
 
@@ -202,7 +202,7 @@ const LayoutContainer = styled.div<{ isArticlePage: boolean }>`
           padding-top: 72px;
         `}
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_PC_1}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_1}) {
     grid-template:
       'col1 . col2' auto
       'col1 . col2' auto
@@ -212,7 +212,7 @@ const LayoutContainer = styled.div<{ isArticlePage: boolean }>`
     padding-top: 32px;
   }
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     grid-template:
       'col2' auto
       '.   ' 80px
@@ -249,7 +249,7 @@ const Col2Container = styled.div`
   align-items: start;
   gap: 40px;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_PC_1}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_1}) {
     grid-template:
       'introduction' 'foundation' 'basics' 'accessibility' 'products' 'communication' auto
       / 1fr;
@@ -272,7 +272,7 @@ const StyledH3 = styled.h3`
     margin-top: -8px;
   }
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     margin-bottom: 0;
 
     & + & {
@@ -287,7 +287,7 @@ const StyledUl = styled.ul`
   list-style: none;
   color: ${CSS_COLOR.TEXT_BLACK};
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     display: none;
   }
 
@@ -307,7 +307,7 @@ const StyledLink = styled(Link)`
 const StyledCopyright = styled.p`
   margin-top: 64px;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     margin-top: 40px;
   }
 

--- a/src/components/shared/GlobalStyle/GlobalStyle.tsx
+++ b/src/components/shared/GlobalStyle/GlobalStyle.tsx
@@ -5,7 +5,7 @@ import { createGlobalStyle } from 'styled-components'
 export const GlobalStyle = createGlobalStyle`
   :root {
     --header-height: 112px;
-    @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
       --header-height: 80px;
     }
   }

--- a/src/components/shared/Header/Header.tsx
+++ b/src/components/shared/Header/Header.tsx
@@ -147,18 +147,18 @@ const Wrapper = styled.header<{ isIndex: boolean }>`
   ${({ isIndex }) =>
     isIndex
       ? css`
-          @media (width <= ${CSS_SIZE.BREAKPOINT_PC_2}) {
+          @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_2}) {
             padding-inline: 48px;
           }
-          @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+          @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
             padding-inline: 24px;
           }
         `
       : css`
-          @media (width <= ${CSS_SIZE.BREAKPOINT_PC_2}) {
+          @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_2}) {
             padding-inline: 48px;
           }
-          @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+          @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
             padding-inline: 24px;
           }
         `}
@@ -169,13 +169,13 @@ const Container = styled(Cluster).attrs({ gap: { row: 0.75, column: 1 }, align: 
 const SiteName = styled(LinkComponent)`
   padding: 6px 10px;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     padding: revert;
   }
 
   img {
     display: block;
-    @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
       width: 204px;
       height: auto;
     }
@@ -192,11 +192,11 @@ const StyledNav = styled(Cluster).attrs({ gap: { row: 0.75, column: 0.5 }, justi
     margin: 0;
     padding: 0;
     gap: 6px;
-    @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
       display: none;
     }
     &.-optional {
-      @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+      @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
         display: none;
       }
     }
@@ -247,7 +247,7 @@ const StyledLink = styled(LinkComponent)`
   line-height: 1;
   color: ${defaultColor.TEXT_BLACK};
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_PC_1}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_1}) {
     padding-inline: 6px;
   }
 
@@ -284,11 +284,11 @@ const GlobalStyleForMenu = createGlobalStyle`
     box-shadow: 0 4px 8px 2px rgba(0, 0, 0, 0.24);
     bottom: 16px;
     max-height: 678px;
-    @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
       top: 1rem;
       right: calc(3rem - 12px);
     }
-    @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
       width: auto;
       right: calc(1.5rem - 12px);
       left: calc(1.5rem - 12px);
@@ -300,7 +300,7 @@ const MenuContainer = styled.div`
   display: none;
   align-items: center;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     display: flex;
   }
 `

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,14 +34,14 @@ export default Home
 
 const GotchaContainer = styled.div`
   margin: 40px 80px 192px;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_PC_1}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_1}) {
     margin-top: 48px;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     margin: 0 1rem 4rem;
     padding-top: 0;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     margin: 0 0 64px;
   }
 `
@@ -50,10 +50,10 @@ const IndexPageContainer = styled.div`
   max-width: ${CSS_SIZE.CONTENT_WIDTH};
   margin: 0 auto;
   padding: 0 120px;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     padding: 0 48px;
   }
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
     padding: 0;
 
     /*

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -33,7 +33,7 @@ const LoginContainer = styled.div`
   margin-top: var(--header-height);
   padding-inline: 16px;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     margin-top: 0;
   }
 `

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -55,7 +55,7 @@ const Wrapper = styled.div`
 const Main = styled.main`
   padding-inline: 16px;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     margin-top: 0;
   }
 `

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -423,11 +423,11 @@ const Main = styled.main`
   display: grid;
   grid-template: 'sidebar article index' auto / 1fr minmax(auto, 712px) 1fr;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_PC_1}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_1}) {
     grid-template: 'sidebar article .' auto / 1fr minmax(auto, 712px) minmax(40px, 1fr);
   }
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     grid-template: '. article .' auto / minmax(40px, 1fr) minmax(auto, 712px) minmax(40px, 1fr);
     margin-top: 0;
   }
@@ -451,7 +451,7 @@ const MainSidebar = styled.div`
     grid-column: nav;
   }
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     grid-column: article;
     display: block;
     position: static;
@@ -479,7 +479,7 @@ const MainIndexNav = styled.div`
     grid-column: nav;
   }
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_PC_1}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_PC_1}) {
     display: none;
   }
 `
@@ -490,7 +490,7 @@ const MainArticle = styled.article`
   padding-top: 112px;
   padding-bottom: 240px;
 
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     padding-bottom: 112px;
   }
 `
@@ -510,7 +510,7 @@ const MainArticleNav = styled.ul`
   display: grid;
   gap: 1rem;
   grid-template: 'left right' 1fr/1fr 1fr;
-  @media (width <= ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
+  @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     grid-template:
       'left' 1fr
       'right' 1fr


### PR DESCRIPTION
## 課題・背景

Media QueriesのRange Syntaxの記法を使っていましたが、Safariへの導入が最近だったことでレイアウトが崩れて見えてしまうユーザーがいたため差し戻します。

## やったこと

- Range Syntaxにする以前の書き方に戻しました
- stylelintのRange Syntaxのルールを無効にしました

## やらなかったこと


## 動作確認


## キャプチャ

見た目上の変化はありません
