### PR TITLE
プライベートコンテンツのmdパーサーを変更

### DIFF
--- a/src/components/shared/Private/Private.tsx
+++ b/src/components/shared/Private/Private.tsx
@@ -1,5 +1,6 @@
 import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import { LoginContext } from '@Context/LoginContext'
+import { marked } from 'marked'
 import { micromark } from 'micromark'
 import { mdxjs } from 'micromark-extension-mdxjs'
 import React, { useContext, useEffect, useState } from 'react'
@@ -50,7 +51,8 @@ export const Private: FC<Props> = ({ path }) => {
       }
 
       const mdString = await res.text()
-      const html = micromark(mdString, { extensions: [mdxjs()] })
+      // mdxファイルの場合はmicromarkでパースする
+      const html = path.endsWith('md') ? marked.parse(mdString) : micromark(mdString, { extensions: [mdxjs()] })
 
       setPrivateData(html)
       setIsShow(true)


### PR DESCRIPTION
## 課題・背景
https://pxgrid.slack.com/archives/C018J0A6DCH/p1695197744014409?thread_ts=1695193755.228289&cid=C018J0A6DCH

## やったこと
プライベートコンテンツのマークダウンをHTMLに変換するパーサーを、micromarkからmarkedに置き換えました。

画像が入っているプライベートコンテンツが表示できていない問題があり、画像をbase64エンコードしてmdに埋め込む実装を検討していますが、micromarkは埋め込みの画像に非対応のため、markedにしたい、という事情です。marked自体は`ComponentPropsTable`などですでに使われています。

## やらなかったこと
micromarkはここ以外では使われていませんが、ひとまず残しています。

micromarkが採用された理由はおそらくmdx用の拡張があるからなので、変換したいコンテンツが`.mdx`の場合にはmicromarkを使う、という実装にしてあります。
ただし、現在は.mdxのプライベートコンテンツは読み込んでいなさそうですし、.mdx＋埋め込み画像の場合にはパースできないため、.mdのみの対応で良いということであれば今後削除しても良さそうです。

## 動作確認
プライベートコンテンツのあるページ：
https://deploy-preview-885--smarthr-design-system.netlify.app/basics/illustration/item/
https://deploy-preview-885--smarthr-design-system.netlify.app/basics/illustration/smarthr-co/
https://deploy-preview-885--smarthr-design-system.netlify.app/basics/illustration/user-co-main/
https://deploy-preview-885--smarthr-design-system.netlify.app/communication/mock/
https://deploy-preview-885--smarthr-design-system.netlify.app/communication/capture/service-capture-in-mock/
↑最後が画像が表示できていないページですが、Private側のコードを更新後に不具合が解消する想定です。

## キャプチャ
見た目上の変化はありません。
