### PR TITLE
プライベートコンテンツへのリクエスト方法を変更

### DIFF
--- a/netlify/edge-functions/private-fetch.ts
+++ b/netlify/edge-functions/private-fetch.ts
@@ -1,0 +1,25 @@
+import { encode } from 'https://deno.land/std@0.199.0/encoding/base64.ts'
+
+import type { Config } from 'https://edge.netlify.com'
+
+export default async (req: Request) => {
+  const password = req.headers.get('Sds-Private-Auth')
+  const basic = `Basic ${encode(`sdsuser:${password}`)}`
+
+  const url = req.url.replace(/^.*?\/private/, 'https://smarthr-design-system-private.netlify.app')
+  const res = await fetch(url, {
+    headers: {
+      Authorization: basic,
+    },
+  })
+
+  if (res.status === 200) {
+    return res
+  }
+
+  return new Response('Unauthorized', { status: 401 })
+}
+
+export const config: Config = {
+  path: '/private/*',
+}

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,5 +1,6 @@
-import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
+import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
 import { LoginContext, LoginStatusKey } from '@Context/LoginContext'
+import { navigate } from 'gatsby'
 import React, { FC, useContext, useState } from 'react'
 import { Button, FaLockIcon, Input } from 'smarthr-ui'
 import styled from 'styled-components'
@@ -13,29 +14,15 @@ export const LoginPage: FC = () => {
   return (
     <Wrapper>
       <h1>従業員ログイン</h1>
-      <MaintenanceText>現在ログインできません。システム復旧中です。</MaintenanceText>
-      <p>限定コンテンツを利用したい場合、次の2つの方法で利用できます。（社内限定）</p>
+      <p>ログインすると限定コンテンツにアクセスできます。パスワードの確認方法は2つあります。</p>
       <ul>
         <li>
-          <p>
-            社内Slack<code>#design_system_相談</code>で利用したい限定コンテンツを伝える
-          </p>
+          <p>SmartHR社の1Passwordを利用する</p>
         </li>
         <li>
-          <p>
-            GitHubリポジトリを確認する（
-            <a href="https://github.com/kufu/smarthr-design-system-private" target="_blank" rel="noreferrer">
-              https://github.com/kufu/smarthr-design-system-private
-            </a>
-            ）
-          </p>
+          <p>SmartHR社のSlackに「SDSパスワード」と入力する（自動レスポンスがあります）</p>
         </li>
       </ul>
-      <p>
-        そのほか相談、問い合わせ先
-        <br />
-        社内Slack<code>#design_system_相談</code>
-      </p>
       <div className="inputs">
         <Input
           type="password"
@@ -44,14 +31,12 @@ export const LoginPage: FC = () => {
           onChange={(e) => setPassword(e.currentTarget.value)}
           value={password}
           name="password"
-          disabled={true}
         />
 
         <Button
           variant="primary"
           wide={true}
           onClick={() => login(password, () => setPassword(''), setErrMessage, updateLoginStatus)}
-          disabled={true}
         >
           ログイン
         </Button>
@@ -66,41 +51,39 @@ type Login = (
   password: string,
   clearInput: () => void,
   setErrMessage: (message: string) => void,
-  updateLoginStatus: (newStatus: LoginStatusKey) => void,
+  updateLoginStatus: (newStatus: LoginStatusKey, newPassword: string) => void,
 ) => Promise<void>
 const login: Login = async (password, clearInput, setErrMessage, updateLoginStatus) => {
-  const formDataString = `password=${password}`
-
   clearInput()
   setErrMessage('')
 
   const res = await fetch('/private', {
-    method: 'POST',
-    body: formDataString,
+    method: 'HEAD',
     redirect: 'manual',
     headers: {
-      'content-type': 'application/x-www-form-urlencoded',
+      'Sds-Private-Auth': password,
     },
   })
 
-  // ログインが成功し、Cookieが発行され、リダイレクトされる場合、statusは0になる。
-  // https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect
-
-  if (res.status === 0) {
-    // ログインに成功したら前のページに戻る
-    updateLoginStatus('loggedIn')
-    history.back()
+  // サイトルートには何も置いてないので、パスワードが合っていると404が返る
+  if (res.status === 404) {
+    // ログインに成功したらパスワードを保存し前のページに戻る
+    updateLoginStatus('loggedIn', password)
+    let prevPath = '/'
+    try {
+      const previousUrl = new URL(document.referrer)
+      if (previousUrl.hostname === window.location.hostname) {
+        prevPath = previousUrl.pathname
+      }
+    } catch (error) {
+      // 前のページがない場合はトップに戻る
+    }
+    navigate(prevPath) // history.back()だとcontextが失われるのでnavigateを使う
     return
 
-    // ログイン済みだとPOSTではコンテンツがとれないので404になる。
-  } else if (res.status === 404) {
-    updateLoginStatus('loggedIn')
-    setErrMessage('ログイン済みです。')
-    return
-
-    // パスワードが違うとパスワード画面が401で返される
+    // パスワードが違うと401が返る
   } else if (res.status === 401) {
-    updateLoginStatus('loggedOut')
+    updateLoginStatus('loggedOut', '')
     setErrMessage('ログインに失敗しました')
     return
 
@@ -110,8 +93,6 @@ const login: Login = async (password, clearInput, setErrMessage, updateLoginStat
     return
   }
 }
-
-const MaintenanceText = styled.p``
 
 const Wrapper = styled.div`
   box-sizing: border-box;
@@ -146,22 +127,10 @@ const Wrapper = styled.div`
     text-align: center;
   }
 
-  & ${MaintenanceText} {
-    color: ${CSS_COLOR.DANGER};
-  }
-
   & p {
     padding: 0;
     margin: 0;
     color: ${CSS_COLOR.TEXT_BLACK};
     line-height: 1.6;
-    & code {
-      padding: 0.125rem 0.25rem;
-      border-radius: 4px;
-      background-color: ${CSS_COLOR.LIGHT_GREY_2};
-      font-size: ${CSS_FONT_SIZE.PX_14};
-      vertical-align: 0.05rem;
-      margin: 0.125rem;
-    }
   }
 `

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,3 +1,4 @@
+import { PRIVATE_DOC_PATH } from '@Constants/application'
 import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
 import { LoginContext, LoginStatusKey } from '@Context/LoginContext'
 import { navigate } from 'gatsby'
@@ -57,7 +58,7 @@ const login: Login = async (password, clearInput, setErrMessage, updateLoginStat
   clearInput()
   setErrMessage('')
 
-  const res = await fetch('/private', {
+  const res = await fetch(PRIVATE_DOC_PATH, {
     method: 'HEAD',
     redirect: 'manual',
     headers: {
@@ -65,8 +66,7 @@ const login: Login = async (password, clearInput, setErrMessage, updateLoginStat
     },
   })
 
-  // サイトルートには何も置いてないので、パスワードが合っていると404が返る
-  if (res.status === 404) {
+  if (res.status === 200) {
     // ログインに成功したらパスワードを保存し前のページに戻る
     updateLoginStatus('loggedIn', password)
     let prevPath = '/'

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,5 +1,5 @@
 import { PRIVATE_DOC_PATH } from '@Constants/application'
-import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
+import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import { LoginContext, LoginStatusKey } from '@Context/LoginContext'
 import { navigate } from 'gatsby'
 import React, { FC, useContext, useState } from 'react'
@@ -15,15 +15,29 @@ export const LoginPage: FC = () => {
   return (
     <Wrapper>
       <h1>従業員ログイン</h1>
-      <p>ログインすると限定コンテンツにアクセスできます。パスワードの確認方法は2つあります。</p>
+      <MaintenanceText>現在ログインできません。システム復旧中です。</MaintenanceText>
+      <p>限定コンテンツを利用したい場合、次の2つの方法で利用できます。（社内限定）</p>
       <ul>
         <li>
-          <p>SmartHR社の1Passwordを利用する</p>
+          <p>
+            社内Slack<code>#design_system_相談</code>で利用したい限定コンテンツを伝える
+          </p>
         </li>
         <li>
-          <p>SmartHR社のSlackに「SDSパスワード」と入力する（自動レスポンスがあります）</p>
+          <p>
+            GitHubリポジトリを確認する（
+            <a href="https://github.com/kufu/smarthr-design-system-private" target="_blank" rel="noreferrer">
+              https://github.com/kufu/smarthr-design-system-private
+            </a>
+            ）
+          </p>
         </li>
       </ul>
+      <p>
+        そのほか相談、問い合わせ先
+        <br />
+        社内Slack<code>#design_system_相談</code>
+      </p>
       <div className="inputs">
         <Input
           type="password"
@@ -32,12 +46,14 @@ export const LoginPage: FC = () => {
           onChange={(e) => setPassword(e.currentTarget.value)}
           value={password}
           name="password"
+          disabled={true}
         />
 
         <Button
           variant="primary"
           wide={true}
           onClick={() => login(password, () => setPassword(''), setErrMessage, updateLoginStatus)}
+          disabled={true}
         >
           ログイン
         </Button>
@@ -94,6 +110,8 @@ const login: Login = async (password, clearInput, setErrMessage, updateLoginStat
   }
 }
 
+const MaintenanceText = styled.p``
+
 const Wrapper = styled.div`
   box-sizing: border-box;
   max-width: 480px;
@@ -127,10 +145,22 @@ const Wrapper = styled.div`
     text-align: center;
   }
 
+  & ${MaintenanceText} {
+    color: ${CSS_COLOR.DANGER};
+  }
+
   & p {
     padding: 0;
     margin: 0;
     color: ${CSS_COLOR.TEXT_BLACK};
     line-height: 1.6;
+    & code {
+      padding: 0.125rem 0.25rem;
+      border-radius: 4px;
+      background-color: ${CSS_COLOR.LIGHT_GREY_2};
+      font-size: ${CSS_FONT_SIZE.PX_14};
+      vertical-align: 0.05rem;
+      margin: 0.125rem;
+    }
   }
 `

--- a/src/components/shared/Private/Private.tsx
+++ b/src/components/shared/Private/Private.tsx
@@ -19,7 +19,7 @@ type Props = {
 export const Private: FC<Props> = ({ path }) => {
   const [privateData, setPrivateData] = useState('')
   const [isShow, setIsShow] = useState(false)
-  const { loginStatus } = useContext(LoginContext)
+  const { loginStatus, password } = useContext(LoginContext)
   useEffect(() => {
     ;(async () => {
       if (path === undefined) {
@@ -33,7 +33,9 @@ export const Private: FC<Props> = ({ path }) => {
       // /private配下は/static/_redirectsの設定でリダイレクトが設定されている
       // 中身はsmarthr-design-system-privateにある
       const res = await fetch(`/private/${path}`, {
-        method: 'GET',
+        headers: {
+          'Sds-Private-Auth': password,
+        },
       }).catch((err) => {
         throw new Error(err)
       })
@@ -53,7 +55,7 @@ export const Private: FC<Props> = ({ path }) => {
       setPrivateData(html)
       setIsShow(true)
     })()
-  }, [path, loginStatus])
+  }, [path, loginStatus, password])
 
   return isShow ? (
     // ログイン済みの時の表示

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,3 @@
-/private/*  https://smarthr-design-system-private.netlify.app/:splat  200
-
 /about /concept/about
 /about/about_ds/publish /concept/operate-policy
 /foundations /foundation


### PR DESCRIPTION
## 課題・背景
kufu/smarthr-design-system-issues#1292

## やったこと
プライベートコンテンツをBasic認証で保護し、Edge functions経由で認証・コンテンツ取得するように変更しました。

- リダイレクト（リライト）ルールの削除
- Edge functionsの設置
- ログイン、ログイン状態保持を行う部分を上記に合わせて修正

Basic認証に変更すると、Cookieでのセッション維持ができなくなるため、Gatsby内で状態を保持するように変更しています。そのため、サイト内回遊中は問題ありませんが、リロードを行うとログイン状態は維持できなくなる仕様です。

## やらなかったこと
このPRをマージしてからでないとプライベートサイト側を更新できないため、現状ではログインはまだできません。プライベートサイト側の更新後に、ログインページをアクティブに戻します。

## 動作確認
- /privateパスの、リライト設定がなくなっている
  - このページ下部に出ているredirect rulesが、57→56になっているので問題なく反映されていそうです
- ページロード時のログインチェックで必要なヘッダーが送られる
  - そして401が返る
- Basic認証のダイアログが表示されない（Privateサイト側にsite protectionがある間はされないはずではありますが）

ことをこのPRで確認したいです。ローカルでは `netlify dev`コマンドにて確認できています。

## キャプチャ
画面上の変更はありません。
