### PR TITLE
外部リンクに自動的にアイコン・target属性を付与する仕組みを追加

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -197,6 +197,7 @@ export const ComponentStory: FC<Props> = ({ name, dirName }) => {
             target="_blank"
             size="s"
             suffix={<FaExternalLinkAltIcon />}
+            rel="noreferrer"
           >
             Storybook
           </AnchorButton>
@@ -205,6 +206,7 @@ export const ComponentStory: FC<Props> = ({ name, dirName }) => {
             target="_blank"
             size="s"
             suffix={<FaExternalLinkAltIcon />}
+            rel="noreferrer"
           >
             GitHub
           </AnchorButton>

--- a/src/components/article/CustomLink/CustomLink.tsx
+++ b/src/components/article/CustomLink/CustomLink.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'gatsby'
+import React, { FC } from 'react'
+import { FaExternalLinkAltIcon } from 'smarthr-ui'
+import styled from 'styled-components'
+
+type Props = {
+  children: React.ReactNode
+  href: string
+}
+
+export const CustomLink: FC<Props> = ({ children, href }) => {
+  const isExternal = href.match(/^https?:\/\/(?!smarthr\.design).*?$/) !== null
+  return isExternal ? (
+    <StyledLink to={href} target="_blank">
+      {children}
+      <FaExternalLinkAltIcon />
+    </StyledLink>
+  ) : (
+    <Link to={href}>{children}</Link>
+  )
+}
+
+const StyledLink = styled(Link)`
+  svg {
+    margin-inline: 0.25em;
+  }
+`

--- a/src/components/article/CustomLink/CustomLink.tsx
+++ b/src/components/article/CustomLink/CustomLink.tsx
@@ -11,7 +11,7 @@ type Props = {
 export const CustomLink: FC<Props> = ({ children, href }) => {
   const isExternal = href.match(/^https?:\/\/(?!smarthr\.design).*?$/) !== null
   return isExternal ? (
-    <StyledLink to={href} target="_blank">
+    <StyledLink to={href} target="_blank" rel="noreferrer">
       {children}
       <FaExternalLinkAltIcon />
     </StyledLink>

--- a/src/components/article/CustomLink/index.ts
+++ b/src/components/article/CustomLink/index.ts
@@ -1,0 +1,1 @@
+export { CustomLink } from './CustomLink'

--- a/src/components/contents/shared/TextUrlToLink.tsx
+++ b/src/components/contents/shared/TextUrlToLink.tsx
@@ -1,3 +1,4 @@
+import { CustomLink } from '@Components/article/CustomLink'
 import React, { FC } from 'react'
 import reactStringReplace from 'react-string-replace'
 
@@ -10,9 +11,9 @@ export const TextUrlToLink: FC<Props> = ({ text }) => {
     <>
       {reactStringReplace(text, /(https?:\/\/\S+)/g, (match: string, strIndex: number) => {
         return (
-          <a key={strIndex} href={match}>
+          <CustomLink key={strIndex} href={match}>
             {match}
-          </a>
+          </CustomLink>
         )
       })}
     </>

--- a/src/components/shared/Footer/FootStaticLinks.tsx
+++ b/src/components/shared/Footer/FootStaticLinks.tsx
@@ -2,7 +2,7 @@ import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import { LoginContext } from '@Context/LoginContext'
 import { Link } from 'gatsby'
 import React, { FC, useContext } from 'react'
-import { AnchorButton } from 'smarthr-ui'
+import { AnchorButton, FaExternalLinkAltIcon } from 'smarthr-ui'
 import styled from 'styled-components'
 
 type Props = unknown
@@ -76,6 +76,7 @@ export const FootStaticLinks: FC<Props> = () => {
             {isExternal ? (
               <StyledAnchor href={path} target="_blank" rel="noopener noreferrer">
                 {title}
+                <FaExternalLinkAltIcon />
               </StyledAnchor>
             ) : (
               <StyledLink to={path}>{title}</StyledLink>
@@ -131,6 +132,9 @@ const StyledAnchorButton = styled(AnchorButton)`
 const StyledAnchor = styled.a`
   display: inline-block;
   width: 100%;
+  svg {
+    margin-inline: 0.25em;
+  }
 `
 
 const StyledLink = styled(Link)`

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -1,5 +1,6 @@
 import { Head as HeadComponent } from '@Components/Head'
 import { CodeBlock } from '@Components/article/CodeBlock'
+import { CustomLink } from '@Components/article/CustomLink'
 import { FragmentTitle } from '@Components/article/FragmentTitle/FragmentTitle'
 import { IndexNav } from '@Components/article/IndexNav/IndexNav'
 import { Sidebar } from '@Components/article/Sidebar/Sidebar'
@@ -50,6 +51,7 @@ const components: MDXProviderComponents = {
     </FragmentTitle>
   ),
   table: ({ children }) => <TableWrapper mdTable={true}>{children}</TableWrapper>,
+  a: ({ children, href }) => <CustomLink href={href}>{children}</CustomLink>,
 }
 
 const shortcodes = {


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1290

## やったこと
- MDXコンテンツにテンプレートを適用する際、`a`タグにカスタムコンポーネントを適用し、リンク先が外部であれば`target="_blank"`属性およびアイコンを自動的に追加するようにしました。
  - ESLintのルール[jsx-no-target-blank](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) により、`_blank`の場合は`rel="noreferrer"`の指定が推奨されているため、こちらも追加しています。
- Airtableコンテンツなどで使われている、`https://〜`から始まる文字列をリンクに変換するコンポーネント（`<TextUrlToLink>`）にも同じルールを適用しました。
- フッターの「更新情報（Twitter）」「運営会社」へのリンクには、手動でアイコンを追加しました。

## やらなかったこと
Reactコンポーネント内にリンクが書かれていた場合は、自動的な属性・アイコン付与の対象にはなりません。現状の実装では、コンポーネントごとに個別対応が必要です。
- 外部リンクを含むコンポーネントはあまりなさそうです。
- 例えば`<ComponentStory>`コンポーネントでは、smarthr-uiのStorybookへのリンクには元から`target`属性とアイコンがついています。

## 動作確認
外部・内部リンクが記述されている事例
- https://deploy-preview-849--smarthr-design-system.netlify.app/accessibility/alternative-text/#h2-2
- https://deploy-preview-849--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/usage/
  - 議事録のリンクは`<TextUrlToLink>`コンポーネント由来です


## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/135d3187-102e-468e-bdcc-3ca4e7f19290" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/e79afb8b-4bfa-4040-8640-8da0419df5fa" alt width="350"> |



