### PR TITLE
a要素のカスタムコンポーネントに属性値の継承処理を追加

### DIFF
--- a/src/components/article/CustomLink/CustomLink.tsx
+++ b/src/components/article/CustomLink/CustomLink.tsx
@@ -8,15 +8,26 @@ type Props = {
   href: string
 }
 
-export const CustomLink: FC<Props> = ({ children, href }) => {
+export const CustomLink: FC<Props> = ({ children, href, ...props }) => {
   const isExternal = href.match(/^https?:\/\/(?!smarthr\.design).*?$/) !== null
+  const attrs = isExternal
+    ? Object.assign(
+        { ...props },
+        {
+          target: '_blank',
+          rel: 'noreferrer',
+        },
+      )
+    : props
   return isExternal ? (
-    <StyledLink to={href} target="_blank" rel="noreferrer">
+    <StyledLink {...attrs} to={href}>
       {children}
       <FaExternalLinkAltIcon />
     </StyledLink>
   ) : (
-    <Link to={href}>{children}</Link>
+    <Link {...attrs} to={href}>
+      {children}
+    </Link>
   )
 }
 

--- a/src/components/contents/ServiceCapture/CaptureImageWithDesc.tsx
+++ b/src/components/contents/ServiceCapture/CaptureImageWithDesc.tsx
@@ -25,7 +25,6 @@ const Figure = styled.figure`
     background-color: ${CSS_COLOR.DIVIDER};
   }
   a {
-    display: block;
     height: 208px;
   }
   span {

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -51,7 +51,11 @@ const components: MDXProviderComponents = {
     </FragmentTitle>
   ),
   table: ({ children }) => <TableWrapper mdTable={true}>{children}</TableWrapper>,
-  a: ({ children, href }) => <CustomLink href={href}>{children}</CustomLink>,
+  a: ({ children, href, ...props }) => (
+    <CustomLink {...props} href={href}>
+      {children}
+    </CustomLink>
+  ),
 }
 
 const shortcodes = {


### PR DESCRIPTION
## 課題・背景
関連：#849、#866

#849 にて、テンプレートに `a`要素を置換するカスタムコンポーネントを追加しましたが、mdxファイル内の画像にも影響し、一部のページで画像が表示できない原因となっていたため、修正しました。

具体的には、mdxファイル内の画像記法（`![xxx](yyy)`）→gatsby-remark-imagesプラグインで`a`タグでのラップ、スタイルの適用などの処理が行われる→`a`タグなので#849 のカスタムコンポーネントが適用、という処理になっていますが、
カスタムコンポーネント適用時にgatsby-remark-imagesが追加したスタイルが失われていました。

## やったこと
カスタムコンポーネントに、`href`以外の属性値もrest propsとして渡し、適用するようにしました。
外部リンクの場合には、`target="_blank"`と`rel="noreferrer"`を追加する、という処理は変わりません。

また、#866でスタイルの追加をしていますが、このPRの修正で根本的に解決でき、不要になるので、元に戻しました。

## 動作確認
画像が表示されている：
https://deploy-preview-869--smarthr-design-system.netlify.app/communication/capture/service-capture/

外部リンクにはアイコンと`target="_blank"`と`rel="noreferrer"`が適用できている例：
https://deploy-preview-869--smarthr-design-system.netlify.app/accessibility/alternative-text/#h2-2


## キャプチャ
見た目上の変化はありません。