### PR TITLE
「写真・動画」のコンテンツの内容をindexに掲載

### DIFF
--- a/content/articles/communication/photography/index.mdx
+++ b/content/articles/communication/photography/index.mdx
@@ -4,4 +4,19 @@ description: ''
 order: 1
 ---
 
+import { VideoEmbed } from '@Components/article/VideoEmbed/VideoEmbed'
+
+
 SmartHRのサービス全体で利用できる写真・動画です。
+
+## コンテンツ
+
+- [オフィス写真](/photography-office/)
+    - SmartHRのオフィスの写真についてまとめています。
+- [ジングルムービー](/jingle-movie/)
+    - イベントやライブストリーミングで利用できるジングルムービーです。
+        <VideoEmbed
+        poster="/images/jingle_movie_thumb.png"
+        source="/video/jingle_movie.mp4"
+        title="SmartHR jingle movie"
+        youtubeUrl="https://www.youtube.com/watch?v=EKpYFkLSIjY"/>

--- a/content/articles/communication/photography/jingle-movie.mdx
+++ b/content/articles/communication/photography/jingle-movie.mdx
@@ -12,8 +12,7 @@ import { VideoEmbed } from '@Components/article/VideoEmbed/VideoEmbed'
   poster="/images/jingle_movie_thumb.png"
   source="/video/jingle_movie.mp4"
   title="SmartHR jingle movie"
-  youtubeUrl="https://www.youtube.com/watch?v=EKpYFkLSIjY"
-/>
+  youtubeUrl="https://www.youtube.com/watch?v=EKpYFkLSIjY"/>
 
 イベントやライブストリーミングで利用できるジングルムービーです。  
 


### PR DESCRIPTION
## 課題・背景
[[写真・動画](https://smarthr.design/communication/photography/)] 配下にどんなコンテンツがあるのか？が分かりづらいので、コンテンツの内容を掲載しました。

## やったこと
- [[写真・動画](https://smarthr.design/communication/photography/)] に、配下にあるコンテンツ「[オフィス写真](https://smarthr.design/communication/photography/photography-office/)」と「[ジングルムービー](https://smarthr.design/communication/photography/jingle-movie/)」の概要を掲載しました。


## やらなかったこと
- とくになし

## 動作確認
https://deploy-preview-1059--smarthr-design-system.netlify.app/communication/photography/

## キャプチャ
|Before|After|
| --- | --- |
| ![CleanShot 2024-01-11 at 11 41 23@2x](https://github.com/kufu/smarthr-design-system/assets/101125529/674c7ee4-6e00-440d-886d-0542a9ae613d) | ![CleanShot 2024-01-11 at 11 37 01@2x](https://github.com/kufu/smarthr-design-system/assets/101125529/2d8ed7aa-1ed6-430f-b53b-9773fd41c2c7) |
