### PR TITLE
ログイン画面を有効なものに戻す

### DIFF
--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,5 +1,5 @@
 import { PRIVATE_DOC_PATH } from '@Constants/application'
-import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
+import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
 import { LoginContext, LoginStatusKey } from '@Context/LoginContext'
 import { navigate } from 'gatsby'
 import React, { FC, useContext, useState } from 'react'
@@ -15,29 +15,15 @@ export const LoginPage: FC = () => {
   return (
     <Wrapper>
       <h1>従業員ログイン</h1>
-      <MaintenanceText>現在ログインできません。システム復旧中です。</MaintenanceText>
-      <p>限定コンテンツを利用したい場合、次の2つの方法で利用できます。（社内限定）</p>
+      <p>ログインすると限定コンテンツにアクセスできます。パスワードの確認方法は2つあります。</p>
       <ul>
         <li>
-          <p>
-            社内Slack<code>#design_system_相談</code>で利用したい限定コンテンツを伝える
-          </p>
+          <p>SmartHR社の1Passwordを利用する</p>
         </li>
         <li>
-          <p>
-            GitHubリポジトリを確認する（
-            <a href="https://github.com/kufu/smarthr-design-system-private" target="_blank" rel="noreferrer">
-              https://github.com/kufu/smarthr-design-system-private
-            </a>
-            ）
-          </p>
+          <p>SmartHR社のSlackに「SDSパスワード」と入力する（自動レスポンスがあります）</p>
         </li>
       </ul>
-      <p>
-        そのほか相談、問い合わせ先
-        <br />
-        社内Slack<code>#design_system_相談</code>
-      </p>
       <div className="inputs">
         <Input
           type="password"
@@ -46,14 +32,12 @@ export const LoginPage: FC = () => {
           onChange={(e) => setPassword(e.currentTarget.value)}
           value={password}
           name="password"
-          disabled={true}
         />
 
         <Button
           variant="primary"
           wide={true}
           onClick={() => login(password, () => setPassword(''), setErrMessage, updateLoginStatus)}
-          disabled={true}
         >
           ログイン
         </Button>
@@ -110,8 +94,6 @@ const login: Login = async (password, clearInput, setErrMessage, updateLoginStat
   }
 }
 
-const MaintenanceText = styled.p``
-
 const Wrapper = styled.div`
   box-sizing: border-box;
   max-width: 480px;
@@ -145,22 +127,10 @@ const Wrapper = styled.div`
     text-align: center;
   }
 
-  & ${MaintenanceText} {
-    color: ${CSS_COLOR.DANGER};
-  }
-
   & p {
     padding: 0;
     margin: 0;
     color: ${CSS_COLOR.TEXT_BLACK};
     line-height: 1.6;
-    & code {
-      padding: 0.125rem 0.25rem;
-      border-radius: 4px;
-      background-color: ${CSS_COLOR.LIGHT_GREY_2};
-      font-size: ${CSS_FONT_SIZE.PX_14};
-      vertical-align: 0.05rem;
-      margin: 0.125rem;
-    }
   }
 `


### PR DESCRIPTION
## 課題・背景
kufu/smarthr-design-system-issues#1292

プライベートコンテンツ提供サイトの認証方法を変更し、#863 でこちら側もリクエスト方法を切り替えました。動作に問題なさそうなので、無効にしていたログインUIを再度有効にします。

## やったこと
ログインページのパスワード入力フォームが機能するように戻し、ログイン不具合の注意書きなども削除しました。見た目上は、不具合発生以前の状態に戻っています。

## 動作確認
ローカルでは`netlify dev`コマンドにて動作確認済みです。
ログイン機能には、引き続きNetlify特有の機能を利用しているので、ローカルでは`yarn dev`コマンドでの動作確認はできません。

### プレビューページ
- ログイン画面：https://deploy-preview-864--smarthr-design-system.netlify.app/login/
- プライベートコンテンツのあるページ例：https://deploy-preview-864--smarthr-design-system.netlify.app/basics/illustration/user-co-main/

### ログイン状態の維持
認証方法が以前と変わったため、ログイン状態を維持できる範囲が少し変わりました。
- 画面をリロードした場合：以前はログインしたままでしたが、今後はログアウト状態になります

リンクを辿ってサイト内を回遊している状況では維持されますが、上記の点が不便なようでしたらsessionStorageの活用などを検討するのが良いかもしれません。

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/2b614fc5-2c58-4a87-b0b2-1610d2594368" width="350" alt> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/c019c71d-a17a-44d8-aa72-438fd5ac90bb" width="350" alt> |
