### PR TITLE
ページを検索エンジンにindexするかどうかを指定する機能を追加

### DIFF
--- a/content/articles/contact.mdx
+++ b/content/articles/contact.mdx
@@ -2,6 +2,7 @@
 title: 'お問い合わせ'
 description: ''
 order: 9
+robotsNoIndex: true
 ---
 
 SmartHR Design Systemに関して気づいたことがありましたら、いつでもお問い合わせ・フィードバックをください。

--- a/src/gatsby-node/index.ts
+++ b/src/gatsby-node/index.ts
@@ -112,6 +112,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       title: String!
       description: String!
       order: Int
+      robotsNoIndex: Boolean
     }
   `
 

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -75,6 +75,7 @@ export const query = graphql`
         title
         description
         ignoreH3Nav
+        robotsNoIndex
       }
       fields {
         category
@@ -338,7 +339,8 @@ export const Head: FC<Props> = ({ data }) => {
   // memo: カテゴリのtitleとカテゴリ直下のindexページのタイトルが重複した場合はカテゴリ名のみを表示する
   const headTitle = title === parentCategoryName ? title : `${title} | ${parentCategoryName}`
 
-  return <HeadComponent title={headTitle} description={description} ogTitle={title} />
+  const headerMeta = frontmatter?.robotsNoIndex ? [{ name: 'robots', content: 'noindex' }] : []
+  return <HeadComponent title={headTitle} description={description} ogTitle={title} meta={headerMeta} />
 }
 
 const Wrapper = styled.div`


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1296

## やったこと
MDXファイルで、frontmatterに`robotsNoIndex: true`をセットすると、そのページのHTMLヘッダーに`<meta name="robots" content="noindex"/>`が追加されるようにし、お問い合わせページに適用しました。

## やらなかったこと
[サイト内検索](https://smarthr.design/search/)のインデックスについては何もしていないので、そちらの検索では引き続きお問い合わせページも出てきます。

## 動作確認
- HTMLヘッダーにメタタグが出力されている：
  - https://deploy-preview-877--smarthr-design-system.netlify.app/contact/
- トップページやその他のページには出力されていない：
  - https://deploy-preview-877--smarthr-design-system.netlify.app/ 
  - https://deploy-preview-877--smarthr-design-system.netlify.app/introduction/ （例）

※Gatsbyの仕様上、devサーバ（`yarn dev`コマンドで起動）では確認できません。ローカルではビルドした`public/contact/index.html`ファイルを直接確認しました。

## キャプチャ
見た目上の変化はありません。
