### PR TITLE
記載例として適切じゃないページの削除

### DIFF
--- a/content/articles/products/contents/help-center/error-handling.mdx
+++ b/content/articles/products/contents/help-center/error-handling.mdx
@@ -47,8 +47,7 @@ order: 6
 見出し2と本文のスタイルを適用します。
 
 #### 記載例
-* [Q. PDF書類にPDFファイルがアップロードできません](https://support.smarthr.jp/ja/help/articles/900006399563)  
-* [Q. PDFファイルの一括アップロード画面でエラーが表示されたら？](https://support.smarthr.jp/ja/help/articles/4402948144153)  
+* [Q. 「書類の作成に失敗しました。必須項目の内容を確認してください。」と表示される場合は？](https://support.smarthr.jp/ja/help/articles/360047119273)  
 * [Q. 評価シート画面で「編集内容の保存に失敗しました。更新権限があるフォームの下書きが存在しません。」というエラーが出ました](https://support.smarthr.jp/ja/help/articles/4411286053273)  
 
 ## いくつかのエラーをまとめた記事の構成


### PR DESCRIPTION
## 課題・背景
- 去年、yunakさんとokeの全ページ修正・整理したことで「よくある質問」の例として適切じゃなくなったページがある

<!--
issueをリンクしてね
-->

## やったこと

- ２ページ分の例の削除
- 代わりに1ページの例を追加

<!--
- 〇〇に追記
- 〇〇ページを追加

## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
- 
-->
## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
