### PR TITLE
LiveEditorのエディタをiframeの外に移動

### DIFF
--- a/src/components/article/CodeBlock/LiveContainer.tsx
+++ b/src/components/article/CodeBlock/LiveContainer.tsx
@@ -1,11 +1,12 @@
 import { CSS_COLOR } from '@Constants/style'
 import { Script } from 'gatsby'
 import { themes } from 'prism-react-renderer'
-import React, { FC } from 'react'
+import React, { FC, useEffect, useRef, useState } from 'react'
+import Frame, { FrameContextConsumer } from 'react-frame-component'
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live'
 import { CssBaseLine } from 'smarthr-normalize-css'
 import * as ui from 'smarthr-ui'
-import styled, { ThemeProvider, css } from 'styled-components'
+import styled, { StyleSheetManager, ThemeProvider, css } from 'styled-components'
 import 'smarthr-ui/smarthr-ui.css'
 
 import { ComponentPreview } from '../../ComponentPreview'
@@ -15,10 +16,7 @@ import { CopyButton } from './CopyButton'
 
 import type { LiveContainerProps } from './CodeBlock'
 
-type Props = {
-  tsLoaded: boolean
-  setTsLoaded: React.Dispatch<React.SetStateAction<boolean>>
-} & LiveContainerProps
+type Props = LiveContainerProps
 
 const smarthrTheme = ui.createTheme()
 
@@ -33,54 +31,94 @@ const transformCode = (snippet: string) => {
   })
 }
 
-export const LiveContainer: FC<Props> = ({
-  code,
-  language,
-  scope,
-  noIframe,
-  withStyled,
-  gap,
-  align,
-  layout,
-  tsLoaded,
-  setTsLoaded,
-}) => (
-  <ThemeProvider theme={smarthrTheme}>
-    {/* ライブエディタ内のコードのトランスパイルに使用するTS（容量が大きいためCDNを利用） */}
-    <Script src="https://unpkg.com/typescript@latest/lib/typescript.js" onLoad={() => setTsLoaded(true)} />
-    {tsLoaded && (
-      <LiveProvider
-        code={code}
-        language={language}
-        scope={{ ...React, ...ui, styled, css, ...scope }}
-        theme={{
-          ...themes.vsDark,
-          plain: {
-            color: CSS_COLOR.LIGHT_GREY_3,
-            backgroundColor: CSS_COLOR.TEXT_BLACK,
-          },
-        }}
-        noInline={withStyled}
-        transformCode={transformCode}
-      >
-        <ComponentPreview gap={gap} align={align} layout={layout}>
-          {!noIframe && <CssBaseLine />}
-          <LivePreview Component={React.Fragment} />
-        </ComponentPreview>
-        <CodeWrapper>
-          <StyledLiveEditorContainer>
-            <PreContainer>
-              <CopyButton text={code || ''} />
-              {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
-              <LiveEditor padding={0} />
-            </PreContainer>
-          </StyledLiveEditorContainer>
-        </CodeWrapper>
-        <LiveError />
-      </LiveProvider>
-    )}
-  </ThemeProvider>
-)
+export const LiveContainer: FC<Props> = ({ code, language, scope, noIframe, withStyled, gap, align, layout }) => {
+  const [tsLoaded, setTsLoaded] = useState(false)
+
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [iframeHeight, setIframeHeight] = useState(600) // デフォルトの高さを設定
+
+  // Gatsbyではページロード時に<Frame>がレンダリングされないため、クライアントで表示をトリガーする
+  // https://github.com/ryanseddon/react-frame-component/issues/192#issuecomment-1153078390
+  const [showFrame, setShowFrame] = useState(false)
+  useEffect(() => {
+    setShowFrame(true)
+  }, [])
+
+  // iframeの高さをコンテンツに合わせて変更する
+  useEffect(() => {
+    if (!tsLoaded) return // CDNからのTSスクリプトのロード後に描画されるので、それまでは高さを計算しない
+    const innerWindow = iframeRef.current?.contentWindow
+    if (!innerWindow) return // ここに該当することはないはず
+
+    // TSスクリプトロード後、レンダリングが終わるのを待ってから高さを計算・セットする
+    setTimeout(() => {
+      const height = innerWindow.document.body.scrollHeight
+      if (height > 0) {
+        setIframeHeight(height + 8) // ComponentPreviewコンポーネントに`margin-block-start: 8px`が指定されているため
+      }
+    }, 500)
+  }, [tsLoaded])
+
+  return (
+    <ThemeProvider theme={smarthrTheme}>
+      {/* ライブエディタ内のコードのトランスパイルに使用するTS（容量が大きいためCDNを利用） */}
+      <Script src="https://unpkg.com/typescript@latest/lib/typescript.js" onLoad={() => setTsLoaded(true)} />
+      {tsLoaded && (
+        <LiveProvider
+          code={code}
+          language={language}
+          scope={{ ...React, ...ui, styled, css, ...scope }}
+          theme={{
+            ...themes.vsDark,
+            plain: {
+              color: CSS_COLOR.LIGHT_GREY_3,
+              backgroundColor: CSS_COLOR.TEXT_BLACK,
+            },
+          }}
+          noInline={withStyled}
+          transformCode={transformCode}
+        >
+          {/* smarthr-ui側が対応したらnoIframeの条件分岐は削除し、iframeのdocument.bodyをLiveEditorに渡してportalにする予定です。 */}
+          {!noIframe && showFrame ? (
+            <Frame
+              ref={iframeRef}
+              width="100%"
+              height={`${iframeHeight}px`}
+              style={{ border: 'none', overflow: 'hidden', display: 'block' }}
+              referrerPolicy="same-origin"
+              head={<link href="/smarthr-ui.css" rel="stylesheet" />}
+            >
+              <FrameContextConsumer>
+                {({ document }) => (
+                  <StyleSheetManager target={document?.head}>
+                    <ComponentPreview gap={gap} align={align} layout={layout}>
+                      <CssBaseLine />
+                      <LivePreview Component={React.Fragment} />
+                    </ComponentPreview>
+                  </StyleSheetManager>
+                )}
+              </FrameContextConsumer>
+            </Frame>
+          ) : (
+            <ComponentPreview gap={gap} align={align} layout={layout}>
+              <LivePreview Component={React.Fragment} />
+            </ComponentPreview>
+          )}
+          <CodeWrapper>
+            <StyledLiveEditorContainer>
+              <PreContainer>
+                <CopyButton text={code || ''} />
+                {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
+                <LiveEditor padding={0} />
+              </PreContainer>
+            </StyledLiveEditorContainer>
+          </CodeWrapper>
+          <LiveError />
+        </LiveProvider>
+      )}
+    </ThemeProvider>
+  )
+}
 
 const CodeWrapper = styled.div`
   position: relative;


### PR DESCRIPTION
## 課題・背景
closes kufu/smarthr-design-system-issues#1313

## やったこと
CodeBlockのライブエディタ部分をiframe（react-frame-component）い入れていましたが、編集時にエラーが出るため、エディタ部分のみiframeの外に出しました。

## やらなかったこと
NotificationBarページで、以下のテキストの折り返しが効かなくなっていますが、ここは元からiframeの適用外で、別の問題と思われるので、何もしていません。
https://smarthr.design/products/components/notification-bar/#h3-2

## 動作確認
ライブエディタのあるページ：

https://deploy-preview-1048--smarthr-design-system.netlify.app/operational-guideline/page-template/component-template/
https://deploy-preview-1048--smarthr-design-system.netlify.app/operational-guideline/page-template/style-template/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/badge/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/button/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/fieldset/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/form-control/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/heading/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/icon/
https://deploy-preview-1048--smarthr-design-system.netlify.app/components/notification-bar/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/status-label/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/switch/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/base/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/components/dropdown/dropdown-menu-button/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/design-patterns/upward-navigation/
https://deploy-preview-1048--smarthr-design-system.netlify.app/products/design-patterns/select-company-account/


## キャプチャ
見た目上は変わりありません。
