### PR TITLE
stylelint-config-standardのアップデートに伴いルールを調整

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -16,6 +16,7 @@
   "rules": {
     "value-list-comma-space-after": null,
     "custom-property-no-missing-var-function": null,
-    "media-feature-range-notation": null
+    "media-feature-range-notation": null,
+    "media-query-no-invalid": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "stylelint": "^15.11.0",
     "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-smarthr": "^2.0.0",
-    "stylelint-config-standard": "^33.0.0",
+    "stylelint-config-standard": "^34.0.0",
     "stylelint-config-styled-components": "^0.1.1",
     "textlint": "^13.4.1",
     "textlint-filter-rule-allowlist": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15507,22 +15507,22 @@ stylelint-config-prettier@^9.0.5:
   resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz#9f78bbf31c7307ca2df2dd60f42c7014ee9da56e"
   integrity sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==
 
-stylelint-config-recommended@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz#d0993232fca017065fd5acfcb52dd8a188784ef4"
-  integrity sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==
+stylelint-config-recommended@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz#c48a358cc46b629ea01f22db60b351f703e00597"
+  integrity sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==
 
 stylelint-config-smarthr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-smarthr/-/stylelint-config-smarthr-2.0.0.tgz#59eed260fa480bcbcbde9b6a25bb9d93e5b3ff70"
   integrity sha512-QkXnwGN2QARLMxABUqn36CGT+B6hTfPQ49BM6leKNHQRqViW+CzfDKOd2S4LC/WcmZbwk5RWJ6t6UsnC8PyieQ==
 
-stylelint-config-standard@^33.0.0:
-  version "33.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz#1f7bb299153a53874073e93829e37a475842f0f9"
-  integrity sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==
+stylelint-config-standard@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz#309f3c48118a02aae262230c174282e40e766cf4"
+  integrity sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==
   dependencies:
-    stylelint-config-recommended "^12.0.0"
+    stylelint-config-recommended "^13.0.0"
 
 stylelint-config-styled-components@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
## 課題・背景
#992 

上記PRでのLintのログ：https://github.com/kufu/smarthr-design-system/actions/runs/6999634767/job/19039192615?pr=992

## やったこと
stylelint-config-standard のアップデートに伴い、`media-query-no-invalid`ルールのLintエラーが数十個出るようになったため、ルールを無効にしました。

```
@media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {...}
```
のような、styled-componentsとJS変数を用いたメディアクエリがすべて引っかかってしまうのですが、[stylelintのドキュメント](https://stylelint.io/user-guide/rules/media-query-no-invalid/)にも

> This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as Sass or Less, as they have their own syntaxes.

と書かれており、CSS-in-JSな環境では無効にして良いのではという判断です。

### メモ
SDSのstylelintのルールは、[stylelint-config-smarthr](https://github.com/kufu/stylelint-config-smarthr)も適用しているので、そちらでまとめて無効にするようなことがあれば、SDSでは特に指定しなくても良くなるかもしれません。

## 動作確認
`yarn lint:style` でエラーが出なくなったことを確認しました。

## キャプチャ
ビルド後のサイトには影響しません。
