### PR TITLE
Storybookのコードが取得できていない不具合を修正

### DIFF
--- a/src/components/ComponentStory/ComponentStory.tsx
+++ b/src/components/ComponentStory/ComponentStory.tsx
@@ -124,9 +124,8 @@ export const ComponentStory: FC<Props> = ({ name, dirName }) => {
   useEffect(() => {
     const { search } = location
     const params = new URLSearchParams(search)
-    const version = params.get('v') || packageInfo.version
-    if (version === displayVersion) return
-
+    if (params.get('v') === displayVersion) return
+    const version = params.get('v') || displayVersion
     fetchData(version)
   }, [location, displayVersion, fetchData])
 


### PR DESCRIPTION
## 課題・背景
#994 の変更に伴い、コードのほうがページロード時に取得できなくなっていました。

## やったこと
GitHubからのコード取得（`fetch`）をトリガーする条件を調整しました。

## やらなかったこと
初期表示バージョンのコードだけでもサーバー側でセットしておいても良いのかもしれませんが、未検討です。

## 動作確認
https://deploy-preview-995--smarthr-design-system.netlify.app/products/components/accordion-panel/

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/682b44f6-f6bc-4c16-af03-73a09dd1df4b" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/5970c447-89eb-4201-bec8-1fa5bbd237f2" alt width="350"> |