### PR TITLE
postcssのバージョン固定を解除

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",
     "unist-util-visit": "2.0.3"
-  },
-  "resolutions": {
-    "postcss": "^8.4.26"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12922,10 +12922,10 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.2.15, postcss@^8.2.9, postcss@^8.3.11, postcss@^8.4.25, postcss@^8.4.26:
-  version "8.4.26"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.26.tgz#1bc62ab19f8e1e5463d98cf74af39702a00a9e94"
-  integrity sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==
+postcss@^8.2.15, postcss@^8.2.9, postcss@^8.3.11, postcss@^8.4.24, postcss@^8.4.27:
+  version "8.4.27"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.27.tgz#234d7e4b72e34ba5a92c29636734349e0d9c3057"
+  integrity sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==
   dependencies:
     nanoid "^3.3.6"
     picocolors "^1.0.0"


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system/pull/812
→ postcssをpackage.jsonの `resolutions`に指定しているため、RenovateのPRが自動マージされない

## やったこと
#360 で、stylelintの動作不具合解消のためにpostcssのバージョンを固定しましたが、最近は最新バージョンに追従しても問題なくなっているため、固定を解除しました。

## 動作確認
stylelintが実行できることを確認しました。