### PR TITLE
游ゴシックがWindowsで見にくくなってしまう問題の対応

### DIFF
--- a/src/components/shared/GlobalStyle/GlobalStyle.tsx
+++ b/src/components/shared/GlobalStyle/GlobalStyle.tsx
@@ -24,7 +24,7 @@ export const GlobalStyle = createGlobalStyle`
 
   body {
     margin: 0;
-    font-family: SDSYuGothic, Yu Gothic, YuGothic, 游ゴシック体, sans-serif;
+    font-family: SDSYuGothic, 'Yu Gothic', YuGothic, sans-serif;
     line-height: ${defaultLeading.RELAXED};
     color: ${defaultColor.TEXT_BLACK};
     overflow-wrap: break-word;

--- a/src/components/shared/GlobalStyle/GlobalStyle.tsx
+++ b/src/components/shared/GlobalStyle/GlobalStyle.tsx
@@ -24,7 +24,7 @@ export const GlobalStyle = createGlobalStyle`
 
   body {
     margin: 0;
-    font-family: SDSYuGothic, 'Yu Gothic', YuGothic, sans-serif;
+    font-family: SDSYuGothic, Yu Gothic, YuGothic, sans-serif;
     line-height: ${defaultLeading.RELAXED};
     color: ${defaultColor.TEXT_BLACK};
     overflow-wrap: break-word;

--- a/src/components/shared/GlobalStyle/GlobalStyle.tsx
+++ b/src/components/shared/GlobalStyle/GlobalStyle.tsx
@@ -10,9 +10,21 @@ export const GlobalStyle = createGlobalStyle`
     }
   }
 
+  @font-face {
+    font-family: SDSYuGothic;
+    font-weight: 400;
+    src: local('Yu Gothic Medium');
+  }
+
+  @font-face {
+    font-family: SDSYuGothic;
+    font-weight: 700;
+    src: local('Yu Gothic Bold');
+  }
+
   body {
     margin: 0;
-    font-family: Yu Gothic Medium, 游ゴシック Medium, YuGothic, 游ゴシック体, sans-serif;
+    font-family: SDSYuGothic, Yu Gothic, YuGothic, 游ゴシック体, sans-serif;
     line-height: ${defaultLeading.RELAXED};
     color: ${defaultColor.TEXT_BLACK};
     overflow-wrap: break-word;


### PR DESCRIPTION
## 課題・背景

游ゴシックのフォントがWindows環境で見にくい状態になっていた

## やったこと

font-faceを使って太字の場合は`Yu Gothic Bold`が適用されるようにした

## やらなかったこと

## 動作確認
- https://deploy-preview-784--smarthr-design-system.netlify.app/accessibility/
- Windows11のChrome、EdgeでBeforeとAfterでフォントが見やすくなったことを確認済みです

## キャプチャ

|Before|After|
| --- | --- |
| <img width="750" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/1369376/77accc9a-349b-472a-a080-0f766a32dcb1"> | <img width="750" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/1369376/33f93bc9-815a-49b0-9ce8-4cea71c42cd7"> |
