### PR TITLE
リンク切れになっていたアンカーリンク先を再設定

### DIFF
--- a/content/articles/communication/capture/capture-others.mdx
+++ b/content/articles/communication/capture/capture-others.mdx
@@ -11,7 +11,7 @@ import { CaptureImageWithDesc } from '@Components/contents/ServiceCapture/Captur
 利用頻度が高いプロダクト以外の画面キャプチャを選定して掲載しています。  
 未掲載を含むすべての画面キャプチャは<a href="https://drive.google.com/drive/folders/1PT1gK4rrz8DufFkFc2r3Z_xpp03YxHwC" target="_blank">プロダクトキャプチャ | Google ドライブ</a>からアクセスできます。
 
-サイトにアクセスするすべての人が参照できますが、利用に関しては[利用者・利用範囲](#h2-5)を確認してください。
+サイトにアクセスするすべての人が参照できますが、利用に関しては[利用者・利用範囲](#h2-3)を確認してください。
 
 
 ## SmartHRスクール

--- a/content/articles/communication/capture/capture-product.mdx
+++ b/content/articles/communication/capture/capture-product.mdx
@@ -11,7 +11,7 @@ import { CaptureImageWithDesc } from '@Components/contents/ServiceCapture/Captur
 利用頻度が高いプロダクトの画面キャプチャを掲載しています。  
 未掲載を含むすべての画面キャプチャは<a href="https://drive.google.com/drive/folders/1PT1gK4rrz8DufFkFc2r3Z_xpp03YxHwC" target="_blank">プロダクトキャプチャ | Google ドライブ</a>からアクセスできます。
 
-サイトにアクセスするすべての人が参照できますが、利用に関しては[利用者・利用範囲](#h2-5)を確認してください。
+サイトにアクセスするすべての人が参照できますが、利用に関しては[利用者・利用範囲](#h2-2)を確認してください。
 
 
 


### PR DESCRIPTION
## 課題・背景
https://github.com/kufu/smarthr-design-system/actions/runs/6528126011#summary-17723875304

## やったこと
同じページ内のアンカーリンクが今は存在しない`id`を指していたので、修正しました。

## 動作確認

https://deploy-preview-923--smarthr-design-system.netlify.app/communication/capture/capture-product/
https://deploy-preview-923--smarthr-design-system.netlify.app/communication/capture/capture-others/

どちらも、本文5行目の「利用者・利用範囲」のリンク先が `#2-5`になっており、機能していなかったので正しいものに修正しました。

## キャプチャ
見た目上の変化はありません。
