### PR TITLE
選択できるSmartHR UIバージョンの数・並び順を改善

### DIFF
--- a/plugins/gatsby-source-ui-versions/gatsby-node.ts
+++ b/plugins/gatsby-source-ui-versions/gatsby-node.ts
@@ -14,6 +14,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }: Sou
     createNode({
       version: item.version,
       commitHash: item.commitHash,
+      commitDate: item.commitDate,
       uiProps: item.uiProps,
       uiStories: item.uiStories,
       id: createNodeId(`${NODE_TYPE}-${item.version}`),

--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -28,9 +28,10 @@ type Props = {
 
 const query = graphql`
   query StoryData {
-    allUiVersion {
+    allUiVersion(sort: { fields: commitDate, order: DESC }) {
       nodes {
         commitHash
+        commitDate
         version
         uiStories {
           storyName


### PR DESCRIPTION
## 課題・背景
プロダクト＞コンポーネント以下の各SmarthrUIコンポーネントについて、バージョン選択のドロップダウンメニューの並び順が期待どおりでなくなっているので修正する。

新しい2件が最後になってしまっている。
<img src="https://github.com/kufu/smarthr-design-system/assets/7822534/cddd7607-100f-46bf-ae86-6c4cf3387aa2" alt width="600">


## やったこと
- GitHubのAPIからリリースコミットの作成日時も取得するように変更してgatsby-nodeに登録し、`useStaticQuery()`での取得の際に、日時での`sort`オプションを追加しました。
- また、GitHubのAPIはデフォルトでは30件までの取得になっていたので、上限の100件に増やしました。

順序が期待通りでなくなる現象は、明確には再現できませんでしたが、GitHubのAPIからのデータ取得時には時系列になっており、そのままgatsby-nodeに登録できていることは確認しました。キャッシュがある状態で、新しいバージョンが追加された場合などに順序がずれてしまっていたのかもしれません。

## やらなかったこと
GitHub APIからのデータ取得は、`page`パラメータをつけてループ処理にすれば101件以降も取得できますが、現状は実装していません。現状でも新しいものから100件までは取得可能ですし、また100件以上となるとUI側（ドロップダウンメニュー）がそのままで良いかも検討したいかもしれません。必要があれば別途対応できればと思っています。

## 動作確認
https://deploy-preview-875--smarthr-design-system.netlify.app/products/components/accordion-panel/

データの並び順・数のみの変更なので、動作には影響はないかと思います。

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/ab88d0e2-a4e9-4848-9ef7-819a1b48a564" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/4ca3606a-82f2-44cf-8568-c67caa992500" alt width="350"> |

