### PR TITLE
Buttonコンポーネントページの表示不具合を修正

### DIFF
--- a/content/articles/products/components/button.mdx
+++ b/content/articles/products/components/button.mdx
@@ -3,6 +3,7 @@ title: 'Button'
 description: ' '
 ---
 
+import { Button, Cluster, FaCaretDownIcon, FaCloudDownloadAltIcon, FaFilterIcon, FaPlusCircleIcon } from 'smarthr-ui'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 

--- a/plugins/gatsby-source-component-captures/fetchComponentCaptures.ts
+++ b/plugins/gatsby-source-component-captures/fetchComponentCaptures.ts
@@ -63,7 +63,7 @@ export const fetchComponentCaptures = async () => {
 
   for (const id in storiesMap) {
     const { kind, tags, importPath } = storiesMap[id]
-    if (tags.includes('docs')) continue // ドキュメントはコンポーネント一覧として表示しない
+    if (Array.isArray(tags) && tags.includes('docs')) continue // ドキュメントはコンポーネント一覧として表示しない
 
     const groupName = kind.split('/')[0]
     const displayName = kind.split('/')[1]


### PR DESCRIPTION
## 課題・背景
https://pxgrid.slack.com/archives/C018J0A6DCH/p1697016863956069

## やったこと
プロダクト→コンポーネント→Button ページで、ページ内で使われているコンポーネントの `import`文がどこかの段階で消えてしまっていたようなので、追加しました。

## やらなかったこと
他のコンポーネントのページもひととおり確認しましたが、上記のようなimport漏れはなさそうでした。（余分にimportされているページはあるかもしれませんが、その場合は表示不具合は起きないので、そのままにしてあります。）

## 動作確認
https://deploy-preview-912--smarthr-design-system.netlify.app/products/components/button/#h2-2

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/6e6ef65a-47c4-45c7-bfdb-463404e0db8b" width="350" alt> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/b05bab80-12b5-4883-9a31-345e59ceadd7" width="350" alt> |