### PR TITLE
ESLintで警告の出ていたheadingとsectioning contentを調整

### DIFF
--- a/src/components/ComponentCaptures/ComponentCaptures.tsx
+++ b/src/components/ComponentCaptures/ComponentCaptures.tsx
@@ -1,6 +1,7 @@
 import { CSS_COLOR, CSS_FONT_SIZE } from '@Constants/style'
 import { graphql, useStaticQuery } from 'gatsby'
 import React, { FC } from 'react'
+import { Section } from 'smarthr-ui'
 import styled from 'styled-components'
 
 const query = graphql`
@@ -28,7 +29,7 @@ export const ComponentCaptures: FC = () => {
   return (
     <Wrapper>
       {allComponentCapture.nodes.map((node) => (
-        <ComponentGroup key={node.groupName}>
+        <ComponentGroupSection key={node.groupName}>
           <h2 id={`component-${node.groupName}`}>{node.groupName}</h2>
           <ComponentList>
             {node.storyKinds.map((storyKind) => {
@@ -46,14 +47,14 @@ export const ComponentCaptures: FC = () => {
               ) : null
             })}
           </ComponentList>
-        </ComponentGroup>
+        </ComponentGroupSection>
       ))}
     </Wrapper>
   )
 }
 
 const Wrapper = styled.div``
-const ComponentGroup = styled.div`
+const ComponentGroupSection = styled(Section)`
   && {
     > h2 {
       margin-top: 64px;

--- a/src/components/article/PageIndex/PageIndex.tsx
+++ b/src/components/article/PageIndex/PageIndex.tsx
@@ -2,6 +2,7 @@ import { CSS_FONT_SIZE } from '@Constants/style'
 import { Link, graphql, useStaticQuery } from 'gatsby'
 import { marked } from 'marked'
 import React, { FC } from 'react'
+import { Section } from 'smarthr-ui'
 import styled from 'styled-components'
 
 type Props = {
@@ -73,7 +74,7 @@ export const PageIndex: FC<Props> = ({ path, excludes, heading = 'h2', children 
         {pageData.map((item, idx: number) => {
           const itemName = item.pathList[item.pathList.length - 2]
           return (
-            <React.Fragment key={idx}>
+            <Section key={idx}>
               <PageTitleHeading as={heading} id={`page-${idx}`}>
                 <Link to={item.slug}>{item.title}</Link>
               </PageTitleHeading>
@@ -84,7 +85,7 @@ export const PageIndex: FC<Props> = ({ path, excludes, heading = 'h2', children 
                   <p>{item.description}</p>
                 </PageDescription>
               )}
-            </React.Fragment>
+            </Section>
           )
         })}
       </PageList>

--- a/src/components/index/ContentNavigation/Category.tsx
+++ b/src/components/index/ContentNavigation/Category.tsx
@@ -1,6 +1,7 @@
 import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import { Link } from 'gatsby'
 import React, { FC } from 'react'
+import { Section } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import { FloatingTextLink } from '../../shared/FloatingTextLink'
@@ -27,7 +28,7 @@ type Props = {
 
 export const Category: FC<Props> = ({ data }) => {
   return (
-    <NavigationContainer>
+    <NavigationSection>
       <NavigationText>
         <h2>{data.title}</h2>
         <p>{data.description}</p>
@@ -59,11 +60,11 @@ export const Category: FC<Props> = ({ data }) => {
           </NavigationLinks>
         )}
       </NavigationLinksContainer>
-    </NavigationContainer>
+    </NavigationSection>
   )
 }
 
-const NavigationContainer = styled.div`
+const NavigationSection = styled(Section)`
   display: flex;
   gap: 40px;
   @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {

--- a/src/components/index/Faq/FaqItem.tsx
+++ b/src/components/index/Faq/FaqItem.tsx
@@ -1,6 +1,7 @@
 import { RoundedBoxLink } from '@Components/shared/RoundedBoxLink'
 import { CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import React, { FC } from 'react'
+import { Section } from 'smarthr-ui'
 import styled from 'styled-components'
 
 type FaqJsonObject = {
@@ -18,15 +19,15 @@ type Props = {
 
 export const FaqItem: FC<Props> = ({ data }) => {
   return (
-    <Wrapper>
+    <FaqItemSection>
       <QuestionHeading>{data.question}</QuestionHeading>
       <AnswerText>{data.answer}</AnswerText>
       <RoundedBoxLink path={data.path} label="もっと詳しく" title={data.linkLabel} />
-    </Wrapper>
+    </FaqItemSection>
   )
 }
 
-const Wrapper = styled.div`
+const FaqItemSection = styled(Section)`
   display: block;
   text-align: left;
 `

--- a/src/components/index/Faq/FaqList.tsx
+++ b/src/components/index/Faq/FaqList.tsx
@@ -1,5 +1,6 @@
 import { CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import React, { FC } from 'react'
+import { Section } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import indexFaqJson from '../../../data/indexFaq.json'
@@ -19,7 +20,7 @@ const data = indexFaqJson as ItemJsonType[]
 
 export const FaqList: FC = () => {
   return (
-    <IndexFaqContainer>
+    <IndexFaqSection>
       <h2>よくあるご質問</h2>
       <ul>
         {data.map((item, i) => {
@@ -30,11 +31,11 @@ export const FaqList: FC = () => {
           )
         })}
       </ul>
-    </IndexFaqContainer>
+    </IndexFaqSection>
   )
 }
 
-const IndexFaqContainer = styled.div`
+const IndexFaqSection = styled(Section)`
   margin: 240px 0 0;
   text-align: center;
   > h2 {

--- a/src/components/index/Gotcha.tsx
+++ b/src/components/index/Gotcha.tsx
@@ -89,7 +89,7 @@ export const Gotcha: FC<unknown> = () => {
 
   return (
     <Wrapper>
-      <Heading>
+      <GotchaMain>
         <ImageContainer className={isAnimated ? 'runAnimation' : ''} aria-busy={isAnimated}>
           {/* 次の画像 */}
           {nextItemIndex > -1 && (
@@ -141,7 +141,7 @@ export const Gotcha: FC<unknown> = () => {
 
         {/* 活用事例ラベル */}
         <Label>活用事例</Label>
-      </Heading>
+      </GotchaMain>
 
       {/* 関連リンク */}
       {currentItemIndex > -1 && (
@@ -182,7 +182,7 @@ const Wrapper = styled.div`
     width: 100%;
   }
 `
-const Heading = styled.div`
+const GotchaMain = styled.div`
   position: relative;
   width: 100%;
   aspect-ratio: 1272 / 352;

--- a/src/components/index/Introduction/Introduction.tsx
+++ b/src/components/index/Introduction/Introduction.tsx
@@ -1,5 +1,6 @@
 import { CSS_COLOR, CSS_FONT_SIZE, CSS_SIZE } from '@Constants/style'
 import React, { FC } from 'react'
+import { PageHeading } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import { FloatingTextLink } from '../../shared/FloatingTextLink'
@@ -8,11 +9,11 @@ export const Introduction: FC = () => {
   return (
     <>
       <IntroductionContainer>
-        <StyledHeading>
+        <StyledPageHeading>
           <span>だれでも・</span>
           <span>効率よく・</span>
           <span>迷わずに。</span>
-        </StyledHeading>
+        </StyledPageHeading>
         <StyledText>
           <span>SmartHR Design Systemは、</span>
           <span>すべての人によりよい体験を届けるためのデザインシステムです。</span>
@@ -49,7 +50,7 @@ const IntroductionContainer = styled.div`
   }
 `
 
-const StyledHeading = styled.h1`
+const StyledPageHeading = styled(PageHeading)`
   font-size: ${CSS_FONT_SIZE.PX_54};
   font-weight: normal;
   margin: 0 0 24px;

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -3,7 +3,7 @@ import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
 import { LoginContext, LoginStatusKey } from '@Context/LoginContext'
 import { navigate } from 'gatsby'
 import React, { FC, useContext, useState } from 'react'
-import { Button, FaLockIcon, Input } from 'smarthr-ui'
+import { Button, FaLockIcon, Input, PageHeading } from 'smarthr-ui'
 import styled from 'styled-components'
 
 export const LoginPage: FC = () => {
@@ -14,7 +14,7 @@ export const LoginPage: FC = () => {
 
   return (
     <Wrapper>
-      <h1>従業員ログイン</h1>
+      <PageHeading>従業員ログイン</PageHeading>
       <p>ログインすると限定コンテンツにアクセスできます。パスワードの確認方法は2つあります。</p>
       <ul>
         <li>

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -127,6 +127,8 @@ const Wrapper = styled.div`
   & h1 {
     padding: 0;
     margin: 0;
+    font-weight: bold;
+    font-size: 2rem;
     text-align: center;
   }
 

--- a/src/components/search/IndexList/IndexList.tsx
+++ b/src/components/search/IndexList/IndexList.tsx
@@ -140,9 +140,11 @@ export const IndexList: FC = () => {
         const level2Item = level2Items[item]
         if (!level2Item) return null
         return (
-          <h3 key={level2Item.link}>
-            <Link to={`/${level2Item.link}/`}>{level2Item.title}</Link>
-          </h3>
+          <Section key={level2Item.link}>
+            <h3>
+              <Link to={`/${level2Item.link}/`}>{level2Item.title}</Link>
+            </h3>
+          </Section>
         )
       })}
     </Wrapper>

--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -103,7 +103,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
   const footerCategories = useStaticQuery<Queries.FooterQuery>(query)
   return (
     <Wrapper isArticlePage={isArticlePage}>
-      <LayoutContainer isArticlePage={isArticlePage}>
+      <FooterSection isArticlePage={isArticlePage}>
         <Col1Container>
           <StyledLogoHeading>SmartHR Design System</StyledLogoHeading>
           <FootStaticLinks />
@@ -141,7 +141,7 @@ export const Footer: FC<Props> = ({ isArticlePage = false }) => {
             <small>© SmartHR, Inc.</small>
           </StyledCopyright>
         </CopyrightContainer>
-      </LayoutContainer>
+      </FooterSection>
     </Wrapper>
   )
 }
@@ -181,7 +181,7 @@ const Wrapper = styled.footer<{ isArticlePage: boolean }>`
   }
 `
 
-const LayoutContainer = styled.div<{ isArticlePage: boolean }>`
+const FooterSection = styled.div<{ isArticlePage: boolean }>`
   display: grid;
   grid-template:
     'col1 . col2' auto

--- a/src/components/shared/Private/Private.tsx
+++ b/src/components/shared/Private/Private.tsx
@@ -4,7 +4,7 @@ import { marked } from 'marked'
 import { micromark } from 'micromark'
 import { mdxjs } from 'micromark-extension-mdxjs'
 import React, { useContext, useEffect, useState } from 'react'
-import { AnchorButton, FaExclamationCircleIcon, FaLockIcon } from 'smarthr-ui'
+import { AnchorButton, FaExclamationCircleIcon, FaLockIcon, Section } from 'smarthr-ui'
 import styled from 'styled-components'
 
 import type { FC } from 'react'
@@ -61,17 +61,17 @@ export const Private: FC<Props> = ({ path }) => {
 
   return isShow ? (
     // ログイン済みの時の表示
-    <AuthView>
+    <AuthViewSection>
       <AuthViewHeading>
         <StyledLockIcon />
         <span>SmartHR社従業員限定コンテンツ</span>
         <Tooltip>
           <StyledExclamationIcon />
-          <p className="message">制作パートナー・グループ会社への共有は可能ですが、SNS等へのシェアはしないでください。</p>
+          <span className="message">制作パートナー・グループ会社への共有は可能ですが、SNS等へのシェアはしないでください。</span>
         </Tooltip>
       </AuthViewHeading>
       <div dangerouslySetInnerHTML={{ __html: privateData }}></div>
-    </AuthView>
+    </AuthViewSection>
   ) : (
     // ログイン前の表示
     <UnAuthView>
@@ -111,7 +111,7 @@ const UnAuthView = styled.div`
   }
 `
 
-const AuthView = styled.div`
+const AuthViewSection = styled(Section)`
   margin-block: 48px;
   background-color: ${CSS_COLOR.CAUTION_LIGHT};
   padding: 30px 36px;
@@ -176,7 +176,7 @@ const Tooltip = styled.div`
   &:hover .message {
     display: block;
   }
-  & p {
+  & span {
     display: none;
     top: -60px; /* 絶対的な値なのでremじゃなくpxで指定 */
     left: -30px; /* 絶対的な値なのでremじゃなくpxで指定 */
@@ -189,7 +189,7 @@ const Tooltip = styled.div`
     padding: 8px;
     border-radius: 4px;
   }
-  & p::before {
+  & span::before {
     content: '';
     position: absolute;
     top: 100%;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -3,6 +3,7 @@ import { Footer } from '@Components/shared/Footer/Footer'
 import { GlobalStyle } from '@Components/shared/GlobalStyle/GlobalStyle'
 import { Header } from '@Components/shared/Header/Header'
 import React, { FC } from 'react'
+import { PageHeading } from 'smarthr-ui'
 import styled from 'styled-components'
 
 export const Head = () => {
@@ -25,7 +26,7 @@ const NotFoundPage: FC = () => (
     <Header />
 
     <NotFoundContent>
-      <h1>404</h1>
+      <PageHeading>404</PageHeading>
       <p>お探しのページは見つかりませんでした</p>
     </NotFoundContent>
 

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -63,6 +63,8 @@ const Main = styled.main`
 
 const StyledPageHeading = styled(PageHeading)`
   margin-block: 140px 40px;
+  font-weight: bold;
+  font-size: 2rem;
   text-align: center;
   line-height: 1.25;
 `

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -8,6 +8,7 @@ import { CSS_COLOR, CSS_SIZE } from '@Constants/style'
 import algoliasearch from 'algoliasearch/lite'
 import React, { FC } from 'react'
 import { InstantSearch } from 'react-instantsearch-dom'
+import { PageHeading } from 'smarthr-ui'
 import styled from 'styled-components'
 
 export const Head = () => {
@@ -25,7 +26,7 @@ const SearchPage: FC = () => {
         <Header />
 
         <Main>
-          <PageHeading id="label-for-search-input">SmartHR Design Systemを検索</PageHeading>
+          <StyledPageHeading id="label-for-search-input">SmartHR Design Systemを検索</StyledPageHeading>
           <Search className="ais-SearchBox__root">
             <InstantSearch indexName={process.env.GATSBY_ALGOLIA_INDEX_NAME || ''} searchClient={searchClient}>
               <CustomSearchBox
@@ -60,7 +61,7 @@ const Main = styled.main`
   }
 `
 
-const PageHeading = styled.h1`
+const StyledPageHeading = styled(PageHeading)`
   margin-block: 140px 40px;
   text-align: center;
   line-height: 1.25;


### PR DESCRIPTION
## 課題・背景
ref: https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-heading-in-sectioning-content

ESLintで smarthr/a11y-heading-in-sectioning-content の警告が複数出ており、また依存するsmarthr-uiのバージョンが上がってPageHeadingコンポーネントが利用できるようになったので、警告に対処しました。

## やったこと
ページ全体の見出しとして `h1` でマークアップされていた箇所は `PageHeading`コンポーネントに置き換え、他は見出し（`h2`や`h3`）とそれに続くコンテンツをまとめて`Section`コンポーネントでラップしました。

## やらなかったこと
トップページの、各カテゴリへのリンク部分について、`ul > li h2`のようなマークアップになっており、そもそも`h2`や`h3`があることが正しくない、またはリストであることが正しくないかもしれません。修正が必要であれば別途対応したいです。

## 動作確認
`yarn eslint:ts`で警告がゼロになったことを確認しています。ページごとのマークアップの変化は以下です。

### h1にPageHeadingを適用したページ
検索ページ、404ページ、ログインページ
→ `PageHeading`にするとスタイルが適用されて見た目が変わってしまう箇所もあったので、CSSも調整しています。

### フッター
「SmartHR Design System」のところが `h2`なので、見出しが対応する範囲としてフッター全体を`Section`でラップしました。

### トップページ
- Gotchaのメインの画像部分が `Heading`という名前のコンポーネントになっていたのですが、見出しではないので名称を`GotchaMain`に変更しました。マークアップは以前から `div`なのでそのままです。
- 「だれでも・効率よく・迷わずに。」の部分が `h1`でマークアップされていたので、`PageHeading`を適用しました。
- それに続く「基本原則」などの各カテゴリの名称は`h2`ですが、見出しが指す範囲を明確にするため、説明文とリンクのリストまでを`Section`コンポーネントでラップしました
- 「よくあるご質問」も `h2`ですが、こちらもFAQセクション全体を`Section`でラップしました
  - それぞれの質問の"Q"にあたる部分は`h3`なので、それぞれのQ&Aのペアを`Section`でラップしました

### コンポーネントページ
https://deploy-preview-913--smarthr-design-system.netlify.app/products/components/
- 「Buttons（ボタン）」などのグループ名が `h2`なので、それに続くリンクリストとともに `Section`でラップしました

### PageIndexコンポーネント
ページ例：https://deploy-preview-913--smarthr-design-system.netlify.app/products/contents/
各ページへのリンク部分に `h2` `h3`などを指定できるようになっているので、ページの説明文と合わせて `Section`でラップしました

### 検索ページ
検索フォームの下のサイトマップで、「利用者のかたへ」などの部分が `h3`なので、それに続くリンクリストと合わせて`Section`でラップしました。（その上の `h2`の階層はすでに`Section`が適用されていました。）

### プライベートコンテンツ
ページ例：https://deploy-preview-913--smarthr-design-system.netlify.app/basics/illustration/user-co-main/#h2-1

ログイン後の表示で、「SmartHR社従業員限定コンテンツ」が `h2`なので、プライベートコンテンツ全体を `Section`でラップしました。
また、`h2`にはツールチップ部分も含まれていますが、ツールチップの中身が `p`、マークアップがh2 > p となっていたので、`span`に変更しています。その結果、文字サイズが小さくなるなどの影響があります（後にキャプチャを貼ります）。

## キャプチャ
プライベートコンテンツのツールチップ部分のみ見た目が変わっています。これまでは、articleテンプレートが適用するスタイルがメッセージに影響して、文字サイズや表示位置などが意図しない状態になっていたのではないかと思いますが、どうでしょうか？

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/02809db0-1711-4ed8-9dba-a7ebdf550380" width="350" alt> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/d3cdd020-c748-4d84-b510-7e0e1e29e47f" alt width="350"> |
