### PR TITLE
Storybook checkerをプラグインに合わせて修正

### DIFF
--- a/scripts/content-checker/storybookUrlChecker.ts
+++ b/scripts/content-checker/storybookUrlChecker.ts
@@ -8,23 +8,24 @@ import { SHRUI_GITHUB_PATH } from '../../src/constants/application'
 
 const CONTENT_PATH = path.join(__dirname, '../../content/articles/products/components/**/*.mdx')
 
+const options = {
+  uiRepoApi: 'https://api.github.com/repos/kufu/smarthr-ui',
+  releaseBotEmail: '41898282+github-actions[bot]@users.noreply.github.com',
+  chromaticDomain: '63d0ccabb5d2dd29825524ab.chromatic.com',
+}
+
 const checkStoryPages = async () => {
   const errorList: string[] = []
 
   const parentPackageJson = JSON.parse(await fs.readFile(path.join(__dirname, '../../package.json'), 'utf8'))
   const defaultVersion = parentPackageJson.dependencies['smarthr-ui'].replace('^', '')
-  const versionsData = await fetchUiVersions()
-  const commitHash =
-    versionsData.find((item) => {
-      return item.version === defaultVersion
-    })?.commitHash ?? null
+  const versionsData = await fetchUiVersions([], options)
+  const commitHash = versionsData.find((item) => item.version === defaultVersion)?.commitHash ?? null
   if (commitHash === null) {
     console.error(`Couldn't get current commit hash.`)
     process.exit(1)
   }
-  const targetVersion = versionsData.find((item) => {
-    return item.version === defaultVersion
-  })
+  const targetVersion = versionsData.find((item) => item.version === defaultVersion)
 
   for (const file of await glob(CONTENT_PATH)) {
     const content = await fs.readFile(file, 'utf8')


### PR DESCRIPTION
## 課題・背景
#1026 で、gatsby-plugin-ui-versionsにキャッシュ機能を追加しましたが、StorybookのURLチェッカーからもプラグイン内のコードを利用しており、合わせて変更が必要でした。

## やったこと
チェックの際にはキャッシュは使わず、オプションを渡してデータを取得するようにしました。

## 動作確認
このブランチにて、手動でチェックを実行しました：https://github.com/kufu/smarthr-design-system/actions/runs/7286011908

## キャプチャ
サイト本体には影響しません。