### PR TITLE
用字用語：一覧のコンポーネントにReactのキーを追加

### DIFF
--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -146,15 +146,15 @@ export const IdiomaticUsageTable: FC<Props> = ({ type }) => {
                           <tr key={index}>
                             <RecommendTd>
                               <strong>
-                                {prop.okExample?.split(/(\u3000)/).map((word) => {
+                                {prop.okExample?.split(/(\u3000)/).map((word, wordIndex) => {
                                   // 全角スペース（u3000）があれば改行に変換
-                                  return word === '　' ? <br /> : word
+                                  return word === '　' ? <br key={wordIndex} /> : word
                                 })}
                               </strong>
                             </RecommendTd>
                             <NGTd>
-                              {prop.ngExample?.split(/(\u3000)/).map((word) => {
-                                return word === '　' ? <br /> : word
+                              {prop.ngExample?.split(/(\u3000)/).map((word, wordIndex) => {
+                                return word === '　' ? <br key={wordIndex} /> : word
                               })}
                             </NGTd>
                             <ReasonTd>


### PR DESCRIPTION
## 課題・背景
kufu/smarthr-design-system-issues#1262

#764 で、全角スペースによる改行を追加した際、Reactの`key`が不足していて、開発環境ではコンソールにエラーが出ている。
![screen](https://github.com/kufu/smarthr-design-system/assets/7822534/8f430351-6d24-4037-b6ea-867523260c8f)


## やったこと
ループ処理で出力する`<br />`エレメントにReactの `key`が付与できていなかったので追加しました。

## 動作確認
https://deploy-preview-798--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/data/

開発中以外は元からコンソールエラー出ないので変化がわかりませんが、ローカルではエラーが消えたことを確認しています。

## キャプチャ
見た目上の変化はありません