### PR TITLE
SmartHR Design Systemに掲載している表記「SmartHR Plus β版」から「β版」をトル

### DIFF
--- a/content/articles/basics/colors/index.mdx
+++ b/content/articles/basics/colors/index.mdx
@@ -211,7 +211,7 @@ SmartHRのカラーパレットをKeynoteで利用する方法です。
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/colors/index.mdx
+++ b/content/articles/basics/colors/index.mdx
@@ -251,3 +251,4 @@ SmartHRのカラーパレットをKeynoteで利用する方法です。
 
 - 社内Slack `#design_comm_依頼`
 - SmartHR Design System 運営チーム  smarthr-design-system@smarthr.co.jp
+

--- a/content/articles/basics/icons/index.mdx
+++ b/content/articles/basics/icons/index.mdx
@@ -104,7 +104,7 @@ SVG・PNG形式のアイコンデータをダウンロードできます。
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/illustration/index.mdx
+++ b/content/articles/basics/illustration/index.mdx
@@ -130,7 +130,7 @@ SmartHR社に関する人物です。
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/illustration/item.mdx
+++ b/content/articles/basics/illustration/item.mdx
@@ -161,7 +161,7 @@ import { AnchorButton } from 'smarthr-ui'
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/illustration/scene.mdx
+++ b/content/articles/basics/illustration/scene.mdx
@@ -296,7 +296,7 @@ import { AnchorButton } from 'smarthr-ui'
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/illustration/smarthr-co.mdx
+++ b/content/articles/basics/illustration/smarthr-co.mdx
@@ -304,7 +304,7 @@ SmartHRスクールで、SmartHRの情報を教えてくれる人物。女性。
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/illustration/user-co-main.mdx
+++ b/content/articles/basics/illustration/user-co-main.mdx
@@ -209,7 +209,7 @@ import { AnchorButton } from 'smarthr-ui'
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/illustration/user-co-other.mdx
+++ b/content/articles/basics/illustration/user-co-other.mdx
@@ -281,7 +281,7 @@ import { AnchorButton } from 'smarthr-ui'
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/logos/index.mdx
+++ b/content/articles/basics/logos/index.mdx
@@ -171,7 +171,7 @@ Figmaを利用開始する方法や使い方になどについては、[Figmaの
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/logos/motion.mdx
+++ b/content/articles/basics/logos/motion.mdx
@@ -120,7 +120,7 @@ mov形式のモーションロゴをダウンロードできます。
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/logos/sound.mdx
+++ b/content/articles/basics/logos/sound.mdx
@@ -66,7 +66,7 @@ wav形式のサウンドロゴをダウンロードできます。
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/basics/meta/index.mdx
+++ b/content/articles/basics/meta/index.mdx
@@ -116,7 +116,7 @@ order: 6
     </tr>
     <tr>
       <td>SmartHR従業員</td>
-      <td>SmartHR Plus β版</td>
+      <td>SmartHR Plus</td>
       <td><strong>◯ 利用できます</strong></td>
     </tr>
     <tr>

--- a/content/articles/communication/capture/capture-others.mdx
+++ b/content/articles/communication/capture/capture-others.mdx
@@ -118,7 +118,7 @@ SmartHR Mag.を代表する画面です。
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/communication/capture/capture-product.mdx
+++ b/content/articles/communication/capture/capture-product.mdx
@@ -197,7 +197,7 @@ SmartHRのタレントマネジメント領域をあらわすシーンに適し�
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/communication/capture/kit.mdx
+++ b/content/articles/communication/capture/kit.mdx
@@ -59,7 +59,7 @@ Keynoteなどで画面キャプチャの上に配置することで簡易合成�
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/communication/capture/service-capture-in-mock.mdx
+++ b/content/articles/communication/capture/service-capture-in-mock.mdx
@@ -61,7 +61,7 @@ order: 1
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/communication/eye-catching-images.mdx
+++ b/content/articles/communication/eye-catching-images.mdx
@@ -79,7 +79,7 @@ Figmaのアカウントの発行方法などは[Figmaの利用方法](https://sm
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/communication/mock.mdx
+++ b/content/articles/communication/mock.mdx
@@ -106,7 +106,7 @@ KeynoteやGoogleスライドなどのスライド資料の場合、画面キャ�
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/communication/photography/jingle-movie.mdx
+++ b/content/articles/communication/photography/jingle-movie.mdx
@@ -115,7 +115,7 @@ mov形式のジングルムービーをダウンロードできます。
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/communication/slides.mdx
+++ b/content/articles/communication/slides.mdx
@@ -128,7 +128,7 @@ SmartHR社の方は、以下の資料テンプレートを利用できます。�
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>

--- a/content/articles/introduction/user/smarthr_employee.mdx
+++ b/content/articles/introduction/user/smarthr_employee.mdx
@@ -13,10 +13,10 @@ order: 2
 
 **ただし、以下のサービスの場合は、利用できるコンテンツに制限があります。**  
 
-### 1. 「SmartHR Plus β版」名義
+### 1. 「SmartHR Plus」名義
 
-SmartHR Plus β版名義で利用する場合、利用できるアセットは以下のとおりです。  
-SmartHR Plus β版は、株式会社SmartHRが提供しているサービスですが、プロダクトSmartHRとは異なるブランドであるため、ロゴのみ制限を設けています。
+SmartHR Plus名義で利用する場合、利用できるアセットは以下のとおりです。  
+SmartHR Plusは、株式会社SmartHRが提供しているサービスですが、プロダクトSmartHRとは異なるブランドであるため、ロゴのみ制限を設けています。
 この制限は、それぞれのブランドが不要に混同されずに適切に認知され、お互いのブランドを守るために設定しているものです。
 
 | カテゴリ | コンテンツ | 利用可否 |
@@ -32,10 +32,10 @@ SmartHR Plus β版は、株式会社SmartHRが提供しているサービスで�
 | **コミュニケーション** | **[画面キャプチャ](/communication/capture/)** | **<strong>◯ 利用できます</strong>** |
 | **コミュニケーション** | **[端末モック](/communication/mock/)** | **<strong>◯ 利用できます</strong>** |
 
-※ SmartHR Plus β版名義、つまり「SmartHR Plus β版のロゴ」としての利用はできませんが、サービス「SmartHR」「株式会社SmartHR」のロゴとして利用することは問題ありません。
+※ SmartHR Plus名義、つまり「SmartHR Plusのロゴ」としての利用はできませんが、サービス「SmartHR」「株式会社SmartHR」のロゴとして利用することは問題ありません。
 
 #### 対象となるアウトプットの例
-- アプリストア「<a href="https://www.smarthr.plus/" target="_blank">SmartHR Plus β版</a>」
+- アプリストア「<a href="https://www.smarthr.plus/" target="_blank">SmartHR Plus</a>」
 
 ### 2. 「SmartHRグループ会社・提供サービス」名義
 

--- a/content/articles/products/index.mdx
+++ b/content/articles/products/index.mdx
@@ -55,7 +55,7 @@ SmartHRのプロダクト群全体で再利用できる、デザイントーク�
       </tr>
       <tr>
         <td>SmartHR従業員</td>
-        <td>SmartHR Plus β版</td>
+        <td>SmartHR Plus</td>
         <td><strong>◯ 利用できます</strong></td>
       </tr>
       <tr>


### PR DESCRIPTION
## 課題・背景
アプリストアSmartHR Plusを2023/12/4に正式リリースしたことに伴い、SmartHR Design System内のすべての表記を「SmartHR Plus β版」から「SmartHR Plus」に変更しました。


## やったこと
- SmartHR Design System内のすべての表記を「SmartHR Plus β版」から「SmartHR Plus」に変更
  - どこを変更したのか？の確認は、[Files changedタブ](https://github.com/kufu/smarthr-design-system/pull/1058/files)からお願いします🙏


## やらなかったこと
- とくになし

## 動作確認
変更箇所が多いため、割愛します

## キャプチャ
変更箇所が多いため、割愛します

