### PR TITLE
LiveEditorをiframe内に入れてCSSノーマライズを適用

### DIFF
--- a/content/articles/operational-guideline/page-template/component-template.mdx
+++ b/content/articles/operational-guideline/page-template/component-template.mdx
@@ -47,6 +47,18 @@ import { ComponentStory } from '@Components/ComponentStory'
 </>
 ```
 
+#### iframeを使用したくない場合（非推奨）
+
+```tsx editable codeBlock noIframe
+// ```tsx editable codeBlock noIframe
+// 編集可能なコードブロックは、iframe内にレンダリングされます。ツールチップがiframeの外にレンダリングされるなど不都合がある場合は`noIframe`を指定します。
+// `noIframe`では、CSSノーマライズが適用されないなどの問題があるため、非推奨です。
+// ```
+<Stack style={{width: '100%', background: '#f8f7f6', padding: '8px'}}>
+  <NotificationBar type="warning" message={<LineClamp maxLines={1} withTooltip>非推奨ですが、LineClampを使用して省略もできます。そのでっかい領域によるヘッダー（のナビゲーション）へのアクセス性の低下をフォローするために多くのウェブサイトはヘッダーを固定していますが、それでは同時にコンテンツの閲覧性に影響を与えてしまいます。</LineClamp>} onClose={()=>{}} />
+</Stack>
+```
+
 #### プロダクト
 
 ```tsx editable withStyled layout=product codeBlock

--- a/content/articles/products/components/button.mdx
+++ b/content/articles/products/components/button.mdx
@@ -167,7 +167,7 @@ SmartHR UIでは、プレフィックス（`prefix`props）およびサフィッ
 
 無効状態の理由を配置するスペースがどうしてもない場合、`disabledDetail`propsで理由を表示することを検討します。
 
-```tsx editable codeBlock
+```tsx editable codeBlock noIframe
 <>
   <Button variant="primary" prefix={<FaPlusCircleIcon />} disabled>ボタン</Button>
   <Button prefix={<FaPlusCircleIcon />} disabled>ボタン</Button>

--- a/content/articles/products/components/dropdown/dropdown-menu-button.mdx
+++ b/content/articles/products/components/dropdown/dropdown-menu-button.mdx
@@ -114,7 +114,7 @@ import { FaCaretDownIcon, FaEllipsisHIcon } from 'smarthr-ui'
 
 ドロップダウンメニューボタンのレイアウトは次のとおりです。
 
-```tsx editable withStyled codeBlock
+```tsx editable withStyled codeBlock noIframe
 type Actions = ActionItem | ActionItem[]
 // これでコンポーネントを絞れるわけではないが Button[variant=text] を使ってほしいんだよ! という気持ち
 type ActionItem =

--- a/content/articles/products/components/notification-bar.mdx
+++ b/content/articles/products/components/notification-bar.mdx
@@ -81,7 +81,7 @@ export const AnimateNotificationBar = () => {
 
 非推奨ですが[LineClamp](/products/components/line-clamp/)コンポーネントも使えます。
 
-```tsx editable codeBlock
+```tsx editable codeBlock noIframe
 <Stack style={{width: '100%', background: '#f8f7f6', padding: '8px'}}>
   <NotificationBar type="warning" message={<LineClamp maxLines={1} withTooltip>非推奨ですが、LineClampを使用して省略もできます。そのでっかい領域によるヘッダー（のナビゲーション）へのアクセス性の低下をフォローするために多くのウェブサイトはヘッダーを固定していますが、それでは同時にコンテンツの閲覧性に影響を与えてしまいます。</LineClamp>} onClose={()=>{}} />
 </Stack>

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "postinstall-postinstall": "^2.1.0",
     "prettier": "3.0.3",
     "prism-react-renderer": "^2.1.0",
+    "react-frame-component": "^5.2.6",
     "remark-emoji": "^2.2.0",
     "smarthr-normalize-css": "^1.1.0",
     "stylelint": "^15.10.3",

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -16,10 +16,13 @@ import type { LiveProvider } from 'react-live'
 type LiveProviderProps = React.ComponentProps<typeof LiveProvider>
 
 export type LiveContainerProps = {
-  code: string
-  language: string
+  code?: string
+  language?: string
   withStyled?: boolean
-  withIframe?: boolean
+  /**
+   * @deprecated noIframe は非推奨です。iframeが原因で表示が崩れるなどやむを得ない場合のみ使用してください。
+   */
+  noIframe?: boolean
 } & Pick<LiveProviderProps, 'scope'> & {
     gap?: Gap | SeparateGap
     align?: CSSProperties['alignItems']
@@ -48,7 +51,7 @@ export const CodeBlock: FC<Props> = ({
   children,
   className,
   editable = false,
-  withIframe = false,
+  noIframe = false,
   isStorybook = false,
   scope,
   withStyled = false,
@@ -103,7 +106,7 @@ export const CodeBlock: FC<Props> = ({
       code={code}
       language={language}
       withStyled={withStyled}
-      withIframe={withIframe}
+      noIframe={noIframe}
       tsLoaded={tsLoaded}
       setTsLoaded={setTsLoaded}
       gap={gap}
@@ -122,7 +125,7 @@ export const CodeBlock: FC<Props> = ({
             </TextLink>
           </LinkWrapper>
         )}
-        {withIframe && showFrame && (
+        {!noIframe && showFrame && (
           <Frame
             ref={iframeRef}
             width="100%"
@@ -135,7 +138,8 @@ export const CodeBlock: FC<Props> = ({
             </FrameContextConsumer>
           </Frame>
         )}
-        {!withIframe && LiveContainerComponent()}
+        {/* smarthr-ui側が対応したら以下は削除し、iframeのdocument.bodyをLiveEditorに渡してportalにする予定です。 */}
+        {noIframe && LiveContainerComponent()}
       </Wrapper>
     )
   }

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -83,8 +83,9 @@ export const CodeBlock: FC<Props> = ({
     // TSスクリプトロード後、レンダリングが終わるのを待ってから高さを計算・セットする
     setTimeout(() => {
       const height = innerWindow.document.body.scrollHeight
+      console.log(height)
       if (height > 0) {
-        setIframeHeight(height + 8) // ComponentPreviewコンポーネントに`margin-block-start: 8px`が指定されているため
+        setIframeHeight(height + 9) // ComponentPreviewコンポーネントに`margin-block-start: 8px`が指定されているため・高さが小数点以下の精度の場合があるため
       }
     }, 500)
   }, [tsLoaded])

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -83,7 +83,6 @@ export const CodeBlock: FC<Props> = ({
     // TSスクリプトロード後、レンダリングが終わるのを待ってから高さを計算・セットする
     setTimeout(() => {
       const height = innerWindow.document.body.scrollHeight
-      console.log(height)
       if (height > 0) {
         setIframeHeight(height + 9) // ComponentPreviewコンポーネントに`margin-block-start: 8px`が指定されているため・高さが小数点以下の精度の場合があるため
       }

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -173,10 +173,6 @@ const LinkWrapper = styled.div`
 
 const CodeWrapper = styled.div`
   position: relative;
-
-  /* bodyに指定があるが、Frame内には効かないので再指定 */
-  line-height: 1.75;
-  overflow-wrap: break-word;
 `
 
 const PreContainer = styled.div<{ isStorybook?: boolean }>`
@@ -218,16 +214,4 @@ const PreContainer = styled.div<{ isStorybook?: boolean }>`
     `};
 `
 
-const StyledLiveEditorContainer = styled(PreContainer)`
-  overflow: auto;
-  margin: 0;
-
-  /* LiveEditor内のpreにはpaddingの一括指定しかできないので親要素で設定 */
-  padding: 2.75rem 1.5rem 1.5rem;
-  border-width: 0 1px 1px;
-  background-color: ${CSS_COLOR.TEXT_BLACK};
-  max-height: 40em;
-  pre {
-    width: fit-content;
-  }
-`
+export { PreContainer }

--- a/src/components/article/CodeBlock/LiveContainer.tsx
+++ b/src/components/article/CodeBlock/LiveContainer.tsx
@@ -10,6 +10,7 @@ import styled, { ThemeProvider, css } from 'styled-components'
 
 import { ComponentPreview } from '../../ComponentPreview'
 
+import { PreContainer } from './CodeBlock'
 import { CopyButton } from './CopyButton'
 
 import type { LiveContainerProps } from './CodeBlock'
@@ -68,9 +69,11 @@ export const LiveContainer: FC<Props> = ({
         </ComponentPreview>
         <CodeWrapper>
           <StyledLiveEditorContainer>
-            <CopyButton text={code} />
-            {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
-            <LiveEditor padding={0} />
+            <PreContainer>
+              <CopyButton text={code} />
+              {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
+              <LiveEditor padding={0} />
+            </PreContainer>
           </StyledLiveEditorContainer>
         </CodeWrapper>
         <LiveError />
@@ -87,55 +90,18 @@ const CodeWrapper = styled.div`
   overflow-wrap: break-word;
 `
 
-const PreContainer = styled.div<{ isStorybook?: boolean }>`
-  font-family: monospace;
-  margin-block: 16px 0;
-  border: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
-  background-color: ${CSS_COLOR.LIGHT_GREY_3};
-  overflow-x: scroll;
-
-  & > button {
-    position: absolute;
-    top: 1.5rem;
-    right: 1.5rem;
-  }
-
-  /* preのデフォルトは display: block; で幅100%になるが、100%を超えられるように上書き(祖先要素には横スクロールを適用) */
-  pre {
-    width: max-content;
-    min-width: 100%;
-    min-height: 100%;
+const StyledLiveEditorContainer = styled.div`
+  & > * {
+    overflow: auto;
     margin: 0;
+
+    /* LiveEditor内のpreにはpaddingの一括指定しかできないので親要素で設定 */
     padding: 2.75rem 1.5rem 1.5rem;
-    box-sizing: border-box;
-  }
-
-  /* LiveEditor内で preに white-space: pre-wrap; が適用されているため、文字を強制的に折り返すようにする */
-  * {
-    word-break: break-all;
-  }
-
-  ${({ isStorybook }) =>
-    isStorybook &&
-    `
-      margin: 0;
-      height: 300px;
-      border: 0;
-      overflow: scroll;
-      resize: vertical;
-    `};
-`
-
-const StyledLiveEditorContainer = styled(PreContainer)`
-  overflow: auto;
-  margin: 0;
-
-  /* LiveEditor内のpreにはpaddingの一括指定しかできないので親要素で設定 */
-  padding: 2.75rem 1.5rem 1.5rem;
-  border-width: 0 1px 1px;
-  background-color: ${CSS_COLOR.TEXT_BLACK};
-  max-height: 40em;
-  pre {
-    width: fit-content;
+    border-width: 0 1px 1px;
+    background-color: ${CSS_COLOR.TEXT_BLACK};
+    max-height: 40em;
+    pre {
+      width: fit-content;
+    }
   }
 `

--- a/src/components/article/CodeBlock/LiveContainer.tsx
+++ b/src/components/article/CodeBlock/LiveContainer.tsx
@@ -37,7 +37,7 @@ export const LiveContainer: FC<Props> = ({
   code,
   language,
   scope,
-  withIframe,
+  noIframe,
   withStyled,
   gap,
   align,
@@ -64,13 +64,13 @@ export const LiveContainer: FC<Props> = ({
         transformCode={transformCode}
       >
         <ComponentPreview gap={gap} align={align} layout={layout}>
-          {withIframe && <CssBaseLine />}
+          {!noIframe && <CssBaseLine />}
           <LivePreview Component={React.Fragment} />
         </ComponentPreview>
         <CodeWrapper>
           <StyledLiveEditorContainer>
             <PreContainer>
-              <CopyButton text={code} />
+              <CopyButton text={code || ''} />
               {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
               <LiveEditor padding={0} />
             </PreContainer>
@@ -93,7 +93,7 @@ const CodeWrapper = styled.div`
 const StyledLiveEditorContainer = styled.div`
   & > * {
     overflow: auto;
-    margin: 0;
+    margin-block: 0;
 
     /* LiveEditor内のpreにはpaddingの一括指定しかできないので親要素で設定 */
     padding: 2.75rem 1.5rem 1.5rem;

--- a/src/components/article/CodeBlock/LiveContainer.tsx
+++ b/src/components/article/CodeBlock/LiveContainer.tsx
@@ -1,0 +1,141 @@
+import { CSS_COLOR } from '@Constants/style'
+import { Script } from 'gatsby'
+import { themes } from 'prism-react-renderer'
+import React, { FC } from 'react'
+import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live'
+import { CssBaseLine } from 'smarthr-normalize-css'
+import * as ui from 'smarthr-ui'
+import styled, { ThemeProvider, css } from 'styled-components'
+// TODO SmartHR な Dark テーマほしいな!!!
+
+import { ComponentPreview } from '../../ComponentPreview'
+
+import { CopyButton } from './CopyButton'
+
+import type { LiveContainerProps } from './CodeBlock'
+
+type Props = {
+  tsLoaded: boolean
+  setTsLoaded: React.Dispatch<React.SetStateAction<boolean>>
+} & LiveContainerProps
+
+const smarthrTheme = ui.createTheme()
+
+const transformCode = (snippet: string) => {
+  if (window.ts === undefined) return '' // TSスクリプトロード後にライブエディタをレンダリングするので、ここには入らないはず。
+
+  // Storybookでも利用するため、コード内に`import`・`export`が記述されているが、ここではエラーになるので削除する。
+  const code = snippet.replace(/^import\s.*\sfrom\s.*$/gm, '').replace(/^export\s/gm, '')
+  return window.ts.transpile(code, {
+    jsx: window.ts.JsxEmit.React,
+    target: window.ts.ScriptTarget.ES2020,
+  })
+}
+
+export const LiveContainer: FC<Props> = ({
+  code,
+  language,
+  scope,
+  withIframe,
+  withStyled,
+  gap,
+  align,
+  layout,
+  tsLoaded,
+  setTsLoaded,
+}) => (
+  <ThemeProvider theme={smarthrTheme}>
+    {/* ライブエディタ内のコードのトランスパイルに使用するTS（容量が大きいためCDNを利用） */}
+    <Script src="https://unpkg.com/typescript@latest/lib/typescript.js" onLoad={() => setTsLoaded(true)} />
+    {tsLoaded && (
+      <LiveProvider
+        code={code}
+        language={language}
+        scope={{ ...React, ...ui, styled, css, ...scope }}
+        theme={{
+          ...themes.vsDark,
+          plain: {
+            color: CSS_COLOR.LIGHT_GREY_3,
+            backgroundColor: CSS_COLOR.TEXT_BLACK,
+          },
+        }}
+        noInline={withStyled}
+        transformCode={transformCode}
+      >
+        <ComponentPreview gap={gap} align={align} layout={layout}>
+          {withIframe && <CssBaseLine />}
+          <LivePreview Component={React.Fragment} />
+        </ComponentPreview>
+        <CodeWrapper>
+          <StyledLiveEditorContainer>
+            <CopyButton text={code} />
+            {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
+            <LiveEditor padding={0} />
+          </StyledLiveEditorContainer>
+        </CodeWrapper>
+        <LiveError />
+      </LiveProvider>
+    )}
+  </ThemeProvider>
+)
+
+const CodeWrapper = styled.div`
+  position: relative;
+
+  /* bodyに指定があるが、Frame内には効かないので再指定 */
+  line-height: 1.75;
+  overflow-wrap: break-word;
+`
+
+const PreContainer = styled.div<{ isStorybook?: boolean }>`
+  font-family: monospace;
+  margin-block: 16px 0;
+  border: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
+  background-color: ${CSS_COLOR.LIGHT_GREY_3};
+  overflow-x: scroll;
+
+  & > button {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+  }
+
+  /* preのデフォルトは display: block; で幅100%になるが、100%を超えられるように上書き(祖先要素には横スクロールを適用) */
+  pre {
+    width: max-content;
+    min-width: 100%;
+    min-height: 100%;
+    margin: 0;
+    padding: 2.75rem 1.5rem 1.5rem;
+    box-sizing: border-box;
+  }
+
+  /* LiveEditor内で preに white-space: pre-wrap; が適用されているため、文字を強制的に折り返すようにする */
+  * {
+    word-break: break-all;
+  }
+
+  ${({ isStorybook }) =>
+    isStorybook &&
+    `
+      margin: 0;
+      height: 300px;
+      border: 0;
+      overflow: scroll;
+      resize: vertical;
+    `};
+`
+
+const StyledLiveEditorContainer = styled(PreContainer)`
+  overflow: auto;
+  margin: 0;
+
+  /* LiveEditor内のpreにはpaddingの一括指定しかできないので親要素で設定 */
+  padding: 2.75rem 1.5rem 1.5rem;
+  border-width: 0 1px 1px;
+  background-color: ${CSS_COLOR.TEXT_BLACK};
+  max-height: 40em;
+  pre {
+    width: fit-content;
+  }
+`

--- a/src/components/article/CodeBlock/LiveContainer.tsx
+++ b/src/components/article/CodeBlock/LiveContainer.tsx
@@ -91,7 +91,7 @@ const CodeWrapper = styled.div`
 `
 
 const StyledLiveEditorContainer = styled.div`
-  & > * {
+  & > div {
     overflow: auto;
     margin-block: 0;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13496,6 +13496,11 @@ react-fast-compare@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
+react-frame-component@^5.2.6:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-5.2.6.tgz#0d9991d251ff1f7177479d8f370deea06b824b79"
+  integrity sha512-CwkEM5VSt6nFwZ1Op8hi3JB5rPseZlmnp5CGiismVTauE6S4Jsc4TNMlT0O7Cts4WgIC3ZBAQ2p1Mm9XgLbj+w==
+
 react-icons@^4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.11.0.tgz#4b0e31c9bfc919608095cc429c4f1846f4d66c65"


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1305

関連： #924 

## やったこと
[react-live](https://github.com/FormidableLabs/react-live)を使ったLiveEditorコンポーネントを、iframeに入れ、局所的に[smarhtr-normalize-css](https://github.com/kufu/smarthr-normalize-css)が適用されるようにしました。

実装は、以下のようになっています。

### iframe
[react-frame-component](https://github.com/ryanseddon/react-frame-component)を使っています。そのまま `iframe`としても、styled-componentsのGlobalStyleはiframeを突き抜けてサイト本体のグローバルとして適用されてしまうためです。
ただし、このコンポーネントはGatsbyの静的ビルドではレンダリングされないようで、初回のページロード時のみうまく表示できません。そこで、[issue](https://github.com/ryanseddon/react-frame-component/issues/192#issuecomment-1153078390)を参考に、クライアントでのレンダリングをトリガーしています。

### 高さの計算
スクロールバーは出したくないので、iframeの中身のレンダリングが完了した時点で高さを計算し、iframeの`height`に設定しています。
LiveEditor部分は、「CDNからtypescriptの読み込みが終わってからCSRする」という実装になっているために、`DOMContentLoaded`が使えず、またtsの読み込み直後ではまだレンダリングが終わっていないため、遅延処理をしています。

### LiveEditor
インデントがずれて差分は出ていますが、LiveEditorそのもののコード（`<ThemeProvider>`の中身）は基本的に変更ありません（`<CssBaseLine />`のみ追加しています）。

## 動作確認
LiveEditorの例：
https://deploy-preview-939--smarthr-design-system.netlify.app/products/components/button/#h4-1
https://deploy-preview-939--smarthr-design-system.netlify.app/products/components/notification-bar/#h3-2

ローカルでは、fieldset要素の枠線が消えることも確認できています。

## キャプチャ
見た目の変化はありません。
