### PR TITLE
Link/Storybookチェッカーの依存に@types/nodeを追加

### DIFF
--- a/scripts/content-checker/package.json
+++ b/scripts/content-checker/package.json
@@ -4,6 +4,7 @@
   "author": "SmartHR Design System Team",
   "license": "MIT",
   "dependencies": {
+    "@types/node": "^20.4.1",
     "glob": "^10.3.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"

--- a/scripts/content-checker/yarn.lock
+++ b/scripts/content-checker/yarn.lock
@@ -52,6 +52,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
+"@types/node@^20.4.1":
+  version "20.4.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.1.tgz#a6033a8718653c50ac4962977e14d0f984d9527d"
+  integrity sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==
+
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"


### PR DESCRIPTION
## 課題・背景
GitHub Actionsでの定期実行時にエラーが出ていた
https://github.com/kufu/smarthr-design-system/actions/runs/5503360958
https://github.com/kufu/smarthr-design-system/actions/runs/5503506784

## やったこと

エラーメッセージを確認するとTSのコンパイルに失敗しており、`fs/promise`や`path`などのNode.js本体に関する型定義が存在しないとなっています。また、
> Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

という記述もあるため、そのとおりに`@types/node`を追加したところ、エラーは出なくなりました。

## やらなかったこと
はっきりした原因は不明です。

[依存するTSバージョンのアップデート](https://github.com/kufu/smarthr-design-system/pull/778)が原因かとも考えましたが、ローカルでは再現しなかったのではっきりとは分かりません。

## 動作確認
このPRのブランチ（コミット [fd5b7c1](https://github.com/kufu/smarthr-design-system/commit/fd5b7c15543fccb73e0a55db3127d534fad2d248)）での手動実行でエラーはなくなっています：
https://github.com/kufu/smarthr-design-system/actions/runs/5505403567
https://github.com/kufu/smarthr-design-system/actions/runs/5505417046

## キャプチャ
SDS本体には影響ありません。