### PR TITLE
サービス画面キャプチャのページの画像が表示されなくなっていた問題を修正

### DIFF
--- a/src/components/contents/ServiceCapture/CaptureImageWithDesc.tsx
+++ b/src/components/contents/ServiceCapture/CaptureImageWithDesc.tsx
@@ -25,7 +25,7 @@ const Figure = styled.figure`
     background-color: ${CSS_COLOR.DIVIDER};
   }
   a {
-    display: inline-block;
+    display: block;
     height: 208px;
   }
   span {

--- a/src/components/contents/ServiceCapture/CaptureImageWithDesc.tsx
+++ b/src/components/contents/ServiceCapture/CaptureImageWithDesc.tsx
@@ -25,6 +25,7 @@ const Figure = styled.figure`
     background-color: ${CSS_COLOR.DIVIDER};
   }
   a {
+    display: inline-block;
     height: 208px;
   }
   span {


### PR DESCRIPTION
## 課題・背景

サービス画面キャプチャのページの画像が、いつの間にか表示されなくなっていた

## やったこと

親のa要素にinline-blockを適用

## やらなかったこと

## 動作確認

https://deploy-preview-866--smarthr-design-system.netlify.app/communication/capture/service-capture/#h2-0

## キャプチャ

|Before|After|
| --- | --- |
| <img width="782" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/1369376/3958c847-852d-48e7-b1a6-af91fbcaf7de"> | <img width="782" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/1369376/0f40ded3-aca4-4934-b257-29ae9445b166"> |
