### PR TITLE
devサーバー起動時にNode.jsのメモリ指定を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages",
-    "dev": "gatsby develop",
+    "dev": "NODE_OPTIONS=--max-old-space-size=8192 gatsby develop",
     "start": "yarn dev",
     "serve": "gatsby serve",
     "clean": "gatsby clean",


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1309

## やったこと
package.json内の`gatsby develop`コマンドに、`NODE_OPTIONS=--max-old-space-size=8192`を追加しました。

## やらなかったこと
依存パッケージの追加・更新や、コンテンツの追加などが影響しているのかもしれませんが、1ヶ月ちょっと前の時点（#939 あたり）のコードでも、キャッシュがない状態ではメモリリークが起こることが確認できたため、それ以上の原因の特定やコードの巻き戻しは試していません。

## 動作確認
ビルド時には問題は再現しないため、Netlify上での検証はできません。

ローカルにて、以下の手順を実行し、変更前は起こっていたメモリリークがなくなったことを確認しました。
```
rm -r node_modules
yarn --frozen-lockfile
yarn clean
yarn dev
```