### PR TITLE
OGPメタタグの整理・更新

### DIFF
--- a/content/articles/basics/meta/index.mdx
+++ b/content/articles/basics/meta/index.mdx
@@ -36,7 +36,7 @@ order: 6
 <link rel="manifest" href="/manifest.webmanifest">
 <meta name="apple-mobile-web-app-title" content="SmartHR">
 <meta name="application-name" content="SmartHR">
-<meta property="og:title" content="SmartHR（スマートHR）">
+<meta property="og:title" content="{ページ名} | SmartHR（スマートHR）">
 <meta property="og:type" content="website">
 <meta property="og:url" content="{url}">
 <meta property="og:image" content="{url}/ogp.png">
@@ -46,7 +46,7 @@ order: 6
 <meta property="fb:app_id" content="{app_id}">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:site" content="@smarthr_jp">
-<meta name="twitter:domain" content="smarthr.jp">
+<meta name="twitter:title" content="{ページ名} | SmartHR（スマートHR）">
 <meta name="twitter:description" content="SmartHRは、人事・労務の業務効率化からタレントマネジメントまで、働くすべての人の生産性向上を支える、「クラウド人事労務ソフト」です。">
 ```
 

--- a/content/articles/basics/meta/ogp.mdx
+++ b/content/articles/basics/meta/ogp.mdx
@@ -13,7 +13,7 @@ OGP（Open Graph Protocol）は、Facebookが提唱するWebページのメタ�
 FacebookをはじめとするSNSでOGPを表示するためには、以下のようなメタタグを`<head>`内に記述する必要があります。
 
 ```html codeBlock
-<meta property="og:title" content="SmartHR（スマートHR）">
+<meta property="og:title" content="{ページ名} | SmartHR（スマートHR）">
 <meta property="og:type" content="website">
 <meta property="og:url" content="{url}">
 <meta property="og:image" content="{url}/ogp-img.png">
@@ -34,7 +34,7 @@ TwitterはOGPとは別に、Twitterカードという機能を提供していま
 ```html codeBlock
 <meta name="twitter:card" content="summary">
 <meta name="twitter:site" content="@smarthr_jp">
-<meta name="twitter:domain" content="smarthr.jp">
+<meta name="twitter:title" content="{ページ名} | SmartHR（スマートHR）">
 <meta name="twitter:description" content="SmartHRは、人事・労務の業務効率化からタレントマネジメントまで、働くすべての人の生産性向上を支える、「クラウド人事労務ソフト」です。">
 ```
 

--- a/src/components/Head/Head.tsx
+++ b/src/components/Head/Head.tsx
@@ -54,6 +54,7 @@ export const Head: FC<Props> = ({ title, ogTitle, description, meta = [] }) => {
       <meta property="og:image" content={ogCloudinaryUrl ?? ogImagePath} />
       <meta property="og:locale" content="ja_JP" />
       <meta property="og:url" content={`${siteMetadata?.siteUrl}${location.pathname}`} />
+      <meta property="og:site_name" content={siteMetadata?.title || ''} />
       <meta name="twitter:card" content="summary" />
       <meta name="twitter:site" content={siteMetadata?.author ?? ''} />
       <meta name="twitter:title" content={pageTitle ?? ''} />


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1288

## やったこと
実際のHTMLヘッダーのOGPタグの出力内容と、メタ情報のページの内容の両方を変更しています。変更後は実際の出力内容とメタ情報ページのコード例にある項目は同じになっています。

- `twitter:domain`の削除（メタ情報ページ）
- `twitter:title`の追加（メタ情報ページ）
- `og:title`の例を変更（メタ情報ページ）
- `og:site_name`の追加（HTMLヘッダー）

## 動作確認
https://deploy-preview-837--smarthr-design-system.netlify.app/basics/meta/#h4-0
https://deploy-preview-837--smarthr-design-system.netlify.app/basics/meta/ogp/#h2-0

トップページのHTMLヘッダー内のメタ情報
```
<meta name="description" content="SmartHR Design Systemは、だれでも・効率よく・迷わずにSmartHRらしい表現をするためのデザインシステムです。" data-gatsby-head="true"/>
<meta property="og:title" content="SmartHR Design System" data-gatsby-head="true"/>
<meta property="og:description" content="SmartHR Design Systemは、だれでも・効率よく・迷わずにSmartHRらしい表現をするためのデザインシステムです。" data-gatsby-head="true"/>
<meta property="og:type" content="website" data-gatsby-head="true"/>
<meta property="og:image" content="https://smarthr.design/images/ogp.png" data-gatsby-head="true"/>
<meta property="og:locale" content="ja_JP" data-gatsby-head="true"/>
<meta property="og:url" content="https://smarthr.design/" data-gatsby-head="true"/>
<meta property="og:site_name" content="SmartHR Design System" data-gatsby-head="true"/>
<meta name="twitter:card" content="summary" data-gatsby-head="true"/>
<meta name="twitter:site" content="@SHRDesignSystem" data-gatsby-head="true"/>
<meta name="twitter:title" content="SmartHR Design System" data-gatsby-head="true"/>
<meta name="twitter:description" content="SmartHR Design Systemは、だれでも・効率よく・迷わずにSmartHRらしい表現をするためのデザインシステムです。" data-gatsby-head="true"/>
<meta name="apple-mobile-web-app-title" content="SmartHR Design System" data-gatsby-head="true"/>
<meta name="application-name" content="SmartHR Design System" data-gatsby-head="true"/>
```