### PR TITLE
target="_blank"の場合はLinkコンポーネントを使わないように修正

### DIFF
--- a/src/components/article/CustomLink/CustomLink.tsx
+++ b/src/components/article/CustomLink/CustomLink.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export const CustomLink: FC<Props> = ({ children, href, ...props }) => {
   const isExternal = href.match(/^https?:\/\/(?!smarthr\.design).*?$/) !== null
-  const attrs = isExternal
+  const attrs: { [key: string]: string } = isExternal
     ? Object.assign(
         { ...props },
         {
@@ -19,10 +19,10 @@ export const CustomLink: FC<Props> = ({ children, href, ...props }) => {
         },
       )
     : props
-  return isExternal ? (
-    <StyledLink {...attrs} to={href}>
+  return attrs.target === '_blank' ? (
+    <StyledLink {...attrs} href={href}>
       {children}
-      <FaExternalLinkAltIcon />
+      {isExternal && <FaExternalLinkAltIcon />}
     </StyledLink>
   ) : (
     <Link {...attrs} to={href}>
@@ -31,7 +31,7 @@ export const CustomLink: FC<Props> = ({ children, href, ...props }) => {
   )
 }
 
-const StyledLink = styled(Link)`
+const StyledLink = styled.a`
   svg {
     margin-inline: 0.25em;
   }


### PR DESCRIPTION
## 課題・背景
関連：#869

#869 で、プラグインが出力した`target="_blank"`属性がそのままHTMLに出力されるように修正しましたが、Gatsbyの`Link`コンポーネントを使用していると、リンク先が内部URLの場合には同一タブで開かれてしまうので修正する。

## やったこと
`target="_blank"`の場合には、`a`タグを使用するように変更しました。

## 動作確認
https://deploy-preview-870--smarthr-design-system.netlify.app/communication/capture/service-capture/

画像をクリックすると、別タブ（ウィンドウ）で開きます。

## キャプチャ
見た目上は変化ありません。