### PR TITLE
右サイドバーに現在地のハイライト表示を追加

### DIFF
--- a/content/articles/products/contents/app-writing.mdx
+++ b/content/articles/products/contents/app-writing.mdx
@@ -2,6 +2,7 @@
 title: 'UIテキスト'
 description: ' '
 order: 4
+ignoreH3Nav: true
 ---
 
 アプリケーション上の表現で迷ったときの判断基準や、推奨する表記を記載しています。

--- a/content/articles/products/contents/idiomatic-usage/usage.mdx
+++ b/content/articles/products/contents/idiomatic-usage/usage.mdx
@@ -2,6 +2,7 @@
 title: '用字用語：理由'
 description: '「用字用語」とは、用いる字（平仮名、カタカナ、漢字、英数字）や語（単語、熟語）のことです。ユーザーが判断に迷わない表現をするために、用字用語を定めます。'
 order: 3
+ignoreH3Nav: true
 ---
 
 import { IdiomaticUsageTable } from '@Components/contents/IdiomaticUsageTable'

--- a/content/articles/products/contents/writing-style.mdx
+++ b/content/articles/products/contents/writing-style.mdx
@@ -2,6 +2,7 @@
 title: 'ライティングスタイル'
 description: ' '
 order: 2
+ignoreH3Nav: true
 ---
 
 言葉をデザインするときの判断基準や表記ルールをトピックごとに記載しています。

--- a/src/components/article/IndexNav/IndexNav.tsx
+++ b/src/components/article/IndexNav/IndexNav.tsx
@@ -44,12 +44,10 @@ export const IndexNav: FC<Props> = ({ target }) => {
         if (!_nestedHeadings[_nestedHeadings.length - 1])
           _nestedHeadings.push({ value: '', children: [], depth: 0, fragmentId: '' })
 
-        if (!idAttr?.startsWith('rec'))
-          //Airtableコンテンツの場合はh3は除外
-          _nestedHeadings[_nestedHeadings.length - 1].children.push({
-            value: element.textContent || '',
-            fragmentId: element.getAttribute('id') || `h3-c${index}`,
-          })
+        _nestedHeadings[_nestedHeadings.length - 1].children.push({
+          value: element.textContent || '',
+          fragmentId: element.getAttribute('id') || `h3-c${index}`,
+        })
       }
     })
     setNestedHeadings(_nestedHeadings)

--- a/src/components/article/IndexNav/IndexNav.tsx
+++ b/src/components/article/IndexNav/IndexNav.tsx
@@ -1,6 +1,7 @@
 import { CSS_COLOR } from '@Constants/style'
+import { throttle } from '@Lib/throttle'
 import { Link } from 'gatsby'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useEffect, useRef, useState } from 'react'
 import { Nav as NavComponent } from 'smarthr-ui'
 import styled from 'styled-components'
 
@@ -13,7 +14,9 @@ type HeadingItem = {
 }
 
 export const IndexNav: FC<Props> = ({ target }) => {
+  const indexNavRef = useRef<HTMLUListElement>()
   const [nestedHeadings, setNestedHeadings] = useState<HeadingItem[]>([])
+  const [currentHeading, setCurrentHeading] = useState<string>('')
 
   //クライアントでのレンダリング時にページ内インデックスのマークアップを作成する
   useEffect(() => {
@@ -52,16 +55,58 @@ export const IndexNav: FC<Props> = ({ target }) => {
     setNestedHeadings(_nestedHeadings)
   }, [target])
 
+  useEffect(() => {
+    // スクロール時に現在地を示すための処理
+    const handleScroll = throttle(() => {
+      const currentRef = target.current
+      if (!currentRef) return
+      const headingList = Array.from(currentRef.querySelectorAll('h2, h3'))
+      const _currentHeading = headingList.find((element, index) => {
+        const elementTop = element.getBoundingClientRect().top
+        const nextItemTop = headingList[index + 1]?.getBoundingClientRect().top
+        // 200pxより上にあり、かつ次の見出しがが200pxより下にあるものを現在地とする
+        //（最後の見出しの場合は、200pxより上にあれば現在地とする）
+        return elementTop < 200 && (nextItemTop === undefined || nextItemTop > 200)
+      })
+      setCurrentHeading(_currentHeading?.getAttribute('id') || '')
+    }, 200)
+    handleScroll()
+
+    window.addEventListener('scroll', handleScroll)
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [target])
+
+  useEffect(() => {
+    // 現在地が移動した際、その見出しが表示範囲内に入るようにスクロールする処理
+    const currentItem = indexNavRef.current?.querySelector(`a[aria-current="true"]`)
+    const navElement = indexNavRef.current?.parentElement // Navにrefを渡せないため、ulの親要素として取得する
+    if (!(currentItem instanceof HTMLElement) || !navElement) return
+
+    // 表示されている範囲の上端・下端の取得
+    const navAreaTop = navElement.scrollTop
+    const navAreaBottom = navAreaTop + navElement.clientHeight
+    // 表示範囲に入っていれば何もしない
+    if (currentItem.offsetTop > navAreaTop && currentItem.offsetTop < navAreaBottom) return
+
+    // 現在地が表示範囲の中央に来るようにスクロールする
+    navElement.scrollTop = currentItem.offsetTop - navElement.clientHeight / 2
+  }, [currentHeading, indexNavRef])
+
   return (
     <Nav>
       {nestedHeadings.length > 0 && (
-        <ul>
+        <ul ref={indexNavRef}>
           {nestedHeadings.map((depth2Item) => {
             return (
               <li key={depth2Item.fragmentId}>
                 {depth2Item.value !== '' && (
                   <Depth2Item>
-                    <Link to={`#${depth2Item.fragmentId}`}>{depth2Item.value}</Link>
+                    <Link to={`#${depth2Item.fragmentId}`} aria-current={currentHeading === depth2Item.fragmentId}>
+                      {depth2Item.value}
+                    </Link>
                   </Depth2Item>
                 )}
                 {depth2Item.children.length > 0 && (
@@ -70,7 +115,9 @@ export const IndexNav: FC<Props> = ({ target }) => {
                       return (
                         <li key={depth3Item.fragmentId}>
                           <Depth3Item>
-                            <Link to={`#${depth3Item.fragmentId}`}>{depth3Item.value}</Link>
+                            <Link to={`#${depth3Item.fragmentId}`} aria-current={currentHeading === depth3Item.fragmentId}>
+                              {depth3Item.value}
+                            </Link>
                           </Depth3Item>
                         </li>
                       )
@@ -108,7 +155,6 @@ const Nav = styled(NavComponent)`
   }
 
   li {
-    padding: 8px;
     > ul {
       margin: 0 0 0 16px;
       padding: 0;
@@ -118,6 +164,7 @@ const Nav = styled(NavComponent)`
 
   a {
     display: block;
+    padding: 8px;
     text-decoration: none;
     color: ${CSS_COLOR.TEXT_GREY};
     &:hover {
@@ -131,8 +178,16 @@ const Nav = styled(NavComponent)`
 
 const Depth2Item = styled.div`
   display: block;
+  > a[aria-current='true'],
+  a[aria-current='true']:hover {
+    background-color: ${CSS_COLOR.DIVIDER};
+  }
 `
 
 const Depth3Item = styled.div`
   display: block;
+  > a[aria-current='true'],
+  a[aria-current='true']:hover {
+    background-color: ${CSS_COLOR.DIVIDER};
+  }
 `

--- a/src/components/article/IndexNav/IndexNav.tsx
+++ b/src/components/article/IndexNav/IndexNav.tsx
@@ -5,7 +5,7 @@ import React, { FC, useEffect, useRef, useState } from 'react'
 import { Nav as NavComponent } from 'smarthr-ui'
 import styled from 'styled-components'
 
-type Props = { target: React.RefObject<HTMLElement> }
+type Props = { target: React.RefObject<HTMLElement>; ignoreH3Nav?: boolean }
 type HeadingItem = {
   value: string
   children: Array<{ value: string; fragmentId?: string }>
@@ -13,7 +13,7 @@ type HeadingItem = {
   fragmentId: string
 }
 
-export const IndexNav: FC<Props> = ({ target }) => {
+export const IndexNav: FC<Props> = ({ target, ignoreH3Nav = false }) => {
   const indexNavRef = useRef<HTMLUListElement>(null)
   const [nestedHeadings, setNestedHeadings] = useState<HeadingItem[]>([])
   const [currentHeading, setCurrentHeading] = useState<string>('')
@@ -36,7 +36,7 @@ export const IndexNav: FC<Props> = ({ target }) => {
         })
       }
 
-      if (element.tagName === 'H3') {
+      if (element.tagName === 'H3' && !ignoreH3Nav) {
         // id属性がない場合は付与する
         if (idAttr === null) element.setAttribute('id', `h3-c${index}`)
 
@@ -51,14 +51,16 @@ export const IndexNav: FC<Props> = ({ target }) => {
       }
     })
     setNestedHeadings(_nestedHeadings)
-  }, [target])
+  }, [target, ignoreH3Nav])
 
   useEffect(() => {
     // スクロール時に現在地を示すための処理
     const handleScroll = throttle(() => {
       const currentRef = target.current
       if (!currentRef) return
-      const headingList = Array.from(currentRef.querySelectorAll('h2, h3'))
+      const headingList = Array.from(currentRef.querySelectorAll('h2, h3')).filter((element) => {
+        return !(element.tagName === 'H3' && ignoreH3Nav)
+      })
       const _currentHeading = headingList.find((element, index) => {
         const elementTop = element.getBoundingClientRect().top
         const nextItemTop = headingList[index + 1]?.getBoundingClientRect().top
@@ -75,7 +77,7 @@ export const IndexNav: FC<Props> = ({ target }) => {
     return () => {
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [target])
+  }, [target, ignoreH3Nav])
 
   useEffect(() => {
     // 現在地が移動した際、その見出しが表示範囲内に入るようにスクロールする処理

--- a/src/components/article/IndexNav/IndexNav.tsx
+++ b/src/components/article/IndexNav/IndexNav.tsx
@@ -14,7 +14,7 @@ type HeadingItem = {
 }
 
 export const IndexNav: FC<Props> = ({ target }) => {
-  const indexNavRef = useRef<HTMLUListElement>()
+  const indexNavRef = useRef<HTMLUListElement>(null)
   const [nestedHeadings, setNestedHeadings] = useState<HeadingItem[]>([])
   const [currentHeading, setCurrentHeading] = useState<string>('')
 

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -68,6 +68,7 @@ export const query = graphql`
       frontmatter {
         title
         description
+        ignoreH3Nav
       }
       fields {
         category
@@ -129,6 +130,7 @@ const Article: FC<Props> = ({ data }) => {
   const slug = fields?.slug || ''
 
   const title = frontmatter?.title || ''
+  const ignoreH3Nav = frontmatter?.ignoreH3Nav || false
 
   //
   // サイドバー、「前へ」「次へ」コンポーネントのための配列作成
@@ -252,7 +254,7 @@ const Article: FC<Props> = ({ data }) => {
           </MainSidebar>
 
           <MainIndexNav>
-            <IndexNav target={articleRef} />
+            <IndexNav target={articleRef} ignoreH3Nav={ignoreH3Nav} />
           </MainIndexNav>
 
           <MainArticle>


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1283

## やったこと
画面のスクロールが発生した際に、メインコンテンツ部分で表示中のセクションを割り出し、右サイドバーのナビゲーションでもその部分に背景色がつくようにしました。

- メインコンテンツ部分は、iframeのリサイズや従業員限定コンテンツの読み込みなどで、セクションの位置がずれることがあるため、スクロールごとに表示中セクションの算出をしています。
- ハイライトしたい項目が、サイドバーの表示範囲外にある場合は、その項目が中央に来るようスクロールさせています。
  - スムーススクロールなどは入れていませんが、実装は可能です。
- 現在地の判定として、画面上端から200pxのところに見出しが来たら、そのセクションに入ったものとしていますが、この位置（200px）は調整可能です。
- 背景色のpaddingのため、CSSを少し調整しています。

## やらなかったこと
右サイドバーはフォーカス時は下線がつくようになっていますが、それは変更していません。

また、Airtable由来のページでは、右サイドバーに `h3`を表示しない実装になっていましたが、現状該当するページが1ページしか無くなってしまいました→ https://smarthr.design/products/contents/idiomatic-usage/usage/

ハイライト表示にも影響するため、いったん例外処理をなくし、`h3`を表示しています。表示するアイテムが増えるので、非表示にすべきであれば、MDXに移行したAirtabaleコンテンツと合わせて対応できればと思います。

## 動作確認
https://deploy-preview-819--smarthr-design-system.netlify.app/foundation/

右サイドバーが縦に長いページ例
https://deploy-preview-819--smarthr-design-system.netlify.app/products/components/

Airtable由来のページのサイドバー
https://deploy-preview-819--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/usage/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/445f6cc2-678b-4b44-a583-0abb94b6f25e" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/c7bf72eb-58c4-41ef-b89e-73eee154c1a4" alt width="350"> |
