### PR TITLE
右サイドバーのページインデックスをCSRに変更

### DIFF
--- a/src/components/ComponentCaptures/ComponentCaptures.tsx
+++ b/src/components/ComponentCaptures/ComponentCaptures.tsx
@@ -29,7 +29,7 @@ export const ComponentCaptures: FC = () => {
     <Wrapper>
       {allComponentCapture.nodes.map((node) => (
         <ComponentGroup key={node.groupName}>
-          <h2>{node.groupName}</h2>
+          <h2 id={`component-${node.groupName}`}>{node.groupName}</h2>
           <ComponentList>
             {node.storyKinds.map((storyKind) => {
               return storyKind.iframeUrl ? (

--- a/src/components/article/IndexNav/IndexNav.tsx
+++ b/src/components/article/IndexNav/IndexNav.tsx
@@ -53,32 +53,34 @@ export const IndexNav: FC<Props> = ({ target }) => {
 
   return (
     <Nav>
-      <ul>
-        {nestedHeadings.map((depth2Item) => {
-          return (
-            <li key={depth2Item.fragmentId}>
-              {depth2Item.value !== '' && (
-                <Depth2Item>
-                  <Link to={`#${depth2Item.fragmentId}`}>{depth2Item.value}</Link>
-                </Depth2Item>
-              )}
-              {depth2Item.children.length > 0 && (
-                <ul>
-                  {depth2Item.children.map((depth3Item) => {
-                    return (
-                      <li key={depth3Item.fragmentId}>
-                        <Depth3Item>
-                          <Link to={`#${depth3Item.fragmentId}`}>{depth3Item.value}</Link>
-                        </Depth3Item>
-                      </li>
-                    )
-                  })}
-                </ul>
-              )}
-            </li>
-          )
-        })}
-      </ul>
+      {nestedHeadings.length > 0 && (
+        <ul>
+          {nestedHeadings.map((depth2Item) => {
+            return (
+              <li key={depth2Item.fragmentId}>
+                {depth2Item.value !== '' && (
+                  <Depth2Item>
+                    <Link to={`#${depth2Item.fragmentId}`}>{depth2Item.value}</Link>
+                  </Depth2Item>
+                )}
+                {depth2Item.children.length > 0 && (
+                  <ul>
+                    {depth2Item.children.map((depth3Item) => {
+                      return (
+                        <li key={depth3Item.fragmentId}>
+                          <Depth3Item>
+                            <Link to={`#${depth3Item.fragmentId}`}>{depth3Item.value}</Link>
+                          </Depth3Item>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
     </Nav>
   )
 }

--- a/src/components/article/PageIndex/PageIndex.tsx
+++ b/src/components/article/PageIndex/PageIndex.tsx
@@ -74,7 +74,7 @@ export const PageIndex: FC<Props> = ({ path, excludes, heading = 'h2', children 
           const itemName = item.pathList[item.pathList.length - 2]
           return (
             <React.Fragment key={idx}>
-              <PageTitle as={heading}>
+              <PageTitle as={heading} id={`page-${idx}`}>
                 <Link to={item.slug}>{item.title}</Link>
               </PageTitle>
               {injectedDescriptions[itemName] ? (

--- a/src/constants/application.ts
+++ b/src/constants/application.ts
@@ -1,5 +1,3 @@
-export const INDEXED_DEPTH = 3 // h3まではインデックスされる。
-
 // ログイン状態の確認用にアクセスするドキュメント
 export const PRIVATE_DOC_PATH = '/private/basics/romu-hanako-details.md'
 

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -9,18 +9,14 @@ import { GlobalStyle } from '@Components/shared/GlobalStyle/GlobalStyle'
 import { Header } from '@Components/shared/Header/Header'
 import { Private } from '@Components/shared/Private'
 import { RoundedBoxLink } from '@Components/shared/RoundedBoxLink'
-import { AIRTABLE_CONTENTS } from '@Constants/airtable'
-import { INDEXED_DEPTH } from '@Constants/application'
 import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import { MDXProvider, MDXProviderComponents } from '@mdx-js/react'
 import { PageProps, graphql } from 'gatsby'
 import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer'
-import React, { FC } from 'react'
+import React, { FC, useRef } from 'react'
 import styled from 'styled-components'
 
 import { Theme } from './Theme'
-
-import type { airtableContents } from '@Constants/airtable'
 
 const components: MDXProviderComponents = {
   pre: (props) => <div {...props} />,
@@ -64,7 +60,6 @@ export const query = graphql`
     mdx(id: { eq: $id }) {
       id
       body
-      rawBody
       headings {
         depth
         value
@@ -123,83 +118,16 @@ export type SidebarItem = {
 const Article: FC<Props> = ({ data }) => {
   const { mdx: article, parentCategoryAllMdx: parentCategory } = data
 
+  const articleRef: React.RefObject<HTMLElement> = useRef(null)
+
   if (!article) {
     return null
   }
 
-  const { frontmatter, headings, fields, rawBody } = article
+  const { frontmatter, fields } = article
   const slug = fields?.slug || ''
 
   const title = frontmatter?.title || ''
-
-  // Airtableコンテンツのheading。各項目をh2として扱う
-  const airTableHeadings = data.airTable.edges
-    .filter((edge) => {
-      return edge.node.data?.name && edge.node.data?.name !== ''
-    })
-    .map((edge) => {
-      return {
-        depth: 2,
-        value: edge.node.data?.name ?? '',
-        recordId: edge.node.data?.record_id ?? '',
-        name: edge.node.data?.name ?? '',
-        order: edge.node.data?.order ?? Number.MAX_SAFE_INTEGER,
-        fragmentId: '',
-      }
-    })
-
-  // Airtableコンテンツは、ページによりソート方法が異なるので、headingの順序もそれに合わせる
-  const airtableSortType =
-    AIRTABLE_CONTENTS.filter((item: airtableContents) => {
-      return item.pagePath === slug
-    })[0]?.sort || 'NONE'
-
-  if (airtableSortType === 'REVERSE') {
-    airTableHeadings.reverse()
-  }
-  if (airtableSortType === 'CHARACTER') {
-    airTableHeadings.sort((x, y) => (x.name && y.name ? x.name.localeCompare(y.name, 'ja') : -1))
-  }
-  if (airtableSortType === 'AIRTABLE') {
-    airTableHeadings.sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
-  }
-
-  // Mdxコンテンツのheading
-  const mdxHeadings =
-    headings
-      ?.map((heading) => {
-        return {
-          value: heading?.value ?? '',
-          depth: heading?.depth ?? -1,
-          recordId: '',
-          fragmentId: '',
-        }
-      })
-      ?.filter(({ depth }) => depth <= INDEXED_DEPTH) ?? []
-
-  const headingList = [...airTableHeadings, ...mdxHeadings]
-
-  // コンポーネントのページのPropsをheadingListに追加する
-  if (fields?.hierarchy && /^products\/components/.test(fields?.hierarchy)) {
-    // ページ内の全ての<ComponentPropsTable name="{対象}" showTitle />から、name属性の値を取り出す
-    const regex = /<ComponentPropsTable(?:\s+[^>]*?)?(?:\s+name="([^"]+)")(?:\s+[^>]*?)?(?:\s+showTitle(?:={true})?)\s*\/?>/gms
-    const propsHeadingList = []
-    let match
-    while ((match = regex.exec(rawBody)) !== null) {
-      propsHeadingList.push(match[1])
-    }
-    const propsIndex = headingList.findIndex((item) => item.value === 'Props')
-    if (propsIndex > -1 && propsHeadingList.length > 0) {
-      propsHeadingList.forEach((heading, index) => {
-        headingList.splice(propsIndex + index + 1, 0, {
-          value: `${heading} props`,
-          depth: 3,
-          recordId: '',
-          fragmentId: `props-${heading}`,
-        })
-      })
-    }
-  }
 
   //
   // サイドバー、「前へ」「次へ」コンポーネントのための配列作成
@@ -322,13 +250,11 @@ const Article: FC<Props> = ({ data }) => {
             <Sidebar path={slug ?? ''} nestedSidebarItems={nestedSidebarItems} />
           </MainSidebar>
 
-          {headingList.length > 0 && (
-            <MainIndexNav>
-              <IndexNav headings={headingList} />
-            </MainIndexNav>
-          )}
+          <MainIndexNav>
+            <IndexNav target={articleRef} />
+          </MainIndexNav>
 
-          <MainArticle>
+          <MainArticle ref={articleRef}>
             <MainArticleTitle>
               <h1>{title}</h1>
             </MainArticleTitle>


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1266

## やったこと
### レンダリングするタイミングの変更
右サイドバーにあるページ内の見出しへのナビゲーションを、ビルド時ではなくクライアントでのレンダリング時に生成するように変更しました。

これまでは`/src/templates/article.tsx`内でAirtableコンテンツおよびMDXファイル内の見出しタグを取得して`IndexNav`コンポーネントに渡していましたが、代わりに`<article>`要素のrefを渡して`IndexNav`コンポーネント側で見出しタグを取得するように変更しました。

クライアント側での動作なので、これまで表示できていなかったReactコンポーネント内の見出しなども表示できるようになりました。

### `INDEXED_DEPTH`の削除
これまでは、[`INDEXED_DEPTH`という定数が定義されており](https://github.com/kufu/smarthr-design-system/blob/1024578a501a106801a7acc09e7f76e4f24714b1/src/constants/application.ts#L1)、それによってどの見出しレベルまでをMDXから取得するかが決まっていましたが、article.tsxでの取得処理は不要になったので、この定数は削除しました。

`IndexNav`コンポーネントでは元から`h2`と`h3`が表示対象で、またAirtableコンテンツでは例外的に`h2`のみとなっていましたが、その点は変更ありません。

### Reactコンポーネント内の見出しにid属性値を追加
見出しタグにid属性がなかった場合は、`IndexNav`コンポーネント内で連番で付与するようになってはいますが、元からidが振られているほうが良いかと思うので、`ComponentCapture`と`PageIndex`コンポーネントにはid属性値を追加しました→ https://github.com/kufu/smarthr-design-system/commit/b816ae68a0eeec4edc3407bb98152493616c1f2d

## やらなかったこと
Reactコンポーネントで生成された見出しについては、引き続き[`article.tsx`でのコンポーネント変換処理](https://github.com/kufu/smarthr-design-system/blob/1024578a501a106801a7acc09e7f76e4f24714b1/src/templates/article.tsx#L30-L38)の対象にはならないので、`FragmentTitle`コンポーネントは適用されません。
なので、ホバー時のリンクアイコンが表示されません。

|アイコンあり|アイコンなし|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/a73b65cd-b41c-4138-8e4c-d60bdb9450d6" alt="" width="200"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/835107e0-b44c-47b2-afd7-93cea2b413ec" width="200" alt> |

アイコンが出るように、`IndexNav`コンポーネント内で、`FragmentTitle`を適用することもできそうですが、`h2`の中に`a`があるような状況では適用できないなどの事情もあるので、少々煩雑な処理になるかもしれません。

## 動作確認
- 見た目上、これまでと変わらないページ
  - https://deploy-preview-796--smarthr-design-system.netlify.app/foundation/
- Airtable由来のページ（h2まで）
  - https://deploy-preview-796--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/usage
- Reactコンポーネント内の見出しが表示できるようになったページ
  - https://deploy-preview-796--smarthr-design-system.netlify.app/products/contents/
  - https://deploy-preview-796--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data
  - https://deploy-preview-796--smarthr-design-system.netlify.app/products/components/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/9dc4fd64-9fce-4332-8c96-8627c75e98d0" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/dd80038d-bd79-404b-9276-9aa4a1b0fabe" alt width="350"> |
