### PR TITLE
型エラー回避のため@types/reactのバージョンを固定

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/adm-zip": "^0.5.4",
     "@types/color": "^3.0.6",
     "@types/mdx-js__react": "^1.5.8",
-    "@types/react": "18.2.37",
+    "@types/react": "18.2.12",
     "@types/react-dom": "^18.2.15",
     "@types/react-instantsearch-dom": "^6.12.6",
     "@types/styled-components": "^5.1.30",

--- a/renovate.json
+++ b/renovate.json
@@ -52,6 +52,7 @@
           "@types/react"
         ],
         "matchUpdateTypes": [
+          "patch",
           "minor",
           "major"
         ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3260,19 +3260,10 @@
     "@types/react" "*"
     "@types/react-instantsearch-core" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@18.2.12":
   version "18.2.12"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.12.tgz#95d584338610b78bb9ba0415e3180fb03debdf97"
   integrity sha512-ndmBMLCgn38v3SntMeoJaIrO6tGHYKMEBohCUmw8HoLLQdRMOIGXfeYaBTLe2lsFaSB3MOK1VXscYFnmLtTSmw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@18.2.37":
-  version "18.2.37"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.37.tgz#0f03af69e463c0f19a356c2660dbca5d19c44cae"
-  integrity sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
## 課題・背景
#960 で@types/react のバージョンを下げて型エラーが出ないようにしましたが、#963 で上がってしまい、再度エラーになっていました。パッチバージョンのアップデートでもエラーが再発する状況なので、Renovateによる自動マージが起こらないよう設定を変更しました。

## やったこと
- @types/reactをバージョン18.2.12に戻す
- Renovateの設定を更新

## 動作確認
`npx tsc --noEmit` にてエラーが出なくなったことを確認しました。

## キャプチャ
ビルド後のサイトに影響はありません