### PR TITLE
ログインUIにHTMLのformを適用

### DIFF
--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -24,26 +24,29 @@ export const LoginPage: FC = () => {
           <p>SmartHR社のSlackに「SDSパスワード」と入力する（自動レスポンスがあります）</p>
         </li>
       </ul>
-      <div className="inputs">
-        <Input
-          type="password"
-          prefix={<FaLockIcon />}
-          width="100%"
-          onChange={(e) => setPassword(e.currentTarget.value)}
-          value={password}
-          name="password"
-        />
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          login(password, () => setPassword(''), setErrMessage, updateLoginStatus)
+        }}
+      >
+        <div className="inputs">
+          <Input
+            type="password"
+            prefix={<FaLockIcon />}
+            width="100%"
+            onChange={(e) => setPassword(e.currentTarget.value)}
+            value={password}
+            name="password"
+          />
 
-        <Button
-          variant="primary"
-          wide={true}
-          onClick={() => login(password, () => setPassword(''), setErrMessage, updateLoginStatus)}
-        >
-          ログイン
-        </Button>
+          <Button variant="primary" wide={true}>
+            ログイン
+          </Button>
 
-        {errMessage !== '' && <span className="warn">{errMessage}</span>}
-      </div>
+          {errMessage !== '' && <span className="warn">{errMessage}</span>}
+        </div>
+      </form>
     </Wrapper>
   )
 }


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1293

## やったこと
ログインUIにHTMLの`form`要素を適用して、パスワード入力欄とログインボタンをその中に含めました。form内の要素にフォーカスがある状態でEnterキーを押下するとログイン処理が実行されます。

※ gitの差分が多いですが、ほとんどはインデントがずれたことによるものです。

## 動作確認
ローカルでは netlify-cliにて正常にログインできることを確認しました。

## キャプチャ
見た目上の変化はありません。
