### PR TITLE
Calendarを微修正

### DIFF
--- a/content/articles/products/components/calendar.mdx
+++ b/content/articles/products/components/calendar.mdx
@@ -5,7 +5,7 @@ description: ''
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 
-Calendarコンポーネントは、カレンダーを表示し日付を選択するためのコンポーネントです。基本的にはDatePickerと合わせて使用されるため、単独で使用することはありません。
+Calendarコンポーネントは、カレンダーを表示し日付を選択するためのコンポーネントです。基本的には<a href="/products/components/date-picker/">DatePicker</a>と合わせて使用されるため、単独で使用することはありません。
 
 <ComponentStory name="Calendar" />
 

--- a/content/articles/products/components/calendar.mdx
+++ b/content/articles/products/components/calendar.mdx
@@ -5,7 +5,7 @@ description: ''
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 
-カレンダーを表示し日付を選択するためのコンポーネントです。基本的にはDatePickerと合わせて使用されるため、単独で使用することはありません。
+Calendarコンポーネントは、カレンダーを表示し日付を選択するためのコンポーネントです。基本的にはDatePickerと合わせて使用されるため、単独で使用することはありません。
 
 <ComponentStory name="Calendar" />
 


### PR DESCRIPTION
## やったこと

`/products/components/calendar/` にて

- 1文目に主語 `Calendarコンポーネントは、` が抜けていたので追加しました
- DatePickerへの言及があったので、その部分をリンクに変更しました



## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認

- Previewでみてね。→ https://deploy-preview-927--smarthr-design-system.netlify.app/products/components/calendar/

## キャプチャ

|Before|After|
| --- | --- |
| <img width="754" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/7392923/df51f26c-5eb6-44be-9d67-08dd518af2e3"> | <img width="752" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/7392923/d4ffa56e-3d49-4f73-a0b0-d2c866b871fe"> |

