### PR TITLE
CSSファイルをreact-frame-componentから読み込むサンプルを追加

### DIFF
--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -132,6 +132,7 @@ export const CodeBlock: FC<Props> = ({
             height={`${iframeHeight}px`}
             style={{ border: 'none', overflow: 'hidden' }}
             referrerPolicy="same-origin"
+            head={<link href="/example.css" rel="stylesheet" />}
           >
             <FrameContextConsumer>
               {({ document }) => <StyleSheetManager target={document?.head}>{LiveContainerComponent()}</StyleSheetManager>}

--- a/static/example.css
+++ b/static/example.css
@@ -1,0 +1,5 @@
+.frame-content::before {
+  content: "Content from example.css";
+  display: block;
+  border: solid 1px #F00;
+}


### PR DESCRIPTION
`/static` 以下に `example.css` というファイルを用意し、それをCodeBlockコンポーネントのiframeに適用しています。

`::before`でコンテンツを書き出すようになっているので、CSSが適用されていれば以下のような見た目になります。
該当のプレビューページ：https://deploy-preview-983--smarthr-design-system.netlify.app/products/components/button/#h3-1

![スクリーンショット 2023-11-24 10 32 48](https://github.com/kufu/smarthr-design-system/assets/7822534/0d9a360e-5697-477a-84b5-e6f9f1e8daa7)
