### PR TITLE
TypeScriptの型エラーを解消

### DIFF
--- a/netlify/edge-functions/private-fetch.ts
+++ b/netlify/edge-functions/private-fetch.ts
@@ -1,5 +1,7 @@
+// @ts-ignore
 import { encode } from 'https://deno.land/std@0.199.0/encoding/base64.ts'
 
+// @ts-ignore
 import type { Config } from 'https://edge.netlify.com'
 
 export default async (req: Request) => {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/adm-zip": "^0.5.3",
     "@types/color": "^3.0.5",
     "@types/mdx-js__react": "^1.5.7",
-    "@types/react": "^18.2.35",
+    "@types/react": "18.2.12",
     "@types/react-dom": "^18.2.14",
     "@types/react-instantsearch-dom": "^6.12.5",
     "@types/styled-components": "^5.1.29",

--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,16 @@
         "automerge": true
       },
       {
+        "matchPackageNames": [
+          "@types/react"
+        ],
+        "matchUpdateTypes": [
+          "minor",
+          "major"
+        ],
+        "automerge": false
+      },
+      {
         "groupName": "MDX",
         "matchPackagePrefixes": [
           "@mdx-js",

--- a/src/components/ComponentPropsTable/ComponentPropsTable.tsx
+++ b/src/components/ComponentPropsTable/ComponentPropsTable.tsx
@@ -61,8 +61,6 @@ const pickType = (typeValue: string): keyof typeof TYPE_COLOR => {
 
 const pickTypeColor = (value: string): string => TYPE_COLOR[pickType(value)]
 
-marked.setOptions({ headerIds: false, mangle: false })
-
 export const ComponentPropsTable: FC<Props> = ({ name, dirName, showTitle }) => {
   const { allUiVersion } = useStaticQuery<Queries.PropsDataQuery>(query)
 

--- a/src/components/article/PageIndex/PageIndex.tsx
+++ b/src/components/article/PageIndex/PageIndex.tsx
@@ -56,7 +56,7 @@ export const PageIndex: FC<Props> = ({ path, excludes, heading = 'h2', children 
     .sort((x, y) => (x.order && y.order ? x.order - y.order : -1))
 
   const injectedDescriptions: { [key: string]: string } = {}
-  marked.setOptions({ breaks: true, headerIds: false, mangle: false }) //改行の手前にスペース*2がなくても<br>に変換したいので
+  marked.setOptions({ breaks: true }) //改行の手前にスペース*2がなくても<br>に変換したいので
   React.Children.toArray(children)
     .filter((child: any) => {
       // <Description>タグ以外は除外

--- a/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
+++ b/src/components/contents/IdiomaticUsageTable/IdiomaticUsageTable.tsx
@@ -46,8 +46,6 @@ type Props = {
   type: 'data' | 'reason'
 }
 
-marked.setOptions({ headerIds: false, mangle: false })
-
 export const IdiomaticUsageTable: FC<Props> = ({ type }) => {
   const data = useStaticQuery<Queries.IdiomaticUsageTableQuery>(query)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3256,19 +3256,10 @@
     "@types/react" "*"
     "@types/react-instantsearch-core" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@18.2.12":
   version "18.2.12"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.12.tgz#95d584338610b78bb9ba0415e3180fb03debdf97"
   integrity sha512-ndmBMLCgn38v3SntMeoJaIrO6tGHYKMEBohCUmw8HoLLQdRMOIGXfeYaBTLe2lsFaSB3MOK1VXscYFnmLtTSmw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^18.2.35":
-  version "18.2.35"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.35.tgz#bacdc6d139a4d6d47e5186e1a96952c65e1f3792"
-  integrity sha512-LG3xpFZ++rTndV+/XFyX5vUP7NI9yxyk+MQvBDq+CVs8I9DLSc3Ymwb1Vmw5YDoeNeHN4PDZa3HylMKJYT9PNQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
## 課題・背景
closes: kufu/smarthr-design-system-issues#1307

## やったこと
出ていた型エラーは3種類だったので、それぞれ対応しました。

### JSXのエラー
https://github.com/kufu/smarthr-design-system/commit/ab9e1d24ea3108b6666ca9cdd8d872e1f08cd68b

`'XXXComponent' cannot be used as a JSX component` のようなエラー。
これらは、package.jsonに`devDependencies`として定義している`@types/react`のバージョンと、Reactに関係するパッケージ（styled-componentsやAlgoliaのreact-instantsearch-domなど）が依存する`@types/react`のバージョンがずれていることに起因していました。

package.jsonでの依存は`18.2.35`、各パッケージが依存するのはどれも`18.2.12`で、yarn.lockを確認するとこの2バージョンが共存している状態でした。
`18.2.12`に統一すると型エラーは出なくなったため、package.jsonで直接`18.2.12`を指定するようにしました。

パッケージ側が新しい型に対応するまでは、バージョンアップを避けたほうが良さそうなので、Renovateの自動マージも無効にしました。

### markedのオプション関連のエラー

https://github.com/kufu/smarthr-design-system/commit/2db0d3fd7921feefd5ef34ba6161dd0cb2a16ab0

Airtableやsmarthr-ui-props.json から取得したマークダウンコンテンツのパースに使っている[marked](https://www.npmjs.com/package/marked) で、廃止されたオプション指定が残っている箇所があり、TSエラーになっていました。
該当のオプションは、`headerIds`と`mangle`で、無効にするために`false`をセットしていましたが、現在はプラグインを入れない限り有効になることはないようなので、オプション指定ごと削除しました。
参考：https://marked.js.org/using_advanced 内の「Old Options」

### Netlify Edge Functionsのコードのエラー

https://github.com/kufu/smarthr-design-system/commit/87bf84059f6f9ed033591171b4cf603681f8db63

URLからimportしているDenoモジュールがあり、その型定義がないのでエラーになっていました。簡単な解決法はなさそうなことと、Edge Functionsのコードは変更することもあまりなく、Gatsby本体のコードからも独立しているため、`@ts-ignore`コメントを追加しました。

Netlify由来のモジュールに関しては[@netlify/edge-functions](https://www.npmjs.com/package/@netlify/edge-functions)というパッケージから[型定義が取れるようになった](https://answers.netlify.com/t/edge-functions-types-now-available-as-an-npm-module/101230)ようですが、これを導入すると、`netlify dev`での開発サーバーが立ち上がらなくなるという現象が起きたため、使っていません。（`netlify dev`がダメなだけで、本環境では動くのかもしれませんが、ローカルで検証できないのも不便なので。）

## 動作確認
`npx tsc --noEmit` で、エラーは出なくなりました。

## キャプチャ
ビルド後のソースコードに影響はありません。