### PR TITLE
Netlify上でキャッシュクリア・ビルドするGH Actionsを追加

### DIFF
--- a/.github/workflows/netlify-clear-cache-deploy.yml
+++ b/.github/workflows/netlify-clear-cache-deploy.yml
@@ -1,0 +1,16 @@
+name: "Clear cache and deploy site on Netlify"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post to Netlify API
+        run: |
+          curl -X POST https://api.netlify.com/api/v1/sites/${{ secrets.NETLIFY_SITE_ID }}/builds \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.NETLIFY_AUTH_TOKEN }}" \
+            -d '{"clear_cache": true}'

--- a/.github/workflows/netlify-clear-cache-deploy.yml
+++ b/.github/workflows/netlify-clear-cache-deploy.yml
@@ -8,9 +8,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Post to Netlify API
+      - name: main branch
+        # mainブランチで実行されている場合は、NetlifyのキャッシュをクリアしてデプロイするAPIを叩く
+        if: github.ref_name == 'main'
         run: |
+          echo "Request main branch build and deploy without cache"
           curl -X POST https://api.netlify.com/api/v1/sites/${{ secrets.NETLIFY_SITE_ID }}/builds \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.NETLIFY_AUTH_TOKEN }}" \
+            -d '{"clear_cache": true}'
+      - name: not in main branch
+        # mainブランチ以外では、そのブランチでの最新デプロイのIDを取得してから、
+        # そのデプロイをキャッシュなしでリトライするAPIを叩く
+        if: github.ref_name != 'main'
+        run: |
+          response=$(curl https://api.netlify.com/api/v1/sites/${{ secrets.NETLIFY_SITE_ID }}/deploys?per_page=1\&branch=${{ github.ref_name }} \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.NETLIFY_AUTH_TOKEN }}")
+          deploy_id=$(echo $response | jq -r '.[0].id')
+          if [ "$deploy_id" == 'null' ]; then
+            echo "deploy_id for ${{ github.ref_name }} branch not found";
+            exit;
+          fi
+          echo "Request retrying deploy without cache. branch_name: ${{ github.ref_name }} deploy_id: $deploy_id"
+          curl -X POST https://api.netlify.com/api/v1/deploys/$deploy_id/retry \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.NETLIFY_AUTH_TOKEN }}" \
             -d '{"clear_cache": true}'


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1287

## やったこと
NetlifyのAPIにPOSTリクエストを送信することで、キャッシュクリアを伴うビルド・デプロイ（対象はmainブランチ）をトリガーできることが分かったので、GitHub Actionsにそのようなワークフローを追加しました。

Netlifyのsite_idとAuthorization tokenが必要ですが、デプロイ用のワークフローでも利用しているものなので、すでにこのリポジトリのActions用シークレットにセットされているはずです。
このあたり：https://github.com/kufu/smarthr-design-system/blob/94697b4c24d303169b5ec606a4149ffca78aefa1/.github/workflows/deploy-to-netlify.yml#L21-L23

## やらなかったこと
`package.json`に `netlify-build: gatsby clean && gatsby build` のようなNetlify用ビルドコマンドを追加することも考えましたが、Netlify上で毎回キャッシュクリアを行うことは意図していないので、上記のAPI利用を採用しました。

## 動作確認
mainブランチにマージしないとActionsを実行できないため、このリポジトリの環境では未検証です。テスト用リポジトリ・サイトでは動作確認済みで、成功すればNetlify側のビルドログには`Building without cache`と記録されるはずです。

`Initializing`セクションの最初の部分です：
<img src="https://github.com/kufu/smarthr-design-system/assets/7822534/491cd3b3-94b7-4ed3-a245-b72d6e2fc782" width="500" alt>


## キャプチャ
サイト本体への影響はありません。