### PR TITLE
smarthr-ui.cssをコピーするしくみを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "export:zip-images": "ts-node scripts/zipImages.ts",
     "generate:thumbnails": "ts-node scripts/component-thumbnails/componentThumbnails.ts",
     "update:smarthr-ui.css": "ts-node scripts/update-smarthr-ui-css.ts",
-    "postinstall": "husky install"
+    "postinstall": "husky install && cp node_modules/smarthr-ui/smarthr-ui.css static/"
   },
   "dependencies": {
     "@types/marked": "^5.0.2",

--- a/plugins/gatsby-source-ui-versions/gatsby-node.ts
+++ b/plugins/gatsby-source-ui-versions/gatsby-node.ts
@@ -1,23 +1,8 @@
-import fs from 'fs'
-import path from 'path'
-
 import { SourceNodesArgs } from 'gatsby'
 
 import { fetchUiVersions } from './fetchUiVersions'
 
 const NODE_TYPE = `UiVersion`
-
-exports.onPreInit = () => {
-  try {
-    fs.copyFileSync(
-      path.join(process.cwd(), './node_modules/smarthr-ui/smarthr-ui.css'),
-      path.join(process.cwd(), './static/smarthr-ui.css'),
-    )
-    console.log('smarthr-ui.css をコピーしました!!')
-  } catch (error) {
-    console.error('Error copy smarthr-ui.css from node_modules:', error)
-  }
-}
 
 exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }: SourceNodesArgs) => {
   const { createNode } = actions

--- a/plugins/gatsby-source-ui-versions/gatsby-node.ts
+++ b/plugins/gatsby-source-ui-versions/gatsby-node.ts
@@ -1,8 +1,23 @@
+import fs from 'fs'
+import path from 'path'
+
 import { SourceNodesArgs } from 'gatsby'
 
 import { fetchUiVersions } from './fetchUiVersions'
 
 const NODE_TYPE = `UiVersion`
+
+exports.onPreInit = () => {
+  try {
+    fs.copyFileSync(
+      path.join(process.cwd(), './node_modules/smarthr-ui/smarthr-ui.css'),
+      path.join(process.cwd(), './static/smarthr-ui.css'),
+    )
+    console.log('smarthr-ui.css をコピーしました!!')
+  } catch (error) {
+    console.error('Error copy smarthr-ui.css from node_modules:', error)
+  }
+}
 
 exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }: SourceNodesArgs) => {
   const { createNode } = actions


### PR DESCRIPTION
## 課題・背景
https://pxgrid.slack.com/archives/C018J0A6DCH/p1701404956773799

`smarthr-ui.css`を `/static`以下に配置し、ライブエディタのiframeで読み込んでいるが、自動的にコピーされるようにしたい。

## やったこと
以下の2つを実装してみています。どちらかでも良いのかもしれません。
どちらも`node_modules/smarthr-ui/smarthr-ui.css` を `static/` にコピーしています。

### yarn install直後にコピー
`package.json`の`postinstall`に、`cp`コマンドを追加しました。

- リポジトリをcloneして`yarn (install)` すればコピーされる
- smarthr-uiのバージョンを上げる際も、手動で`yarn`は実行すると思うので、そこでもコピーされる
- Netlify上でも`yarn --frozen-lockfile`が実行されるので、ビルド前にコピーされる

### ビルド開始前にコピー
Gatsbyプラグインには、ビルド前や後に実行できるフックがあるので、smarthr-uiのコードなどを取得しているgatsby-source-ui-versionsプラグインに、`onPreInit`フックを追加しました。ビルドのたびにコピーされます。

- ビルドするごとに実行されるので、コピーが動く回数は多くなる
- `yarn dev`した場合にもコピーされる
- smarthr-uiのバージョンが上がった後などに、ローカルで`yarn (--frozen-lockfile)`**しない**人がいれば、古いバージョンのCSSがコピーされる可能性がある
  - → .gitignore にCSSファイルを追加しておくほうが良い？

## やらなかったこと
エラー時（元ファイルがなかった場合など）の動作が、現状は以下のようになっています。

- `package.json`でのコピー→エラーになった場合はそこで止まる
- ビルド時のコピー→エラーは出力されるが、ビルドは続行する

現状では`static/smarthr-ui.css`が存在しなくてもビルド自体はできるので、止める必要はないかもしれませんが、ビルドを止めることも可能です。

## 動作確認
ローカルでは意図どおりコピーされることを確認しました。ファイルの内容に変化がなければgitの差分は出ません。
ビルド時はこんな感じの出力になります：
```
% yarn build                                             
yarn run v1.22.19
$ GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages
success compile gatsby files - 0.772s
success load gatsby config - 0.019s
success load plugins - 0.622s
smarthr-ui.css をコピーしました!!
success onPreInit - 0.003s
...（以下省略）
```