### PR TITLE
コミット時の末尾スラッシュの自動修復を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
       "stylelint"
     ],
     "content/**/*.md{,x}": [
-      "textlint"
+      "textlint",
+      "ts-node scripts/content-checker/linkChecker.ts --fix"
     ]
   },
   "scripts": {


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system-issues/issues/1285

## やったこと

コミットのタイミングでlint-staged→husky経由でリンクチェックが実行されるようにしました。
またその際、末尾スラッシュがないものは自動で追加するようにしました。

それにあたり、リンクチェッカー本体にも以下の変更を加えています。

- `--fix`オプションをつけると末尾スラッシュは自動追加する
- ファイルパスを引数に渡すと、そのファイルのみをチェック（・スラッシュ追加）対象とする
  - lint-staged がステージングされているファイルのパスを絶対パスで渡すため
- エラーがあった場合は`process.exit(1)`で終了していましたが、`process.exit(0)`に変更しました
  - リンク切れがあった場合に、`1`で終了するとコミットが中止してしまうため
  - GitHub Actionsでの定期実行では、`1`で終了しても無視するようにしているので、影響はありません。

また、最終的に出力するエラーメッセージにも、
`No trailing slash - fixed automatically` と `No trailing slash - could not be automatically fixed`（＝修復に失敗した場合。あまり起こらないとは思います）を追加しています。

### 懸念点

コミット時に自動修復するので、ほぼLinterのような動作ですが、無効にはできない（例えば`/* disable...*/`のようなコメントを入れられない）ので、何かの事情でスラッシュを入れたくないケースが出てきた場合に困るかもしれません。

末尾スラッシュ以外のエラー（リンク切れなど）に対しては何もしないので、`--fix`オプションの挙動が少々分かりにくいかもしれません。
- `--fix-trailing-slash`などにする？
- そもそも末尾スラッシュの修正をlinkCheckerから切り離す
- コミット時に、リンク切れなども警告表示は出す

などは可能かもしれません。

## 動作確認
ローカルでの実行例
```
// 全ファイルをチェック（これまで通り）
npx ts-node ./scripts/content-checker/linkChecker.ts

// 全ファイルをチェック＋自動修復
npx ts-node ./scripts/content-checker/linkChecker.ts --fix

// 対象のファイルを指定
npx ts-node ./scripts/content-checker/linkChecker.ts ./content/articles/products/**/*.mdx
```

## キャプチャ
サイト本体への影響はありません
