### PR TITLE
smarthr-ui v34のHeadingレベル周りのアップデートに対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "json-2-csv": "^4.0.0",
     "lint-staged": "^13.2.3",
     "micromark": "^4.0.0",
-    "micromark-extension-mdxjs": "^1.0.1",
+    "micromark-extension-mdxjs": "^2.0.0",
     "npm-run-all": "^4.1.5",
     "postcss-jsx": "^0.36.4",
     "postcss-syntax": "^0.36.2",

--- a/src/components/article/IndexNav/IndexNav.tsx
+++ b/src/components/article/IndexNav/IndexNav.tsx
@@ -1,6 +1,7 @@
 import { CSS_COLOR } from '@Constants/style'
 import { Link } from 'gatsby'
 import React, { FC, useEffect, useState } from 'react'
+import { Nav as NavComponent } from 'smarthr-ui'
 import styled from 'styled-components'
 
 type Props = { target: React.RefObject<HTMLElement> }
@@ -85,7 +86,7 @@ export const IndexNav: FC<Props> = ({ target }) => {
   )
 }
 
-const Nav = styled.nav`
+const Nav = styled(NavComponent)`
   display: block;
   padding-top: 160px;
   overflow-y: auto;

--- a/src/components/article/PageIndex/PageIndex.tsx
+++ b/src/components/article/PageIndex/PageIndex.tsx
@@ -74,9 +74,9 @@ export const PageIndex: FC<Props> = ({ path, excludes, heading = 'h2', children 
           const itemName = item.pathList[item.pathList.length - 2]
           return (
             <React.Fragment key={idx}>
-              <PageTitle as={heading} id={`page-${idx}`}>
+              <PageTitleHeading as={heading} id={`page-${idx}`}>
                 <Link to={item.slug}>{item.title}</Link>
-              </PageTitle>
+              </PageTitleHeading>
               {injectedDescriptions[itemName] ? (
                 <PageDescription dangerouslySetInnerHTML={{ __html: injectedDescriptions[itemName] }} />
               ) : (
@@ -104,7 +104,7 @@ const PageList = styled.div`
   }
 `
 
-const PageTitle = styled.h2`
+const PageTitleHeading = styled.h2`
   font-size: ${CSS_FONT_SIZE.PX_20};
   font-weight: bold;
   a {

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import { SidebarScrollContext } from '@Context/SidebarScrollContext'
 import { useLocation } from '@reach/router'
 import { Link } from 'gatsby'
 import React, { FC, Fragment, useContext, useLayoutEffect, useRef } from 'react'
-import { FaChevronDownIcon, Nav as NavComponent, defaultColor } from 'smarthr-ui'
+import { FaChevronDownIcon, Nav, defaultColor } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import type { SidebarItem } from '../../../templates/article'
@@ -54,85 +54,90 @@ export const Sidebar: FC<Props> = ({ path, nestedSidebarItems }) => {
   }
 
   return (
-    <Nav ref={sidebarRef} onScroll={handleScroll}>
-      {nestedSidebarItems.map((depth1Item) => (
-        <Fragment key={depth1Item.link}>
-          {/* 第1階層 */}
-          <Depth1Heading>
-            <Link to={depth1Item.link} aria-current={path === depth1Item.link}>
-              {depth1Item.title}
-            </Link>
-          </Depth1Heading>
+    <NavWrapper ref={sidebarRef} onScroll={handleScroll}>
+      <Nav>
+        {nestedSidebarItems.map((depth1Item) => (
+          <Fragment key={depth1Item.link}>
+            {/* 第1階層 */}
+            <Depth1Heading>
+              <Link to={depth1Item.link} aria-current={path === depth1Item.link}>
+                {depth1Item.title}
+              </Link>
+            </Depth1Heading>
 
-          {/* 第2階層 */}
-          {depth1Item.children.length > 0 && (
-            <ul>
-              {depth1Item.children.map((depth2Item, depth2Index) => (
-                <li key={depth2Item.link}>
-                  <Depth2Item>
-                    <Link to={depth2Item.link} aria-current={path === depth2Item.link}>
-                      {depth2Item.title}
-                    </Link>
+            {/* 第2階層 */}
+            {depth1Item.children.length > 0 && (
+              <ul>
+                {depth1Item.children.map((depth2Item, depth2Index) => (
+                  <li key={depth2Item.link}>
+                    <Depth2Item>
+                      <Link to={depth2Item.link} aria-current={path === depth2Item.link}>
+                        {depth2Item.title}
+                      </Link>
+                      {depth2Item.children.length > 0 && (
+                        <CaretButton
+                          aria-controls={`Depth3Items__${depth2Index}`}
+                          aria-expanded={path.includes(depth2Item.link)}
+                          onClick={onClickCaret}
+                        >
+                          <FaChevronDownIcon alt={path.includes(depth2Item.link) ? '閉じる' : '開く'} />
+                        </CaretButton>
+                      )}
+                    </Depth2Item>
+
+                    {/* 第3階層 */}
                     {depth2Item.children.length > 0 && (
-                      <CaretButton
-                        aria-controls={`Depth3Items__${depth2Index}`}
-                        aria-expanded={path.includes(depth2Item.link)}
-                        onClick={onClickCaret}
-                      >
-                        <FaChevronDownIcon alt={path.includes(depth2Item.link) ? '閉じる' : '開く'} />
-                      </CaretButton>
-                    )}
-                  </Depth2Item>
+                      <ul id={`Depth3Items__${depth2Index}`} aria-hidden={!path.includes(depth2Item.link)}>
+                        {depth2Item.children.map((depth3Item, depth3Index) => (
+                          <li key={depth3Item.link}>
+                            <Depth3Item>
+                              <Link to={depth3Item.link} aria-current={path === depth3Item.link}>
+                                {depth3Item.title}
+                              </Link>
+                              {depth3Item.children.length > 0 && (
+                                <CaretButton
+                                  aria-controls={`Depth4Items__${depth2Index}__${depth3Index}`}
+                                  aria-expanded={path.includes(depth3Item.link)}
+                                  onClick={onClickCaret}
+                                >
+                                  <FaChevronDownIcon alt={path.includes(depth3Item.link) ? '閉じる' : '開く'} />
+                                </CaretButton>
+                              )}
+                            </Depth3Item>
 
-                  {/* 第3階層 */}
-                  {depth2Item.children.length > 0 && (
-                    <ul id={`Depth3Items__${depth2Index}`} aria-hidden={!path.includes(depth2Item.link)}>
-                      {depth2Item.children.map((depth3Item, depth3Index) => (
-                        <li key={depth3Item.link}>
-                          <Depth3Item>
-                            <Link to={depth3Item.link} aria-current={path === depth3Item.link}>
-                              {depth3Item.title}
-                            </Link>
+                            {/* 第4階層 */}
                             {depth3Item.children.length > 0 && (
-                              <CaretButton
-                                aria-controls={`Depth4Items__${depth2Index}__${depth3Index}`}
-                                aria-expanded={path.includes(depth3Item.link)}
-                                onClick={onClickCaret}
+                              <ul
+                                id={`Depth4Items__${depth2Index}__${depth3Index}`}
+                                aria-hidden={!path.includes(depth3Item.link)}
                               >
-                                <FaChevronDownIcon alt={path.includes(depth3Item.link) ? '閉じる' : '開く'} />
-                              </CaretButton>
+                                {depth3Item.children.map((depth4Item) => (
+                                  <li key={depth4Item.link}>
+                                    <Depth4Item>
+                                      <Link to={depth4Item.link} aria-current={path === depth4Item.link}>
+                                        {depth4Item.title}
+                                      </Link>
+                                    </Depth4Item>
+                                  </li>
+                                ))}
+                              </ul>
                             )}
-                          </Depth3Item>
-
-                          {/* 第4階層 */}
-                          {depth3Item.children.length > 0 && (
-                            <ul id={`Depth4Items__${depth2Index}__${depth3Index}`} aria-hidden={!path.includes(depth3Item.link)}>
-                              {depth3Item.children.map((depth4Item) => (
-                                <li key={depth4Item.link}>
-                                  <Depth4Item>
-                                    <Link to={depth4Item.link} aria-current={path === depth4Item.link}>
-                                      {depth4Item.title}
-                                    </Link>
-                                  </Depth4Item>
-                                </li>
-                              ))}
-                            </ul>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </li>
-              ))}
-            </ul>
-          )}
-        </Fragment>
-      ))}
-    </Nav>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Fragment>
+        ))}
+      </Nav>
+    </NavWrapper>
   )
 }
 
-const Nav = styled(NavComponent)`
+const NavWrapper = styled.div`
   padding-block: 120px 48px;
   overflow-y: auto;
 

--- a/src/components/article/Sidebar/Sidebar.tsx
+++ b/src/components/article/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import { SidebarScrollContext } from '@Context/SidebarScrollContext'
 import { useLocation } from '@reach/router'
 import { Link } from 'gatsby'
 import React, { FC, Fragment, useContext, useLayoutEffect, useRef } from 'react'
-import { FaChevronDownIcon, defaultColor } from 'smarthr-ui'
+import { FaChevronDownIcon, Nav as NavComponent, defaultColor } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import type { SidebarItem } from '../../../templates/article'
@@ -58,11 +58,11 @@ export const Sidebar: FC<Props> = ({ path, nestedSidebarItems }) => {
       {nestedSidebarItems.map((depth1Item) => (
         <Fragment key={depth1Item.link}>
           {/* 第1階層 */}
-          <Depth1Item>
+          <Depth1Heading>
             <Link to={depth1Item.link} aria-current={path === depth1Item.link}>
               {depth1Item.title}
             </Link>
-          </Depth1Item>
+          </Depth1Heading>
 
           {/* 第2階層 */}
           {depth1Item.children.length > 0 && (
@@ -132,7 +132,7 @@ export const Sidebar: FC<Props> = ({ path, nestedSidebarItems }) => {
   )
 }
 
-const Nav = styled.nav`
+const Nav = styled(NavComponent)`
   padding-block: 120px 48px;
   overflow-y: auto;
 
@@ -203,7 +203,7 @@ const Nav = styled.nav`
   }
 `
 
-const Depth1Item = styled.h2`
+const Depth1Heading = styled.h2`
   margin-block: 0 24px;
   font-size: 14px;
   font-weight: bold;

--- a/src/components/index/Faq/FaqItem.tsx
+++ b/src/components/index/Faq/FaqItem.tsx
@@ -19,7 +19,7 @@ type Props = {
 export const FaqItem: FC<Props> = ({ data }) => {
   return (
     <Wrapper>
-      <QuestionText>{data.question}</QuestionText>
+      <QuestionHeading>{data.question}</QuestionHeading>
       <AnswerText>{data.answer}</AnswerText>
       <RoundedBoxLink path={data.path} label="もっと詳しく" title={data.linkLabel} />
     </Wrapper>
@@ -31,7 +31,7 @@ const Wrapper = styled.div`
   text-align: left;
 `
 
-const QuestionText = styled.h3`
+const QuestionHeading = styled.h3`
   margin: 0;
   font-size: ${CSS_FONT_SIZE.PX_28};
   line-height: 1.5;

--- a/src/components/search/IndexList/IndexList.tsx
+++ b/src/components/search/IndexList/IndexList.tsx
@@ -1,6 +1,7 @@
 import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import { Link, graphql, useStaticQuery } from 'gatsby'
-import React, { FC, Fragment } from 'react'
+import React, { FC } from 'react'
+import { Section } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import navigationItem from '../../../data/navigationItem.json'
@@ -101,7 +102,7 @@ export const IndexList: FC = () => {
         if (!level2Item) return null
         const level3Items = allLevel3Items.filter((level3item) => level3item.parent === level2Item.link)
         return (
-          <Fragment key={level2Item.link}>
+          <Section key={level2Item.link}>
             <h2>
               <Link to={`/${level2Item.link}/`}>{level2Item.title}</Link>
             </h2>
@@ -110,7 +111,7 @@ export const IndexList: FC = () => {
             {level3Items.map((level3Item) => {
               const level4Items = allLevel4Items.filter((level4Item) => level4Item.parent === level3Item.link)
               return (
-                <Fragment key={level3Item.link}>
+                <Section key={level3Item.link}>
                   <h3>
                     <Link to={`/${level3Item.link}/`}>{level3Item.title}</Link>
                   </h3>
@@ -127,10 +128,10 @@ export const IndexList: FC = () => {
                       })}
                     </ul>
                   )}
-                </Fragment>
+                </Section>
               )
             })}
-          </Fragment>
+          </Section>
         )
       })}
 

--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -1,6 +1,7 @@
 import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import { Link, graphql, useStaticQuery } from 'gatsby'
 import React, { FC } from 'react'
+import { Section } from 'smarthr-ui'
 import styled, { css } from 'styled-components'
 
 import navigationItem from '../../../data/navigationItem.json'
@@ -104,7 +105,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
     <Wrapper isArticlePage={isArticlePage}>
       <LayoutContainer isArticlePage={isArticlePage}>
         <Col1Container>
-          <StyledLogo>SmartHR Design System</StyledLogo>
+          <StyledLogoHeading>SmartHR Design System</StyledLogoHeading>
           <FootStaticLinks />
         </Col1Container>
 
@@ -112,10 +113,10 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
           {navigationItem.map(({ title, key, path }) => {
             const items = footerCategories[key as keyof Queries.FooterQuery]?.nodes ?? []
             return (
-              <div key={key} style={{ gridArea: key }}>
-                <StyledH3>
+              <Section key={key} style={{ gridArea: key }}>
+                <StyledH3Heading>
                   <StyledLink to={path}>{title}</StyledLink>
-                </StyledH3>
+                </StyledH3Heading>
                 {items.length > 0 && (
                   <StyledUl>
                     {items.map(({ fields, frontmatter }) => {
@@ -129,7 +130,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
                     })}
                   </StyledUl>
                 )}
-              </div>
+              </Section>
             )
           })}
         </Col2Container>
@@ -223,7 +224,7 @@ const LayoutContainer = styled.div<{ isArticlePage: boolean }>`
   }
 `
 
-const StyledLogo = styled.h2`
+const StyledLogoHeading = styled.h2`
   margin-block: 9px 0;
   font-size: ${CSS_FONT_SIZE.PX_14};
   font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
@@ -261,7 +262,7 @@ const CopyrightContainer = styled.div`
   grid-area: copy;
 `
 
-const StyledH3 = styled.h3`
+const StyledH3Heading = styled.h3`
   margin: 0;
   font-size: ${CSS_FONT_SIZE.PX_16};
   line-height: 2.26;

--- a/src/components/shared/Private/Private.tsx
+++ b/src/components/shared/Private/Private.tsx
@@ -58,14 +58,14 @@ export const Private: FC<Props> = ({ path }) => {
   return isShow ? (
     // ログイン済みの時の表示
     <AuthView>
-      <AuthViewTitle>
-        <StyledLockIcon size={16} />
+      <AuthViewHeading>
+        <StyledLockIcon />
         <span>SmartHR社従業員限定コンテンツ</span>
         <Tooltip>
           <StyledExclamationIcon />
           <p className="message">制作パートナー・グループ会社への共有は可能ですが、SNS等へのシェアはしないでください。</p>
         </Tooltip>
-      </AuthViewTitle>
+      </AuthViewHeading>
       <div dangerouslySetInnerHTML={{ __html: privateData }}></div>
     </AuthView>
   ) : (
@@ -144,7 +144,7 @@ const AuthView = styled.div`
   }
 `
 
-const AuthViewTitle = styled.h2`
+const AuthViewHeading = styled.h2`
   font-weight: bold;
   margin: 0 !important; /* md用のスタイルを上書きする */
   padding: 0;

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -25,7 +25,7 @@ const SearchPage: FC = () => {
         <Header />
 
         <Main>
-          <PageTitle id="label-for-search-input">SmartHR Design Systemを検索</PageTitle>
+          <PageHeading id="label-for-search-input">SmartHR Design Systemを検索</PageHeading>
           <Search className="ais-SearchBox__root">
             <InstantSearch indexName={process.env.GATSBY_ALGOLIA_INDEX_NAME || ''} searchClient={searchClient}>
               <CustomSearchBox
@@ -60,7 +60,7 @@ const Main = styled.main`
   }
 `
 
-const PageTitle = styled.h1`
+const PageHeading = styled.h1`
   margin-block: 140px 40px;
   text-align: center;
   line-height: 1.25;

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -14,6 +14,7 @@ import { MDXProvider, MDXProviderComponents } from '@mdx-js/react'
 import { PageProps, graphql } from 'gatsby'
 import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer'
 import React, { FC, useRef } from 'react'
+import { Article as ArticleComponent } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import { Theme } from './Theme'
@@ -410,7 +411,7 @@ const MainIndexNav = styled.div`
   }
 `
 
-const MainArticle = styled.article`
+const MainArticle = styled(ArticleComponent)`
   grid-area: article;
   min-width: 0;
   padding-top: 112px;

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -119,7 +119,7 @@ export type SidebarItem = {
 const Article: FC<Props> = ({ data }) => {
   const { mdx: article, parentCategoryAllMdx: parentCategory } = data
 
-  const articleRef: React.RefObject<HTMLElement> = useRef(null)
+  const articleRef: React.RefObject<HTMLDivElement> = useRef(null)
 
   if (!article) {
     return null
@@ -255,41 +255,43 @@ const Article: FC<Props> = ({ data }) => {
             <IndexNav target={articleRef} />
           </MainIndexNav>
 
-          <MainArticle ref={articleRef}>
-            <MainArticleTitle>
-              <h1>{title}</h1>
-            </MainArticleTitle>
-            <MDXStyledWrapper>
-              <MDXProvider components={{ ...components, ...shortcodes }}>
-                <MDXRenderer>{data.mdx?.body}</MDXRenderer>
-              </MDXProvider>
-            </MDXStyledWrapper>
+          <MainArticle>
+            <div ref={articleRef}>
+              <MainArticleTitle>
+                <h1>{title}</h1>
+              </MainArticleTitle>
+              <MDXStyledWrapper>
+                <MDXProvider components={{ ...components, ...shortcodes }}>
+                  <MDXRenderer>{data.mdx?.body}</MDXRenderer>
+                </MDXProvider>
+              </MDXStyledWrapper>
 
-            {/* 前へ・次へ表示 */}
-            <MainArticleNav>
-              {prevPageIndex !== null && (
-                <PrevArticleLinkWrapper>
-                  <RoundedBoxLink
-                    path={sidebarItems[prevPageIndex].link}
-                    label="前へ"
-                    title={sidebarItems[prevPageIndex].title}
-                    align="left"
-                    caretPosition="left"
-                  />
-                </PrevArticleLinkWrapper>
-              )}
-              {nextPageIndex !== null && (
-                <NextArticleLinkWrapper>
-                  <RoundedBoxLink
-                    path={sidebarItems[nextPageIndex].link}
-                    label="次へ"
-                    title={sidebarItems[nextPageIndex].title}
-                    align="right"
-                    caretPosition="right"
-                  />
-                </NextArticleLinkWrapper>
-              )}
-            </MainArticleNav>
+              {/* 前へ・次へ表示 */}
+              <MainArticleNav>
+                {prevPageIndex !== null && (
+                  <PrevArticleLinkWrapper>
+                    <RoundedBoxLink
+                      path={sidebarItems[prevPageIndex].link}
+                      label="前へ"
+                      title={sidebarItems[prevPageIndex].title}
+                      align="left"
+                      caretPosition="left"
+                    />
+                  </PrevArticleLinkWrapper>
+                )}
+                {nextPageIndex !== null && (
+                  <NextArticleLinkWrapper>
+                    <RoundedBoxLink
+                      path={sidebarItems[nextPageIndex].link}
+                      label="次へ"
+                      title={sidebarItems[nextPageIndex].title}
+                      align="right"
+                      caretPosition="right"
+                    />
+                  </NextArticleLinkWrapper>
+                )}
+              </MainArticleNav>
+            </div>
           </MainArticle>
         </Main>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,6 +3017,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
+"@types/estree@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
+
 "@types/get-port@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/get-port/-/get-port-3.2.0.tgz#f9e0a11443cc21336470185eae3dfba4495d29bc"
@@ -3302,6 +3307,11 @@
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+
+"@types/unist@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.0.tgz#988ae8af1e5239e89f9fbb1ade4c935f4eeedf9a"
+  integrity sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==
 
 "@types/vfile-message@*":
   version "2.0.0"
@@ -10797,6 +10807,20 @@ micromark-extension-mdx-expression@^1.0.0:
     micromark-util-types "^1.0.0"
     uvu "^0.5.0"
 
+micromark-extension-mdx-expression@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-2.0.0.tgz#569694ba7f972985ada598022868a44d5c65a93c"
+  integrity sha512-hUI6PJCCVaymBF5paL29sOpcbtVXtumDdJgBDxN+tbHlXAqQwNl4EhhJfx4fe7bUpEZzcFRIBAeOiGq7hsZBXw==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-factory-mdx-expression "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-events-to-acorn "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
 micromark-extension-mdx-jsx@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-1.0.2.tgz#966817c1c0920e6bf311dd75e07eaf4a069d933b"
@@ -10812,12 +10836,35 @@ micromark-extension-mdx-jsx@^1.0.0:
     uvu "^0.5.0"
     vfile-message "^3.0.0"
 
+micromark-extension-mdx-jsx@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-2.0.0.tgz#cee85ca1d1dca73fdf8466b56e92a094d4955625"
+  integrity sha512-hp6ff4eympWcq3Jh9XIJmJPNpM2RNmBjz5vvU1YkND7h4UwjSZas7lXSrAJjtTG7Z56JMMTyowwcbPkAjZmwMg==
+  dependencies:
+    "@types/acorn" "^4.0.0"
+    "@types/estree" "^1.0.0"
+    devlop "^1.0.0"
+    estree-util-is-identifier-name "^2.0.0"
+    micromark-factory-mdx-expression "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    vfile-message "^4.0.0"
+
 micromark-extension-mdx-md@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/micromark-extension-mdx-md/-/micromark-extension-mdx-md-1.0.0.tgz#382f5df9ee3706dd120b51782a211f31f4760d22"
   integrity sha512-xaRAMoSkKdqZXDAoSgp20Azm0aRQKGOl0RrS81yGu8Hr/JhMsBmfs4wR7m9kgVUIO36cMUQjNyiyDKPrsv8gOw==
   dependencies:
     micromark-util-types "^1.0.0"
+
+micromark-extension-mdx-md@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz#1d252881ea35d74698423ab44917e1f5b197b92d"
+  integrity sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==
+  dependencies:
+    micromark-util-types "^2.0.0"
 
 micromark-extension-mdxjs-esm@^1.0.0:
   version "1.0.2"
@@ -10833,6 +10880,21 @@ micromark-extension-mdxjs-esm@^1.0.0:
     uvu "^0.5.0"
     vfile-message "^3.0.0"
 
+micromark-extension-mdxjs-esm@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-2.0.1.tgz#0049c390716c6765bfc02e9a6afb2aab2b398b0b"
+  integrity sha512-HLPrY5XLYzFtG5KxEcZXfUV/SOy9Eu3R+dnpP1P6ko/ZO9xceGxmgJOAMq4r/rPLrHaEosfhNIOXDcvFSkVfKQ==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-events-to-acorn "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-position-from-estree "^2.0.0"
+    vfile-message "^4.0.0"
+
 micromark-extension-mdxjs@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs/-/micromark-extension-mdxjs-1.0.0.tgz#772644e12fc8299a33e50f59c5aa15727f6689dd"
@@ -10847,19 +10909,19 @@ micromark-extension-mdxjs@^1.0.0:
     micromark-util-combine-extensions "^1.0.0"
     micromark-util-types "^1.0.0"
 
-micromark-extension-mdxjs@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs/-/micromark-extension-mdxjs-1.0.1.tgz#f78d4671678d16395efeda85170c520ee795ded8"
-  integrity sha512-7YA7hF6i5eKOfFUzZ+0z6avRG52GpWR8DL+kN47y3f2KhxbBZMhmxe7auOeaTBrW2DenbbZTf1ea9tA2hDpC2Q==
+micromark-extension-mdxjs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs/-/micromark-extension-mdxjs-2.0.0.tgz#947171b002198bc883d0ec93b1f8ed814c1bb571"
+  integrity sha512-cICbQUdcgFvfg3JH9XTqZoa1ONCZI0GsiOvl9672Ka3SilIo9kMmaKLdSd/QrDgNGxrirWtZfFh19DSKJUivWQ==
   dependencies:
     acorn "^8.0.0"
     acorn-jsx "^5.0.0"
-    micromark-extension-mdx-expression "^1.0.0"
-    micromark-extension-mdx-jsx "^1.0.0"
-    micromark-extension-mdx-md "^1.0.0"
-    micromark-extension-mdxjs-esm "^1.0.0"
-    micromark-util-combine-extensions "^1.0.0"
-    micromark-util-types "^1.0.0"
+    micromark-extension-mdx-expression "^2.0.0"
+    micromark-extension-mdx-jsx "^2.0.0"
+    micromark-extension-mdx-md "^2.0.0"
+    micromark-extension-mdxjs-esm "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-types "^2.0.0"
 
 micromark-factory-destination@^1.0.0:
   version "1.0.0"
@@ -10912,6 +10974,20 @@ micromark-factory-mdx-expression@^1.0.0:
     unist-util-position-from-estree "^1.0.0"
     uvu "^0.5.0"
     vfile-message "^3.0.0"
+
+micromark-factory-mdx-expression@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.1.tgz#f2a9724ce174f1751173beb2c1f88062d3373b1b"
+  integrity sha512-F0ccWIUHRLRrYp5TC9ZYXmZo+p2AM13ggbsW4T0b5CRKP8KHVRB8t4pwtBgTxtjRmwrK0Irwm7vs2JOZabHZfg==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-events-to-acorn "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-position-from-estree "^2.0.0"
+    vfile-message "^4.0.0"
 
 micromark-factory-space@^1.0.0:
   version "1.0.0"
@@ -11079,6 +11155,20 @@ micromark-util-events-to-acorn@^1.0.0:
     micromark-util-types "^1.0.0"
     uvu "^0.5.0"
     vfile-message "^3.0.0"
+
+micromark-util-events-to-acorn@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.1.tgz#d7febd4ba54b9641a911edde2a9068fd68f099b7"
+  integrity sha512-3pf0pxvFaTxzTwisMHmEk5lnW7oSU/oRZxpZcrdx/voJgCpPaspexc89mJodW4ekATo1UILtZvjESclKONSB6w==
+  dependencies:
+    "@types/acorn" "^4.0.0"
+    "@types/estree" "^1.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    estree-util-visit "^1.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    vfile-message "^4.0.0"
 
 micromark-util-html-tag-name@^1.0.0:
   version "1.0.0"
@@ -16023,6 +16113,13 @@ unist-util-position-from-estree@^1.0.0, unist-util-position-from-estree@^1.1.0:
   dependencies:
     "@types/unist" "^2.0.0"
 
+unist-util-position-from-estree@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz#d94da4df596529d1faa3de506202f0c9a23f2200"
+  integrity sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
 unist-util-position@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.1.0.tgz#1c42ee6301f8d52f47d14f62bbdb796571fa2d47"
@@ -16093,6 +16190,13 @@ unist-util-stringify-position@^3.0.0:
   integrity sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==
   dependencies:
     "@types/unist" "^2.0.0"
+
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
 
 unist-util-visit-children@^1.0.0:
   version "1.1.4"
@@ -16401,6 +16505,14 @@ vfile-message@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
+
+vfile-message@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.2.tgz#c883c9f677c72c166362fd635f21fc165a7d1181"
+  integrity sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
 
 vfile-reporter@^7.0.0:
   version "7.0.5"


### PR DESCRIPTION
## 課題・背景
smarthr-ui v34で[SectioningContent](https://smarthr.design/products/components/sectioning-content/)が追加されて見出しレベルが自動計算されるようになっており、合わせて追加されたESLintのルール（`a11y-heading-in-sectioning-content`）で警告が出る箇所がある。

lintの警告が出ている例：https://github.com/kufu/smarthr-design-system/actions/runs/5581720220 → Annotations

## やったこと
### SectioningContent対応
Linterのメッセージに従って、`Nav` `Article`などのsmarthr-uiコンポーネントを利用したり、見出しコンポーネントの名称を修正したりしました。

### 依存パッケージのアップデート
また、直接関連はないのですが、#806 でのmicromarkのメジャーアップデートにより型エラーが出ていたので、関連するパッケージ[micromark-extension-mdxjs
](https://www.npmjs.com/package/micromark-extension-mdxjs) も合わせてアップデートしました（Renovateを待っていると1週間後になりそうなので）。

## やらなかったこと
~~`nav`要素と`article`要素をそれぞれ`Nav`コンポーネントと`Article`コンポーネントに置き換えた部分で、コンポーネントに`ref={}`が定義されていると型エラーになるようです。~~

以下の2箇所です：
https://github.com/kufu/smarthr-design-system/blob/ea58cd78a68c3900ba917ba7d1af4d5a13d508dd/src/templates/article.tsx#L258
https://github.com/kufu/smarthr-design-system/blob/ea58cd78a68c3900ba917ba7d1af4d5a13d508dd/src/components/article/Sidebar/Sidebar.tsx#L57

~~ビルドには支障がないので、今のところ対応はしていません。対応するとなると、`<div>`などで囲ってそちらに`ref={}`を適用するなどの方法でしょうか。~~
→ 動作としても正しくなかったので、`div`要素に`ref`を渡すように変更しました。

## 動作確認
ESLintは警告がなくなりました。
`npx tsc --noEmit`でもエラーはなくなりました。

micromarkは従業員限定コンテンツの表示に使用していますが、これまでどおりパスワードを入力して表示ができています。
例：https://deploy-preview-808--smarthr-design-system.netlify.app/basics/illustration/smarthr-co/

## キャプチャ
表示には影響ありません。
