### PR TITLE
右サイドバーのPC表示時のCSSを修正

### DIFF
--- a/src/components/article/IndexNav/IndexNav.tsx
+++ b/src/components/article/IndexNav/IndexNav.tsx
@@ -120,6 +120,7 @@ export const IndexNav: FC<Props> = ({ target, ignoreH3Nav = false }) => {
 }
 
 const NavWrapper = styled.div`
+  overflow-y: auto;
   @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     display: none;
   }

--- a/src/components/article/IndexNav/IndexNav.tsx
+++ b/src/components/article/IndexNav/IndexNav.tsx
@@ -15,6 +15,7 @@ export type HeadingItem = {
 }
 
 export const IndexNav: FC<Props> = ({ target, ignoreH3Nav = false }) => {
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const indexNavRef = useRef<HTMLUListElement>(null)
   const [nestedHeadings, setNestedHeadings] = useState<HeadingItem[]>([])
   const [currentHeading, setCurrentHeading] = useState<string>('')
@@ -83,23 +84,23 @@ export const IndexNav: FC<Props> = ({ target, ignoreH3Nav = false }) => {
   useEffect(() => {
     // 現在地が移動した際、その見出しが表示範囲内に入るようにスクロールする処理
     const currentItem = indexNavRef.current?.querySelector(`a[aria-current="true"]`)
-    const navElement = indexNavRef.current?.parentElement // Navにrefを渡せないため、ulの親要素として取得する
-    if (!(currentItem instanceof HTMLElement) || !navElement) return
+    const wrapperElement = wrapperRef.current
+    if (!(currentItem instanceof HTMLElement) || !wrapperElement) return
 
     // 表示されている範囲の上端・下端の取得
-    const navAreaTop = navElement.scrollTop
-    const navAreaBottom = navAreaTop + navElement.clientHeight
+    const navAreaTop = wrapperElement.scrollTop
+    const navAreaBottom = navAreaTop + wrapperElement.clientHeight
     // 表示範囲に入っていれば何もしない
     if (currentItem.offsetTop > navAreaTop && currentItem.offsetTop < navAreaBottom) return
 
     // 現在地が表示範囲の中央に来るようにスクロールする
-    navElement.scrollTop = currentItem.offsetTop - navElement.clientHeight / 2
+    wrapperElement.scrollTop = currentItem.offsetTop - wrapperElement.clientHeight / 2
   }, [currentHeading, indexNavRef])
 
   return (
     <>
       {/* PC表示 */}
-      <NavWrapper>
+      <NavWrapper ref={wrapperRef}>
         <IndexNavItems nestedHeadings={nestedHeadings} indexNavRef={indexNavRef} currentHeading={currentHeading} />
       </NavWrapper>
       {/* SP表示 */}

--- a/src/components/article/IndexNav/IndexNavItems.tsx
+++ b/src/components/article/IndexNav/IndexNavItems.tsx
@@ -50,7 +50,6 @@ export const IndexNavItems: FC<Props> = ({ nestedHeadings, indexNavRef, currentH
 const Nav = styled(NavComponent)`
   display: block;
   padding-top: 160px;
-  overflow-y: auto;
   @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
     padding-top: 0;
   }


### PR DESCRIPTION
## 課題・背景
#890 
https://pxgrid.slack.com/archives/C018J0A6DCH/p1697004960165319

## やったこと
右サイドバー部分で、PC/SP表示のコードを共通化した際に、元あったCSSが意図したとおりに適用されなくなっていたため、修正しました。

具体的にはgrid直下の要素に`overflow-y: auto`が適用されるのが正しいため、そのように修正しています。また、表示中の項目が画面内に入るよう、JSでスクロールさせる機能がありますが、そのスクロール対象の要素も合わせて修正しています。

## 動作確認
右サイドバーがメインコンテンツより長くなるページで表示の不具合が発生していました。

ページ例：
https://deploy-preview-910--smarthr-design-system.netlify.app/products/contents/idiomatic-usage/usage/
https://deploy-preview-910--smarthr-design-system.netlify.app/products/components/

※不具合発生前のPRプレビュー例：https://deploy-preview-849--smarthr-design-system.netlify.app/products/components/
この時と同じ表示に戻っています。

## キャプチャ
|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/d65a4c80-c633-45e7-b48a-c37e609b0a34" width="350" alt="修正前の画面キャプチャ。右サイドバーが下に突き抜けている"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/336a2d22-7068-4060-9ad0-0f0d039b8114" width="350" alt="修正後の画面キャプチャ。右サイドバーには縦方向のスクロールバーが表示されている"> |