### PR TITLE
feat: font-familyに多言語の理由を追加

### DIFF
--- a/content/articles/products/design-tokens/typography.mdx
+++ b/content/articles/products/design-tokens/typography.mdx
@@ -16,7 +16,7 @@ export const Sampletext = ({size = 'M', children}) => {
 
 
 ## 書体
-ユーザーが慣れ親しんでいる環境を尊重し、以下の書体を指定します。
+ユーザーが慣れ親しんでいる環境を尊重し、またOSの設定に委ねることでさまざまな言語で正しくレンダリングされることを期待し、以下の書体を指定します。
 
 ```css codeBlock
 font-family: system-ui, sans-serif;


### PR DESCRIPTION
## 課題・背景

[タイポグラフィ | デザイントークン | SmartHR Design System](https://smarthr.design/products/design-tokens/typography/#h2-0)

書体の理由に、さまざまな言語で正しくレンダリングされることを追加

## やったこと

- 文章を追加

<!--
- 〇〇に追記
- 〇〇ページを追加

## やらなかったこと
- 
<!--
e.g.
- 見た目の調整
-->

## 動作確認

- ファイルでの確認で十分だよ。

## キャプチャ

|Before|After|
| --- | --- |
| <img width="737" alt="Beforeスクリーンショット「ユーザーが慣れ親しんでいる環境を尊重し、以下の書体を指定します。」" src="https://github.com/kufu/smarthr-design-system/assets/6724665/64a9120f-2389-42df-b136-f62de32ddf49"> | <img width="754" alt="Afterスクリーンショット「ユーザーが慣れ親しんでいる環境を尊重し、またOSの設定に委ねることでさまざまな言語で正しくレンダリングされることを期待し、以下の書体を指定します。」" src="https://github.com/kufu/smarthr-design-system/assets/6724665/c782a568-66e6-4205-bef0-b328dee98065"> |
