### PR TITLE
HeadlineAreaの「非推奨」メッセージの表示崩れ修正

### DIFF
--- a/content/articles/products/components/headline-area.mdx
+++ b/content/articles/products/components/headline-area.mdx
@@ -4,11 +4,15 @@ description: ''
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
-import { CompactInformationPanel } from 'smarthr-ui'
+import { BaseColumn, WarningIcon } from 'smarthr-ui'
 
-<CompactInformationPanel type="warning">
-  HeadlineAreaコンポーネントは非推奨です。<a href="/products/components/stack/">Stack</a>コンポーネントで書き換えてください。
-</CompactInformationPanel>
+<BaseColumn>
+  <WarningIcon text={
+    <span>
+      HeadlineAreaコンポーネントは非推奨です。<a href="/products/components/stack/">Stack</a>コンポーネントで書き換えてください。
+    </span>}
+    />
+</BaseColumn>
 
 <ComponentStory name="HeadlineArea" />
 


### PR DESCRIPTION
## 課題・背景

- HeadlineArea `/products/components/headline-area/` の上部の「非推奨です」メッセージのCompactInformationPanelの表示が崩れていた
- 他の非推奨コンポーネントではCompactInformationPanelではなくBaseColumnを使っている

## やったこと

「非推奨です」の部分をBaseColumnに書き換え


## 動作確認
- Previewでみてね。 https://deploy-preview-928--smarthr-design-system.netlify.app/products/components/headline-area/

## キャプチャ

|Before|After|
| --- | --- |
| <img width="772" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/7392923/14202fc8-f4b9-4033-942b-6c57896e1312"> | <img width="753" alt="image" src="https://github.com/kufu/smarthr-design-system/assets/7392923/7bc5058e-2b6c-4c56-bada-808874366a60"> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
