### PR TITLE
Storybookのiframe URLの初期値を予めセットしておくように変更

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -76,7 +76,7 @@ export const ComponentStory: FC<Props> = ({ name, dirName }) => {
   const [isIFrameLoaded, setIsIFrameLoaded] = useState<boolean>(false)
   const [isStoryLoaded, setIsStoryLoaded] = useState<boolean>(false)
   const [currentIFrame, setCurrentIFrame] = useState<string>(storyData.storyItems[0]?.iframeName ?? '')
-  const [displayVersion, setDisplayVersion] = useState<string>('')
+  const [displayVersion, setDisplayVersion] = useState<string>(defaultVersion?.version || '')
   const [showError, setShowError] = useState<boolean>(false)
 
   const fetchData = useCallback(


### PR DESCRIPTION
## 課題・背景
products/components/ 以下の各コンポーネントで、Storybookの内容をiframeで表示しているが、ブラウザによりページロード時の表示が `404`（存在しないChromaticのURLにアクセスしてしまう）になっていたため、修正しました。

## やったこと
ChromaticのURLは、`https://2928bb8--63d0ccabb5d2dd29825524ab.chromatic.com/iframe.html?id=...` のようなフォーマットで、サブドメインの最初の7文字（`2928bb8`）がsmarthr-uiの各バージョンを表しますが、デフォルトでは空文字列で、ページロード後に表示すべきバージョンで上書きしていました。

この上書き時に、Chromeでiframeの更新がかかっていないケースがあったため、デフォルトバージョンを予めセットしておき、HTMLに静的に書き出されるように変更しました。

## 動作確認
ページ例：https://deploy-preview-994--smarthr-design-system.netlify.app/products/components/button/

プルダウンでのバージョン切り替え時には、該当のバージョンのURLへのリクエストが行われていることも確認しました。

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/af5de08c-8e79-4db0-bb10-76956480eef5" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/1c834456-a367-4da5-b7ef-6e7d6e1f0cce" alt width="350"> |

また、表示不具合だけでなく、404になってしまう無駄なリクエストもなくなっています。

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/bc469f53-b1d9-45df-af8b-736c173563bd" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/e467e9c0-9ee6-4a89-9e56-3c10b4f673df" alt width="350"> |
