### PR TITLE
サウンドロゴのお問い合わせ先メールアドレスを追加

### DIFF
--- a/content/articles/basics/logos/sound.mdx
+++ b/content/articles/basics/logos/sound.mdx
@@ -116,4 +116,4 @@ SmartHRサウンドロゴの、サウンド、商標などに関しては、株�
 
 サウンドロゴの利用方法に関する相談・お問い合わせ
 - 社内Slack `#design_comm_依頼`
-- 株式会社SmartHR　smarthr-design-system@smarthr.co.jp
+- SmartHR Design System 運営チーム smarthr-design-system@smarthr.co.jp

--- a/content/articles/basics/logos/sound.mdx
+++ b/content/articles/basics/logos/sound.mdx
@@ -116,4 +116,4 @@ SmartHRサウンドロゴの、サウンド、商標などに関しては、株�
 
 サウンドロゴの利用方法に関する相談・お問い合わせ
 - 社内Slack `#design_comm_依頼`
-- {めーる}
+- 株式会社SmartHR　smarthr-design-system@smarthr.co.jp

--- a/content/articles/basics/meta/index.mdx
+++ b/content/articles/basics/meta/index.mdx
@@ -155,5 +155,5 @@ order: 6
 ## フィードバック先
 メタ情報に関する相談・フィードバック
 
-- 株式会社SmartHR smarthr-design-system@smarthr.co.jp
+- SmartHR Design System 運営チーム smarthr-design-system@smarthr.co.jp
 - 社内Slack `#design_system_相談`

--- a/content/articles/communication/business-card/index.mdx
+++ b/content/articles/communication/business-card/index.mdx
@@ -63,5 +63,5 @@ import { ImgWithDesc } from '@Components/article/ImgWithDesc/ImgWithDesc'
 
 ## フィードバック先
 名刺の利用方法に関する相談・フィードバック
-- 株式会社SmartHR　smarthr-design-system@smarthr.co.jp
+- SmartHR Design System 運営チーム smarthr-design-system@smarthr.co.jp
 - 社内Slack `#design_communication`

--- a/content/articles/communication/sample/text.mdx
+++ b/content/articles/communication/sample/text.mdx
@@ -26,5 +26,5 @@ SmartHRのサービス全体で利用できるサンプルテキストです。
 
 ## フィードバック先
 サンプルテキストの利用方法に関する相談・フィードバック
-- 株式会社SmartHR　smarthr-design-system@smarthr.co.jp
+- SmartHR Design System 運営チーム smarthr-design-system@smarthr.co.jp
 - 社内Slack　`#design_system_相談`


### PR DESCRIPTION
## 課題・背景
[[サウンドロゴ] 画面](https://smarthr.design/basics/logos/sound/#h2-4) に、サウンドロゴの利用方法に関する相談・お問い合わせのメールアドレスが掲載されていないので掲載したい。

[issueをみる（社内限定）](https://app.asana.com/0/1204801913310809/1205169518598905/f)

## やったこと
[[サウンドロゴ] 画面](https://smarthr.design/basics/logos/sound/#h2-4) に、サウンドロゴの利用方法に関する相談・お問い合わせのメールアドレスを追加


## やらなかったこと
とくになし

## 動作確認
https://deploy-preview-836--smarthr-design-system.netlify.app/basics/logos/sound/#h2-4

## キャプチャ

|Before|After|
| --- | --- |
| <img width="1169" alt="スクリーンショット 2023-08-01 23 10 56" src="https://github.com/kufu/smarthr-design-system/assets/101125529/f04633b1-af84-4dfa-9880-8e0f5d77b4ba"> | <img width="1121" alt="スクリーンショット 2023-08-01 23 15 03" src="https://github.com/kufu/smarthr-design-system/assets/101125529/184447ce-0ba9-4bd5-833c-164c47759c1e"> |




