### PR TITLE
MDX内のコンポーネントコードをサーバー側でもレンダリングするように変更

### DIFF
--- a/content/articles/products/components/dialog.mdx
+++ b/content/articles/products/components/dialog.mdx
@@ -51,29 +51,25 @@ ActionDialogは、ユーザーに選択の確認や操作を求める場合に�
 
 export const DynamicActionDialog = () => {
   const [isOpen, setIsOpen] = useState(false)
-  if (typeof window !== 'undefined') {
-    return (
-      <>
-        <Button variant="primary" onClick={() => setIsOpen(true)}>ActionDialogを開く</Button>
-        <ActionDialog
-          isOpen={isOpen}
-          title="アクションダイアログタイトル"
-          closeText="キャンセル"
-          actionText="実行"
-          actionTheme="primary"
-          onClickClose={()=> {setIsOpen(false)}}
-          onPressEscape={() => setIsOpen(false)}
-          onClickAction={()=> {setIsOpen(false)}}
-        >
-          <div style={{'boxSizing': 'border-box', 'width': '480px', 'padding': '24px'}}>
-            本文が入ります。
-          </div>
-        </ActionDialog>
-      </>
-    )
-  } else {
-    return null
-  }
+  return (
+    <>
+      <Button variant="primary" onClick={() => setIsOpen(true)}>ActionDialogを開く</Button>
+      <ActionDialog
+        isOpen={isOpen}
+        title="アクションダイアログタイトル"
+        closeText="キャンセル"
+        actionText="実行"
+        actionTheme="primary"
+        onClickClose={()=> {setIsOpen(false)}}
+        onPressEscape={() => setIsOpen(false)}
+        onClickAction={()=> {setIsOpen(false)}}
+      >
+        <div style={{'boxSizing': 'border-box', 'width': '480px', 'padding': '24px'}}>
+          本文が入ります。
+        </div>
+      </ActionDialog>
+    </>
+  )
 }
 
 <ComponentPreview>

--- a/content/articles/products/components/dialog.mdx
+++ b/content/articles/products/components/dialog.mdx
@@ -85,24 +85,20 @@ MessageDialogは、ユーザーの操作を中断させて、ユーザーへの�
 
 export const DynamicMessageDialog = () => {
   const [isOpen, setIsOpen] = useState(false)
-  if (typeof window !== 'undefined') {
-    return (
-      <>
-        <Button variant="primary" onClick={() => setIsOpen(true)}>MessageDialogを開く</Button>
-        <MessageDialog
-          isOpen={isOpen}
-          title="メッセージダイアログタイトル"
-          description={<p style={{'boxSizing': 'border-box', 'width': '432px', 'margin': '0', 'padding': '24px 0'}}>本文が入ります。</p>}
-          closeText="閉じる"
-          onClickClose={() => setIsOpen(false)}
-          onPressEscape={() => setIsOpen(false)}
-          id="dialog-message"
-        />
-      </>
-    )
-  } else {
-    return null
-  }
+  return (
+    <>
+      <Button variant="primary" onClick={() => setIsOpen(true)}>MessageDialogを開く</Button>
+      <MessageDialog
+        isOpen={isOpen}
+        title="メッセージダイアログタイトル"
+        description={<p style={{'boxSizing': 'border-box', 'width': '432px', 'margin': '0', 'padding': '24px 0'}}>本文が入ります。</p>}
+        closeText="閉じる"
+        onClickClose={() => setIsOpen(false)}
+        onPressEscape={() => setIsOpen(false)}
+        id="dialog-message"
+      />
+    </>
+  )
 }
 
 <ComponentPreview>
@@ -116,63 +112,59 @@ ModelessDialogは、ユーザーに任意のタイミングや順序で、情報
 
 export const DynamicModelessDialog = () => {
   const [isOpen, setIsOpen] = useState(false)
-  if (typeof window !== 'undefined') {
-    return (
-      <>
-        <Button
-          variant="primary"
-          onClick={() => setIsOpen(!isOpen)}
-          data-test="dialog-trigger"
-          aria-haspopup="dialog"
-          aria-controls="modeless-dialog"
-        >
-          ModelessDialogを開く
-        </Button>
-        <ModelessDialog
-          isOpen={isOpen}
-          header={<ModelessHeading>モードレスダイアログ</ModelessHeading>}
-          footer={<ModelessFooter>フッター</ModelessFooter>}
-          onClickClose={() => setIsOpen(false)}
-          onPressEscape={() => setIsOpen(false)}
-          width="50%"
-          height="50%"
-          id="modeless-dialog-1"
-          data-test="dialog"
-        >
-          <ModelessContent>
-            <Stack gap="S">
-              <Table>
-                <thead>
-                  <tr>
-                    <Th>
+  return (
+    <>
+      <Button
+        variant="primary"
+        onClick={() => setIsOpen(!isOpen)}
+        data-test="dialog-trigger"
+        aria-haspopup="dialog"
+        aria-controls="modeless-dialog"
+      >
+        ModelessDialogを開く
+      </Button>
+      <ModelessDialog
+        isOpen={isOpen}
+        header={<ModelessHeading>モードレスダイアログ</ModelessHeading>}
+        footer={<ModelessFooter>フッター</ModelessFooter>}
+        onClickClose={() => setIsOpen(false)}
+        onPressEscape={() => setIsOpen(false)}
+        width="50%"
+        height="50%"
+        id="modeless-dialog-1"
+        data-test="dialog"
+      >
+        <ModelessContent>
+          <Stack gap="S">
+            <Table>
+              <thead>
+                <tr>
+                  <Th>
+                    <CheckBox />
+                  </Th>
+                  <Th>テーブル見出し1</Th>
+                  <Th>テーブル見出し2</Th>
+                  <Th>テーブル見出し3</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from(Array(10).keys()).map((i) => (
+                  <tr key={i}>
+                    <Td>
                       <CheckBox />
-                    </Th>
-                    <Th>テーブル見出し1</Th>
-                    <Th>テーブル見出し2</Th>
-                    <Th>テーブル見出し3</Th>
+                    </Td>
+                    <Td>データ1-{i}</Td>
+                    <Td>データ2-{i}</Td>
+                    <Td>データ3-{i}</Td>
                   </tr>
-                </thead>
-                <tbody>
-                  {Array.from(Array(10).keys()).map((i) => (
-                    <tr key={i}>
-                      <Td>
-                        <CheckBox />
-                      </Td>
-                      <Td>データ1-{i}</Td>
-                      <Td>データ2-{i}</Td>
-                      <Td>データ3-{i}</Td>
-                    </tr>
-                  ))}
-                </tbody>
-              </Table>
-            </Stack>
-          </ModelessContent>
-        </ModelessDialog>
-      </>
-    )
-  } else {
-    return null
-  }
+                ))}
+              </tbody>
+            </Table>
+          </Stack>
+        </ModelessContent>
+      </ModelessDialog>
+    </>
+  )
 }
 
 <ComponentPreview>

--- a/content/articles/products/components/notification-bar.mdx
+++ b/content/articles/products/components/notification-bar.mdx
@@ -51,24 +51,20 @@ NotificationBarは、フィードバックやメッセージを伝えるため�
 <!-- textlint-disable -->
 export const AnimateNotificationBar = () => {
   const [visible, setVisible] = useState(false)
-  if (typeof window !== 'undefined') {
-    return (
-      <Stack style={{ width: '100%', background: '#f8f7f6', padding: '8px', }}>
-        {visible && (
-          <NotificationBar
-            type="success"
-            bold={true}
-            message="タスクの登録に成功しました。"
-            animate={true}
-            onClose={() => setVisible(!visible)}
-          />
-        )}
-        <Button onClick={() => setVisible(!visible)}>NotificationBarを{visible ? '隠す' : '表示'}</Button>
-      </Stack>
-    )
-  } else {
-    return null
-  }
+  return (
+    <Stack style={{ width: '100%', background: '#f8f7f6', padding: '8px', }}>
+      {visible && (
+        <NotificationBar
+          type="success"
+          bold={true}
+          message="タスクの登録に成功しました。"
+          animate={true}
+          onClose={() => setVisible(!visible)}
+        />
+      )}
+      <Button onClick={() => setVisible(!visible)}>NotificationBarを{visible ? '隠す' : '表示'}</Button>
+    </Stack>
+  )
 }
 
 <!-- textlint-enable -->

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -65,17 +65,13 @@ Tooltipの配置は8種類の選択肢があります。
 - `horizontal`（横）と`vertical`（縦）の両方に`auto`を指定すると、レイアウトを加味して自動的に方向を決めてくれます。
 
 export const DynamicTooltip = ({children, ...props}) => {
-  if (typeof window !== 'undefined') {
-    // <!-- textlint-disable -->
-    return (
-      <Tooltip {...props}>
-        {children}
-      </Tooltip>
-    )
-    // <!-- textlint-enable -->
-  } else {
-    return null
-  }
+  // <!-- textlint-disable -->
+  return (
+    <Tooltip {...props}>
+      {children}
+    </Tooltip>
+  )
+  // <!-- textlint-enable -->
 }
 
 #### 上配置

--- a/content/articles/products/design-patterns/delete-dialog.mdx
+++ b/content/articles/products/design-patterns/delete-dialog.mdx
@@ -117,29 +117,25 @@ export const DynamicActionDialog = () => {
 
 export const DynamicCancelActionDialog = () => {
   const [isOpen, setIsOpen] = useState(false)
-  if (typeof window !== 'undefined') {
-    return (
-      <>
-        <Button variant="danger" onClick={() => setIsOpen(true)}>取り消し操作時のダイアログを開く</Button>
-        <ActionDialog
-          isOpen={isOpen}
-          title="{操作名}を取り消しますか？"
-          closeText="キャンセル"
-          actionText="取り消し"
-          actionTheme="danger"
-          onClickClose={()=> {setIsOpen(false)}}
-          onClickAction={()=> {setIsOpen(false)}}
-        >
-          <div style={{'boxSizing': 'border-box', 'width': '480px', 'padding': '24px'}}>
-            {'{操作名}を取り消します。'}<br />
-            {'「取り消し」を押すと変更内容が破棄されます。'}
-          </div>
-        </ActionDialog>
-      </>
-    )
-  } else {
-    return null
-  }
+  return (
+    <>
+      <Button variant="danger" onClick={() => setIsOpen(true)}>取り消し操作時のダイアログを開く</Button>
+      <ActionDialog
+        isOpen={isOpen}
+        title="{操作名}を取り消しますか？"
+        closeText="キャンセル"
+        actionText="取り消し"
+        actionTheme="danger"
+        onClickClose={()=> {setIsOpen(false)}}
+        onClickAction={()=> {setIsOpen(false)}}
+      >
+        <div style={{'boxSizing': 'border-box', 'width': '480px', 'padding': '24px'}}>
+          {'{操作名}を取り消します。'}<br />
+          {'「取り消し」を押すと変更内容が破棄されます。'}
+        </div>
+      </ActionDialog>
+    </>
+  )
 }
 
 <ComponentPreview>

--- a/content/articles/products/design-patterns/delete-dialog.mdx
+++ b/content/articles/products/design-patterns/delete-dialog.mdx
@@ -34,35 +34,31 @@ import { AirtableEmbed } from '@Components/article/AirtableEmbed/AirtableEmbed'
 
 export const DynamicActionDialog = () => {
   const [isOpen, setIsOpen] = useState(false)
-  if (typeof window !== 'undefined') {
-    return (
-      <>
-        <Button variant="danger" onClick={() => setIsOpen(true)}>削除ダイアログを開く</Button>
-        <ActionDialog
-          isOpen={isOpen}
-          title="{オブジェクト名}を削除しますか？"
-          closeText="キャンセル"
-          actionText="削除"
-          actionTheme="danger"
-          onClickClose={()=> {setIsOpen(false)}}
-          onClickAction={()=> {setIsOpen(false)}}
-        >
-          <div style={{'boxSizing': 'border-box', 'width': '640px', 'padding': '24px'}}>
-            <p style={{'margin': 0}}>
-            {'【{オブジェクトのインスタンス名}】を削除します。'}<br />
-            {'{関連するオブジェクト名など}に登録されているデータも削除されます。'}<br />
-            {'削除した{オブジェクト名}は元に戻せません。'}
-            </p>
-            <p style={{'marginBottom': 0}}>
-            {'{オブジェクト名}を削除しますか？'}
-            </p>
-          </div>
-        </ActionDialog>
-      </>
-    )
-  } else {
-    return null
-  }
+  return (
+    <>
+      <Button variant="danger" onClick={() => setIsOpen(true)}>削除ダイアログを開く</Button>
+      <ActionDialog
+        isOpen={isOpen}
+        title="{オブジェクト名}を削除しますか？"
+        closeText="キャンセル"
+        actionText="削除"
+        actionTheme="danger"
+        onClickClose={()=> {setIsOpen(false)}}
+        onClickAction={()=> {setIsOpen(false)}}
+      >
+        <div style={{'boxSizing': 'border-box', 'width': '640px', 'padding': '24px'}}>
+          <p style={{'margin': 0}}>
+          {'【{オブジェクトのインスタンス名}】を削除します。'}<br />
+          {'{関連するオブジェクト名など}に登録されているデータも削除されます。'}<br />
+          {'削除した{オブジェクト名}は元に戻せません。'}
+          </p>
+          <p style={{'marginBottom': 0}}>
+          {'{オブジェクト名}を削除しますか？'}
+          </p>
+        </div>
+      </ActionDialog>
+    </>
+  )
 }
 
 <ComponentPreview>


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1306

## やったこと
MDX内のコンポーネントコードから、`typeof window !== 'undefined'`によるレンダリング条件の分岐を削除しました。

## やらなかったこと
条件分岐しているページとしていないページが混在していたので、元からないページはそのままです。（例えば FlashMessage。）

## 動作確認
該当の箇所：
https://deploy-preview-950--smarthr-design-system.netlify.app/products/design-patterns/delete-dialog/#h2-1
https://deploy-preview-950--smarthr-design-system.netlify.app/products/components/dialog/#h2-1
https://deploy-preview-950--smarthr-design-system.netlify.app/products/components/notification-bar/#h3-1
https://deploy-preview-950--smarthr-design-system.netlify.app/products/components/tooltip/#h3-2

- 条件分岐の削除後も、ビルドおよびコードの実行が正常にできることを確認しました。
- ページロード時にコンソールに出ていたReactエラーがなくなったことも確認しました。

## キャプチャ
見た目上の変化はありません。