### PR TITLE
Tooltipの使用上の注意をより具体化した

### DIFF
--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -54,7 +54,7 @@ Tooltip内の情報は隠れるため、操作に必要な情報の表示への�
   - [LineClamp](/products/components/line-clamp/)
     - 折り返して表示することがどうしても難しい場合
   - [SearchInput](/products/components/input/search-input/)
-    - 検索したキーワードに該当する情報がなかった場合、ユーザーへのフィードバックとして検索条件が見える場所に必ず表示されるようにしたうえで、補助としてTooltipのメッセージを使う場合
+    - 検索キーワードに該当する検索結果が得られなかったとき、再検索を行なうめのヒントを見える場所に必ず表示したうえで、補助としてTooltipのメッセージを使う場合
   - [Button](/products/components/button/) の `disabledDetail` props 使用時
     - [DropdownMenuButton](/products/components/dropdown/dropdown-menu-button/) 内のButtonで使う場合（配置できるスペースがドロップダウン内に限られるため仕方なく使う）
     - Button単独の場合でも、ユーザーの操作過程で「確認が必須ではない」程度の付加的な情報を表示する目的で使う場合

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -342,7 +342,6 @@ export const DynamicTooltip = ({children, ...props}) => {
 <ComponentPreview>
   <DynamicTooltip
     message="省略されたすべてのテキストがはいります。"
-    triggerType="icon"
     horizontal="left"
     vertical="bottom">
       <Cluster align="center" gap={0.25}>

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -266,9 +266,8 @@ export const DynamicTooltip = ({children, ...props}) => {
 
 アイコンは、マウスオーバーが可能であることを示唆するためにリンク色（[`TEXT_LINK`](/products/design-tokens/color/#h2-2)）を使います。
 
-※アイコン単体で意味が伝わるようであれば、Tooltipは不要です。
-
-※アイコンに必ず代替テキストを設定します。
+- アイコン単体で意味が伝わるようであれば、Tooltipは不要です。
+- アイコンに必ず代替テキストを設定します。
 
 ##### テキストとあわせて使用
 <ComponentPreview>

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -23,7 +23,7 @@ import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 <BaseColumn>
   <WarningIcon text={
     <span>
-  Tooltipは気づきにくいなどの課題があるため、安易な使用はお勧めしません。基本的にはTooltip以外のUIを使用することを検討してください。
+  Tooltipはユーザーが能動的に表示しなければならない、拡大表示時に領域外に表示されてしまうなどの課題があるため、安易な使用はお勧めしません。基本的にはTooltip以外のUIを使用することを検討してください。
     </span>}
     />
 </BaseColumn>
@@ -48,18 +48,17 @@ Tooltip内の情報は隠れるため、操作に必要な情報の表示への�
 - 操作補助になる情報（ショートカットなど）
 
 
-### 推奨ではないが使用しても構わないケース
-- ユーザーの操作過程で「確認が必ずしも必要ではない程度」の付加的な情報を表示する目的での使用
-- Tooltipによる表示が提供されているコンポーネントにおいて、利用基準に沿った使用（<a href="/products/components/line-clamp/">LineClamp</a>、SearchInput、<a href="/products/components/button/">Button</a>（`disabledDetail` props 使用時））
-    - 各コンポーネントに関して
-        - LineClamp
-            - 折り返して表示することがどうしても難しい場合のみ使う
-        - SearchInput
-            - リトライするためのメッセージが見える場所に必ず表示されるようにしたうえで、Tooltipのメッセージは補助として使う
-        - Buttonの`disabledDetail`
-            - <a href="/products/components/dropdown/dropdown-menu-button/">DropdownMenuButton</a> で Buttonを使用するときに仕方なく使う
-            - Button単独の場合でも、ユーザーの操作過程で「確認が必ずしも必要ではない程度」の付加的な情報を表示する目的での使用は構わない
-            - 上記以外のケースはTooltipを使わずにdisabledである理由を見える場所に表示する
+### 例外
+- ユーザーの操作過程で「確認が必須ではない」程度の付加的な情報を表示する目的での使用
+- Tooltipによる表示が提供されているコンポーネントにおいて、利用基準に沿った使用
+  - [LineClamp](/products/components/line-clamp/)
+    - 折り返して表示することがどうしても難しい場合
+  - [SearchInput](/products/components/input/search-input/)
+    - 検索したキーワードに該当する情報がなかった場合、ユーザーへのフィードバックとして検索条件が見える場所に必ず表示されるようにしたうえで、補助としてTooltipのメッセージを使う場合
+  - [Button](/products/components/button/) の `disabledDetail` props 使用時
+    - [DropdownMenuButton](/products/components/dropdown/dropdown-menu-button/) 内のButtonで使う場合（配置できるスペースがドロップダウン内に限られるため仕方なく使う）
+    - Button単独の場合でも、ユーザーの操作過程で「確認が必須ではない」程度の付加的な情報を表示する目的で使う場合
+    - 上記以外のケースは、Tooltipを使わずにdisabledである理由を見える場所に表示する
 
 ## 種類
 Tooltipはトリガー要素に`focus`や`hover`で表示します。詳しくは[トリガーパターン](#h3-3)を参照してください。

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -59,7 +59,6 @@ Tooltip内の情報は隠れるため、操作に必要な情報の表示への�
         - Buttonの`disabledDetail`
             - <a href="/products/components/dropdown/dropdown-menu-button/">DropdownMenuButton</a> で Buttonを使用するときに仕方なく使う
             - 他のケースはTooltipを使わずにdisabledである理由を見える場所に表示する
-    - いずれにしても付加的な情報であれば使用しても構わない
 
 ## 種類
 Tooltipはトリガー要素に`focus`や`hover`で表示します。詳しくは[トリガーパターン](#h3-3)を参照してください。

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -49,11 +49,7 @@ Tooltip内の情報は隠れるため、操作に必要な情報の表示への�
 
 
 ### 推奨ではないが使用しても構わないケース
-- 付加的な情報を表示する目的での使用
-    - 付加的な情報とは
-        - ユーザーの操作過程で確認するテキストではない情報
-            - 例えば、閲覧時に確認するテキストは付加情報として捉えても良い
-        - 操作時に確認するものであっても、確認しなくても操作に影響しない情報
+- ユーザーの操作過程で「確認が必ずしも必要ではない程度」の付加的な情報を表示する目的での使用
 - 「SmartHR UI」 の <a href="/products/components/line-clamp/">LineClamp</a>、SearchInput、<a href="/products/components/button/">Button</a>（`disabledDetail` props 使用時）での使用
     - 各コンポーネントに関して
         - LineClamp

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -3,6 +3,7 @@ title: 'Tooltip'
 description: ''
 ---
 import {
+  BaseColumn,
   FaArrowAltCircleDownIcon,
   FaArrowAltCircleLeftIcon,
   FaArrowAltCircleRightIcon,
@@ -19,6 +20,13 @@ import { ComponentPreview } from '@Components/ComponentPreview'
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 
+<BaseColumn>
+  <WarningIcon text={
+    <span>
+  Tooltipは気づきにくいなどの課題があるため、安易な使用はお勧めしません。基本的にはTooltip以外のUIを使用することを検討してください。
+    </span>}
+    />
+</BaseColumn>
 
 Tooltipコンポーネントは、UI上のスペースが限られている場合に、補足テキストを一時的に表示するために使います。
 
@@ -37,6 +45,25 @@ Tooltip内の情報は隠れるため、操作に必要な情報の表示への�
 重要な情報とは、フォームの入力に必要な情報などが該当します。具体例は次の通りです。
 - パスワードに使用できる文字や、エラーになる入力値などの入力要件
 - 入力エラーとなった際のエラーメッセージ
+- 操作補助になる情報（ショートカットなど）
+
+
+### 推奨ではないが使用しても構わないケース
+- 付加的な情報を表示する目的での使用
+    - 付加的な情報とは
+        - ユーザーの操作過程で確認するテキストではない情報
+            - 例えば、閲覧時に確認するテキストは付加情報として捉えても良い
+        - 操作時に確認するものであっても、確認しなくても操作に影響しない情報
+- 「SmartHR UI」 の <a href="/products/components/line-clamp/">LineClamp</a>、SearchInput、<a href="/products/components/button/">Button</a>（`disabledDetail` props 使用時）での使用
+    - 各コンポーネントに関して
+        - LineClamp
+            - 折り返して表示することがどうしても難しい場合のみ使う
+        - SearchInput
+            - リトライするためのメッセージが見える場所に必ず表示されるようにしたうえで、Tooltipのメッセージは補助として使う
+        - Buttonの`disabledDetail`
+            - <a href="/products/components/dropdown/dropdown-menu-button/">DropdownMenuButton</a> で Buttonを使用するときに仕方なく使う
+            - 他のケースはTooltipを使わずにdisabledである理由を見える場所に表示する
+    - いずれにしても付加的な情報であれば使用しても構わない
 
 ## 種類
 Tooltipはトリガー要素に`focus`や`hover`で表示します。詳しくは[トリガーパターン](#h3-3)を参照してください。
@@ -48,7 +75,7 @@ Tooltipはトリガー要素に`focus`や`hover`で表示します。詳しく�
 1. [Tooltip](#h4-0)  
 2. [トリガー](#h4-1)
 
-![Tooltipによる補足情報の構成要素](./images/tooltip-overview.png)
+![Tooltipによる補足情報の構成要素](./images/Tooltip-overview.png)
 
 #### 1. Tooltip
 Tooltipそのものです。吹き出し形式で補足的なテキストを表示します。
@@ -242,6 +269,10 @@ export const DynamicTooltip = ({children, ...props}) => {
 何を対象とした補足説明なのかを明確にするために、可能な限り「[テキスト＋アイコン](#h4-6)」を採用することを推奨します。
 
 アイコンは、マウスオーバーが可能であることを示唆するためにリンク色（[`TEXT_LINK`](/products/design-tokens/color/#h2-2)）を使います。
+
+※アイコン単体で意味が伝わるようであれば、Tooltipは不要です。
+
+※アイコンに必ず代替テキストを設定します。
 
 ##### テキストとあわせて使用
 <ComponentPreview>

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -50,7 +50,7 @@ Tooltip内の情報は隠れるため、操作に必要な情報の表示への�
 
 ### 推奨ではないが使用しても構わないケース
 - ユーザーの操作過程で「確認が必ずしも必要ではない程度」の付加的な情報を表示する目的での使用
-- 「SmartHR UI」 の <a href="/products/components/line-clamp/">LineClamp</a>、SearchInput、<a href="/products/components/button/">Button</a>（`disabledDetail` props 使用時）での使用
+- Tooltipによる表示が提供されているコンポーネントにおいて、利用基準に沿った使用（<a href="/products/components/line-clamp/">LineClamp</a>、SearchInput、<a href="/products/components/button/">Button</a>（`disabledDetail` props 使用時））
     - 各コンポーネントに関して
         - LineClamp
             - 折り返して表示することがどうしても難しい場合のみ使う

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -58,7 +58,8 @@ Tooltip内の情報は隠れるため、操作に必要な情報の表示への�
             - リトライするためのメッセージが見える場所に必ず表示されるようにしたうえで、Tooltipのメッセージは補助として使う
         - Buttonの`disabledDetail`
             - <a href="/products/components/dropdown/dropdown-menu-button/">DropdownMenuButton</a> で Buttonを使用するときに仕方なく使う
-            - 他のケースはTooltipを使わずにdisabledである理由を見える場所に表示する
+            - Button単独の場合でも、ユーザーの操作過程で「確認が必ずしも必要ではない程度」の付加的な情報を表示する目的での使用は構わない
+            - 上記以外のケースはTooltipを使わずにdisabledである理由を見える場所に表示する
 
 ## 種類
 Tooltipはトリガー要素に`focus`や`hover`で表示します。詳しくは[トリガーパターン](#h3-3)を参照してください。

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -70,7 +70,7 @@ Tooltipはトリガー要素に`focus`や`hover`で表示します。詳しく�
 1. [Tooltip](#h4-0)  
 2. [トリガー](#h4-1)
 
-![Tooltipによる補足情報の構成要素](./images/Tooltip-overview.png)
+![Tooltipによる補足情報の構成要素](./images/tooltip-overview.png)
 
 #### 1. Tooltip
 Tooltipそのものです。吹き出し形式で補足的なテキストを表示します。


### PR DESCRIPTION
## 課題・背景

Tooltipはユーザビリティやアクセシビリティ観点での懸念点があるため、積極的使用するものではないと思っています。
デザインシステムの Tooltip のページでも「[使用上の注意](https://smarthr.design/products/components/tooltip/#h2-0)」として記載されています。
しかし、「スペースがないからTooltipにしよう」という判断が割とされやすい状況があるように感じています。
「絶対にTooltipを使用しないようにしよう」と言いたいわけではないのですが、「スペースをあまり使いたくない」という理由から即「tooltipを採用しよう！」という判断になることを避けたいなと思いました。

そこで、判断基準をより明確に定義するとわかりやすくなるのではないかと思い、PRを出しました。

[#design_system_相談](https://kufuinc.slack.com/archives/CJX59GJFR/p1700046626026089)でも相談させてもらっている件です。

<!--
issueをリンクしてね
-->

## やったこと

Tooltipに関する注意点をより具体化し、推奨ではないことが伝わりやすくしました。
[#design_system_相談](https://kufuinc.slack.com/archives/CJX59GJFR/p1700046626026089)で相談した内容を[SmartHRでのルール](https://smarthr-inc.docbase.io/posts/3184432#smarthr%E3%81%A7%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)にまとめ、その内容をデザインシステムに反映しています。


<!--
- 〇〇に追記
- 〇〇ページを追加

## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
- 
-->
## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
