### PR TITLE
一時的にログインできない旨を表示

### DIFF
--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,4 +1,4 @@
-import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
+import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import { LoginContext, LoginStatusKey } from '@Context/LoginContext'
 import React, { FC, useContext, useState } from 'react'
 import { Button, FaLockIcon, Input } from 'smarthr-ui'
@@ -21,7 +21,9 @@ export const LoginPage: FC = () => {
         </p>
         <ul>
           <li>
-            <p>社内Slack`#design_system_相談`で利用したい限定コンテンツを伝える</p>
+            <p>
+              社内Slack<code>#design_system_相談</code>で利用したい限定コンテンツを伝える
+            </p>
           </li>
           <li>
             <p>
@@ -36,7 +38,7 @@ export const LoginPage: FC = () => {
         <p>
           そのほか相談、問い合わせ先
           <br />
-          社内Slack`#design_system_相談`
+          社内Slack<code>#design_system_相談</code>
         </p>
       </MaintenanceMessage>
       <div className="inputs">
@@ -159,5 +161,13 @@ const MaintenanceMessage = styled.div`
   color: ${CSS_COLOR.DANGER};
   & p {
     color: ${CSS_COLOR.DANGER};
+    & code {
+      padding: 0.125rem 0.25rem;
+      border-radius: 4px;
+      background-color: ${CSS_COLOR.LIGHT_GREY_2};
+      font-size: ${CSS_FONT_SIZE.PX_14};
+      vertical-align: 0.05rem;
+      margin: 0.125rem;
+    }
   }
 `

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -13,15 +13,32 @@ export const LoginPage: FC = () => {
   return (
     <Wrapper>
       <h1>従業員ログイン</h1>
-      <p>ログインすると限定コンテンツにアクセスできます。パスワードの確認方法は2つあります。</p>
-      <ul>
-        <li>
-          <p>SmartHR社の1Passwordを利用する</p>
-        </li>
-        <li>
-          <p>SmartHR社のSlackに「SDSパスワード」と入力する（自動レスポンスがあります）</p>
-        </li>
-      </ul>
+      <MaintenanceMessage>
+        <p>
+          現在ログインできません。システム復旧中です。
+          <br />
+          限定コンテンツを利用したい場合、次の2つの方法で利用できます。（社内限定）
+        </p>
+        <ul>
+          <li>
+            <p>社内Slack`#design_system_相談`で利用したい限定コンテンツを伝える</p>
+          </li>
+          <li>
+            <p>
+              GitHubリポジトリを確認する（
+              <a href="https://github.com/kufu/smarthr-design-system-private" target="_blank" rel="noreferrer">
+                https://github.com/kufu/smarthr-design-system-private
+              </a>
+              ）
+            </p>
+          </li>
+        </ul>
+        <p>
+          そのほか相談、問い合わせ先
+          <br />
+          社内Slack`#design_system_相談`
+        </p>
+      </MaintenanceMessage>
       <div className="inputs">
         <Input
           type="password"
@@ -30,12 +47,14 @@ export const LoginPage: FC = () => {
           onChange={(e) => setPassword(e.currentTarget.value)}
           value={password}
           name="password"
+          disabled={true}
         />
 
         <Button
           variant="primary"
           wide={true}
           onClick={() => login(password, () => setPassword(''), setErrMessage, updateLoginStatus)}
+          disabled={true}
         >
           ログイン
         </Button>
@@ -133,5 +152,12 @@ const Wrapper = styled.div`
     margin: 0;
     color: ${CSS_COLOR.TEXT_BLACK};
     line-height: 1.6;
+  }
+`
+
+const MaintenanceMessage = styled.div`
+  color: ${CSS_COLOR.DANGER};
+  & p {
+    color: ${CSS_COLOR.DANGER};
   }
 `

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -13,34 +13,29 @@ export const LoginPage: FC = () => {
   return (
     <Wrapper>
       <h1>従業員ログイン</h1>
-      <MaintenanceMessage>
-        <p>
-          現在ログインできません。システム復旧中です。
-          <br />
-          限定コンテンツを利用したい場合、次の2つの方法で利用できます。（社内限定）
-        </p>
-        <ul>
-          <li>
-            <p>
-              社内Slack<code>#design_system_相談</code>で利用したい限定コンテンツを伝える
-            </p>
-          </li>
-          <li>
-            <p>
-              GitHubリポジトリを確認する（
-              <a href="https://github.com/kufu/smarthr-design-system-private" target="_blank" rel="noreferrer">
-                https://github.com/kufu/smarthr-design-system-private
-              </a>
-              ）
-            </p>
-          </li>
-        </ul>
-        <p>
-          そのほか相談、問い合わせ先
-          <br />
-          社内Slack<code>#design_system_相談</code>
-        </p>
-      </MaintenanceMessage>
+      <MaintenanceText>現在ログインできません。システム復旧中です。</MaintenanceText>
+      <p>限定コンテンツを利用したい場合、次の2つの方法で利用できます。（社内限定）</p>
+      <ul>
+        <li>
+          <p>
+            社内Slack<code>#design_system_相談</code>で利用したい限定コンテンツを伝える
+          </p>
+        </li>
+        <li>
+          <p>
+            GitHubリポジトリを確認する（
+            <a href="https://github.com/kufu/smarthr-design-system-private" target="_blank" rel="noreferrer">
+              https://github.com/kufu/smarthr-design-system-private
+            </a>
+            ）
+          </p>
+        </li>
+      </ul>
+      <p>
+        そのほか相談、問い合わせ先
+        <br />
+        社内Slack<code>#design_system_相談</code>
+      </p>
       <div className="inputs">
         <Input
           type="password"
@@ -116,6 +111,8 @@ const login: Login = async (password, clearInput, setErrMessage, updateLoginStat
   }
 }
 
+const MaintenanceText = styled.p``
+
 const Wrapper = styled.div`
   box-sizing: border-box;
   max-width: 480px;
@@ -149,18 +146,15 @@ const Wrapper = styled.div`
     text-align: center;
   }
 
+  & ${MaintenanceText} {
+    color: ${CSS_COLOR.DANGER};
+  }
+
   & p {
     padding: 0;
     margin: 0;
     color: ${CSS_COLOR.TEXT_BLACK};
     line-height: 1.6;
-  }
-`
-
-const MaintenanceMessage = styled.div`
-  color: ${CSS_COLOR.DANGER};
-  & p {
-    color: ${CSS_COLOR.DANGER};
     & code {
       padding: 0.125rem 0.25rem;
       border-radius: 4px;


### PR DESCRIPTION
## 課題・背景
kufu/smarthr-design-system-issues#1292 に付随して、ログイン不具合の解消にはしばらくかかりそうなので、一時的にログインできない旨を表示する。

## やったこと
ログインページの説明文を一時的に変更しました。また、フォームの`input`、`button`にも`disabled`属性を付与しています。

文字色はデザイントークンの`DANGER`です。ログインに失敗した場合のエラー表示などと同じ色です。
https://smarthr.design/products/design-tokens/color/#h3-1

## やらなかったこと
「ログイン」ボタンを押した後に処理を行うJSのコードはそのままで、ひとまず削除などはしていません。

## 動作確認
https://deploy-preview-861--smarthr-design-system.netlify.app/login/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/4b01b5dc-45f8-4df7-b59f-2d32d5d98dfc" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/73611ead-f5c8-4dce-b4c7-76fbc98051e7" width="350" alt> |
