### PR TITLE
人物のイラストレーションの喜怒哀楽表現の参照元について補足を追記

### DIFF
--- a/content/articles/basics/illustration/creation-guideline.mdx
+++ b/content/articles/basics/illustration/creation-guideline.mdx
@@ -24,8 +24,7 @@ order: 9
 
 人物は全身、半身、アイコンの3種類があります。  
 人物にはすべてペルソナを設定しており、ペルソナに沿って作成してください。  
-喜怒哀楽の表現方法は<a href="https://twemoji.twitter.com/">Twemoji</a>を参考にしてください。  
-Twemojiは2023年7月現在OSSですが、非公開となった場合は一旦[Twemojiのバックアップ](https://drive.google.com/drive/folders/10d6zDf_H2KE8Qab37klSkl7UYIGXksEz)を参照してください。
+喜怒哀楽の表現方法は<a href="https://twemoji.twitter.com/">Twemoji</a>を参考にしてください。  Twemojiは2023年7月現在OSSですが、非公開となった場合は一旦[Twemojiのバックアップ](https://drive.google.com/drive/folders/10d6zDf_H2KE8Qab37klSkl7UYIGXksEz)を参照してください。
 
 ### 2. アイテム
 

--- a/content/articles/basics/illustration/creation-guideline.mdx
+++ b/content/articles/basics/illustration/creation-guideline.mdx
@@ -24,7 +24,7 @@ order: 9
 
 人物は全身、半身、アイコンの3種類があります。  
 人物にはすべてペルソナを設定しており、ペルソナに沿って作成してください。  
-喜怒哀楽の表現方法は<a href="https://twemoji.twitter.com/">Twemoji</a>を参考にしてください。  Twemojiは2023年7月現在OSSですが、非公開となった場合は一旦[Twemojiのバックアップ](https://drive.google.com/drive/folders/10d6zDf_H2KE8Qab37klSkl7UYIGXksEz)を参照してください。
+喜怒哀楽の表現方法は<a href="https://twemoji.twitter.com/">Twemoji</a>を参考にしてください。Twemojiは2023年7月現在OSSですが、非公開となった場合は一旦[Twemojiのバックアップ](https://drive.google.com/drive/folders/10d6zDf_H2KE8Qab37klSkl7UYIGXksEz)を参照してください。
 
 ### 2. アイテム
 

--- a/content/articles/basics/illustration/creation-guideline.mdx
+++ b/content/articles/basics/illustration/creation-guideline.mdx
@@ -24,7 +24,8 @@ order: 9
 
 人物は全身、半身、アイコンの3種類があります。  
 人物にはすべてペルソナを設定しており、ペルソナに沿って作成してください。  
-喜怒哀楽の表現方法は<a href="https://twemoji.twitter.com/">Twemoji</a>を参考にしてください。
+喜怒哀楽の表現方法は<a href="https://twemoji.twitter.com/">Twemoji</a>を参考にしてください。  
+Twemojiは2023年7月現在OSSですが、非公開となった場合は一旦[Twemojiのバックアップ](https://drive.google.com/drive/folders/10d6zDf_H2KE8Qab37klSkl7UYIGXksEz)を参照してください。
 
 ### 2. アイテム
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12922,7 +12922,7 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.2.15, postcss@^8.2.9, postcss@^8.3.11, postcss@^8.4.24, postcss@^8.4.27:
+postcss@^8.2.15, postcss@^8.2.9, postcss@^8.3.11, postcss@^8.4.25:
   version "8.4.27"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.27.tgz#234d7e4b72e34ba5a92c29636734349e0d9c3057"
   integrity sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12922,7 +12922,7 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.2.15, postcss@^8.2.9, postcss@^8.3.11, postcss@^8.4.25:
+postcss@^8.2.15, postcss@^8.2.9, postcss@^8.3.11, postcss@^8.4.24, postcss@^8.4.27:
   version "8.4.27"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.27.tgz#234d7e4b72e34ba5a92c29636734349e0d9c3057"
   integrity sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==


### PR DESCRIPTION
## 課題・背景
SmartHR Design Systemでは[イラストレーションの作成ガイドライン](https://smarthr.design/basics/illustration/creation-guideline/)にて、[twemoji](https://twemoji.twitter.com/)を人物のイラストレーションの喜怒哀楽表現の参照元に定めています。
現在twemojiはOSSですが、今後非公開になる可能性もあります。
問題の発生を未然に防ぐため、twemojiが非公開になった場合、何を人物のイラストレーションの喜怒哀楽表現の参照元にするべきなのか追記しました。


## やったこと
- twemojiが非公開になった場合、何を人物のイラストレーションの喜怒哀楽表現の参照元にするのか追記


## やらなかったこと
とくになし

## 動作確認
https://deploy-preview-822--smarthr-design-system.netlify.app/basics/illustration/creation-guideline/#h3-1

## キャプチャ

|Before|After|
| --- | --- |
| <img width="900" alt="スクリーンショット 2023-07-27 12 39 38" src="https://github.com/kufu/smarthr-design-system/assets/101125529/7c0452c1-873a-42ba-82d6-2e69b11367b9"> | <img width="965" alt="スクリーンショット_2023-07-27_12_41_18" src="https://github.com/kufu/smarthr-design-system/assets/101125529/da247b94-1ebc-45bb-be86-ca1f29c2e7b2"> |



