### PR TITLE
SP版のメインメニューのレイアウトを調整

### DIFF
--- a/src/components/shared/Header/Header.tsx
+++ b/src/components/shared/Header/Header.tsx
@@ -73,8 +73,12 @@ export const Header: FC<Props> = ({ isIndex = false }) => {
               {typeof window !== 'undefined' ? (
                 <Dialog
                   isOpen={isOpen}
-                  top={0}
-                  right={0}
+                  // 上下左右の余白は、smarthr-ui側がnumber型のみ対応しているので15pxの固定値にする
+                  // smarthr-uiへの対応などの経緯は：https://github.com/kufu/smarthr-design-system-issues/issues/1311
+                  top={15}
+                  right={15}
+                  left={15}
+                  bottom={15}
                   onPressEscape={() => {
                     setIsOpen(false)
                   }}
@@ -280,25 +284,12 @@ const GlobalStyleForMenu = createGlobalStyle`
     background: transparent;
   }
   #panel-menu .smarthr-ui-Dialog {
-    top: 30px;
-    right: calc(5rem - 12px);
-    width: 100%;
+    width: auto;
     max-width: 396px;
     border-radius: 8px;
     box-shadow: 0 4px 8px 2px rgba(0, 0, 0, 0.24);
     bottom: 16px;
     max-height: 678px;
-
-    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_3}) {
-      top: 1rem;
-      right: calc(3rem - 12px);
-    }
-
-    @media (max-width: ${CSS_SIZE.BREAKPOINT_MOBILE_2}) {
-      width: auto;
-      right: calc(1.5rem - 12px);
-      left: calc(1.5rem - 12px);
-    }
   }
 `
 


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1311

## やったこと
smarthr-uiのDialogコンポーネントに、固定値として`15px`の余白をpropsとして渡すようにしました。

## やらなかったこと
元々は`rem`を使った余白がCSSで指定されており、また画面幅によっても変化させていましたが、いったんpx単位の固定値になっています。

## 動作確認
https://deploy-preview-1024--smarthr-design-system.netlify.app/
→ SP幅でハンバーガーメニューを開く

余白がなく右上にくっついてたのが上下左右均等な余白に戻りました。


## キャプチャ

|Before|After|
| --- | --- |
| <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/f9d6ec92-453c-4c86-bd0b-2ac9eebeb30a" alt width="350"> | <img src="https://github.com/kufu/smarthr-design-system/assets/7822534/00a44fd8-96ca-4f91-9dca-6d750742775d" alt width="350"> |

