### PR TITLE
コンポーネントページのGitHubのリンク先を修正

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -64,6 +64,7 @@ export const ComponentStory: FC<Props> = ({ name, dirName }) => {
   const [storyData, setStoryData] = useState({
     code: '',
     storyItems: defaultData?.storyItems ?? [],
+    sourcePath: defaultData?.filePath?.replace(/^\.\//, '').replace(/[^/]*?\.tsx$/, '') || '',
   })
 
   // プルダウンの選択肢を作成する
@@ -111,8 +112,9 @@ export const ComponentStory: FC<Props> = ({ name, dirName }) => {
       }
 
       const storyItems = targetStoryData.storyItems || []
+      const sourcePath = targetStoryData.filePath?.replace(/^\.\//, '').replace(/[^/]*?\.tsx$/, '') || ''
 
-      setStoryData({ code, storyItems })
+      setStoryData({ code, storyItems, sourcePath })
       setCurrentIFrame(storyItems[0]?.iframeName ?? '')
       setShowError(false)
     },
@@ -202,7 +204,7 @@ export const ComponentStory: FC<Props> = ({ name, dirName }) => {
             Storybook
           </AnchorButton>
           <AnchorButton
-            href={`${SHRUI_GITHUB_PATH}v${displayVersion}/src/components/${name}`}
+            href={`${SHRUI_GITHUB_PATH}v${displayVersion}/${storyData?.sourcePath}`}
             target="_blank"
             size="s"
             suffix={<FaExternalLinkAltIcon />}


### PR DESCRIPTION
## 課題・背景
https://pxgrid.slack.com/archives/C018J0A6DCH/p1692927084500679

階層のあるコンポーネントの場合に、GitHubのソースコードへのリンクが正しくないので修正する。

## やったこと
#771 で階層の指定方法を変更した際に、考慮が漏れていたようです。
Storybookのパスの取得などと同様、GitHubのソースコードのパスも`smarthr-ui-props.json`から取得するように変更しました。

## 動作確認
階層があるために、リンクが正しくなかったページ：
https://deploy-preview-867--smarthr-design-system.netlify.app/products/components/dropdown/dropdown-menu-button/
https://deploy-preview-867--smarthr-design-system.netlify.app/products/components/dropdown/filter-dropdown/
https://deploy-preview-867--smarthr-design-system.netlify.app/products/components/input/search-input/
https://deploy-preview-867--smarthr-design-system.netlify.app/products/components/layout/ 以下の各コンポーネント

階層のないページはそのままです
例：https://deploy-preview-867--smarthr-design-system.netlify.app/products/components/accordion-panel/

## キャプチャ
見た目上の変化はありません。