### PR TITLE
フッターのログインボタン周辺の余白を修正

### DIFF
--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -229,17 +229,23 @@ const FooterContainer = styled.div<{ isArticlePage: boolean }>`
 const StyledLogoHeading = styled.h2`
   margin-block: 9px 0;
   font-size: ${CSS_FONT_SIZE.PX_14};
-  font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+  font-family:
+    Helvetica Neue,
+    Helvetica,
+    Arial,
+    sans-serif;
   line-height: 1.37;
   color: ${CSS_COLOR.BLACK};
 `
 
 const Col1Container = styled.div`
   grid-area: col1;
-  display: grid;
-  grid-template-columns: 100%;
-  gap: 24px;
-  justify-items: start;
+  > section {
+    display: grid;
+    grid-template-columns: 100%;
+    gap: 24px;
+    justify-items: start;
+  }
 `
 
 const Col2Container = styled.div`


### PR DESCRIPTION
## 課題・背景
#843 にて、フッターの一番左のカラム（ロゴ・ログインボタンなどのところ）を`<section>`要素で囲ったため、gridアイテムの適用先が変わってしまい、余白が消えていました。

## やったこと
`<section>`の子要素がgridアイテムになるよう、CSSを調整しました。

## 動作確認
https://deploy-preview-997--smarthr-design-system.netlify.app/

#843 より前のPRのプレビューを参照し、その時と同じ余白に戻ったことを確認しました。

## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/d9386ca6-afcd-4152-8b02-0f1d939959c5" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/e1ea81ee-7b23-43d9-a587-13f60440eff4" alt width="350"> |