### PR TITLE
端末モックのフィードバック先を追加

### DIFF
--- a/content/articles/communication/mock.mdx
+++ b/content/articles/communication/mock.mdx
@@ -136,3 +136,10 @@ KeynoteやGoogleスライドなどのスライド資料の場合、サービス�
 </TableWrapper>
 
 ほかのコンテンツの利用範囲は[利用者のかたへ](/introduction/user/)を参照してください。
+
+
+
+## フィードバック先
+端末モックに関する相談やフィードバック  
+- 社内Slack　`#design_comm_依頼`
+- SmartHR Design System 運営　smarthr-design-system@smarthr.co.jp  


### PR DESCRIPTION
## 課題・背景
- 社内メンバーの一部が、[端末モックと画面キャプチャを合成できるFigmaファイル](https://www.figma.com/file/ul8bbn8p3aPIXo0DsjjsA6/%E7%AB%AF%E6%9C%AB%E3%83%A2%E3%83%83%E3%82%AF%E5%90%88%E6%88%90?type=design&node-id=723%3A121&mode=design&t=u1R3wDAgKOH9kDOk-1)を閲覧できない可能性があるため、[[端末モック](https://smarthr.design/communication/mock/)] 画面にフィードバック先を掲載しました。


## やったこと
- [[端末モック](https://smarthr.design/communication/mock/)] 画面にフィードバック先を掲載


## やらなかったこと
- とくになし


## 動作確認
https://deploy-preview-884--smarthr-design-system.netlify.app/communication/mock/#h2-3

## キャプチャ

![CleanShot 2023-09-19 at 16 50 06](https://github.com/kufu/smarthr-design-system/assets/101125529/ceb9354f-8471-43ba-bd71-e1aefa0c9060)
