### PR TITLE
コンポーネント配下のページのdescriptionを追記

### DIFF
--- a/content/articles/products/components/app-navi.mdx
+++ b/content/articles/products/components/app-navi.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'AppNavi'
-description: ''
+description: 'プロダクト内の主要な機能を切り替えるためのコンポーネントです。機能の切り替えだけでなく、プロダクト全体に影響を及ぼす頻繁に行なう操作を埋め込めます。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/badge.mdx
+++ b/content/articles/products/components/badge.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Badge'
-description: ''
+description: '件数などの数値を視覚的に表すためのコンポーネントです。'
 ---
 
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/base/index.mdx
+++ b/content/articles/products/components/base/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Base'
-description: ' '
+description: '視覚的に他の要素と区別したい場合に使うコンポーネントです。'
 ---
 
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/bottom-fixed-area.mdx
+++ b/content/articles/products/components/bottom-fixed-area.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'BottomFixedArea'
-description: ''
+description: '画面下部に固定で表示する操作パネルです。項目ごとに画面を分けた機能など、連続した入力を求める場合に使用します。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/button.mdx
+++ b/content/articles/products/components/button.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Button'
-description: ' '
+description: 'ユーザーが情報の保存や検索などの操作をできるようにするコンポーネントです。'
 ---
 
 import { Button, Cluster, FaCaretDownIcon, FaCloudArrowDownIcon, FaFilterIcon, FaCirclePlusIcon } from 'smarthr-ui'

--- a/content/articles/products/components/calendar.mdx
+++ b/content/articles/products/components/calendar.mdx
@@ -1,11 +1,12 @@
 ---
 title: 'Calendar'
-description: ''
+description: 'カレンダーを表示し日付を選択するためのコンポーネントです。基本的にはDatePickerと合わせて使用されるため、単独で使用することはありません。
+'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 
-Calendarコンポーネントは、カレンダーを表示し日付を選択するためのコンポーネントです。基本的には<a href="/products/components/date-picker/">DatePicker</a>と合わせて使用されるため、単独で使用することはありません。
+Calendarコンポーネントは、カレンダーを表示し日付を選択するためのコンポーネントです。基本的には[DatePicker](/products/components/date-picker/)と合わせて使用されるため、単独で使用することはありません。
 
 <ComponentStory name="Calendar" />
 

--- a/content/articles/products/components/check-box.mdx
+++ b/content/articles/products/components/check-box.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'CheckBox'
-description: ''
+description: "input[type='checkbox']要素の代わりに使用するコンポーネントです。"
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 
-`input[type="checkbox"]` の代わりに使用するコンポーネントです。見た目をやや大きく変えているだけでほぼ機能に変わりありません。
+`input[type="checkbox"]`の代わりに使用するコンポーネントです。見た目をやや大きく変えているだけでほぼ機能に変わりありません。
 
 <ComponentStory name="CheckBox" />
 

--- a/content/articles/products/components/combo-box.mdx
+++ b/content/articles/products/components/combo-box.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'ComboBox'
-description: ''
+description: '選択肢をリスト形式で持ち、ユーザーが入力によって選択肢を絞り込んだり追加したりできるコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/date-picker.mdx
+++ b/content/articles/products/components/date-picker.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'DatePicker'
-description: ''
+description: "input[type='date']要素の代わりに使用するコンポーネントです。この要素にフォーカスするとCalendarが開き、視覚的に日付を選択できます。"
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-`input[type="date"]` の代わりに使用するコンポーネントです。この要素にフォーカスすると [Calendar](./calendar) が開き、視覚的に日付を選択できます。
+`input[type="date"]`の代わりに使用するコンポーネントです。この要素にフォーカスすると[Calendar](/products/components/calendar/)が開き、視覚的に日付を選択できます。
 
 和暦による入力に対応するため独自で作成しています。例えば、「令和4年12月3日」という日付を入力欄に貼り付けると「2022-12-03」に変換する機能を備えています。
 

--- a/content/articles/products/components/definition-list.mdx
+++ b/content/articles/products/components/definition-list.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'DefinitionList'
-description: ''
+description: '見出しと説明がセットになった定義リストです。特定のデータを一覧して参照させたいときに使います。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/dialog.mdx
+++ b/content/articles/products/components/dialog.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Dialog'
-description: ' '
+description: 'ユーザーに集中してほしい確認や操作を表示するためのコンポーネントです。'
 ---
 
 import { ComponentPreview } from '@Components/ComponentPreview'

--- a/content/articles/products/components/drop-zone.mdx
+++ b/content/articles/products/components/drop-zone.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'DropZone'
-description: ''
+description: 'ファイルを選択するためのコンポーネントです。ドラッグアンドドロップによるファイル選択をするためにドロップ領域を広く持っています。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/dropdown/dropdown-menu-button.mdx
+++ b/content/articles/products/components/dropdown/dropdown-menu-button.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'DropdownMenuButton'
-description: ''
+description: '複数の操作をまとめて提供するためのコンポーネントで、パネル内には操作がリスト形式で表示されます。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 import { FaCaretDownIcon, FaEllipsisHIcon } from 'smarthr-ui'
 
-DropdownMenuButton は複数の操作をまとめて提供するためのコンポーネントで、パネル内には操作がリスト形式で表示されます。
+DropdownMenuButtonは複数の操作をまとめて提供するためのコンポーネントで、パネル内には操作がリスト形式で表示されます。
 
 <ComponentStory name="DropdownMenuButton" />
 

--- a/content/articles/products/components/dropdown/filter-dropdown.mdx
+++ b/content/articles/products/components/dropdown/filter-dropdown.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'FilterDropdown'
-description: ''
+description: '一覧の絞り込みを行なうためのコンポーネントで、パネル内に自由に入力要素を配置できるほか、絞り込みを適用したり解除したりするための機能も有しています。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-FilterDropdown は一覧の絞り込みを行なうためのコンポーネントで、パネル内に自由に入力要素を配置できるほか、絞り込みを適用したり解除したりするための機能も有しています。
+FilterDropdownは一覧の絞り込みを行なうためのコンポーネントで、パネル内に自由に入力要素を配置できるほか、絞り込みを適用したり解除したりするための機能も有しています。
 
 <ComponentStory name="FilterDropdown" />
 

--- a/content/articles/products/components/dropdown/index.mdx
+++ b/content/articles/products/components/dropdown/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Dropdown'
-description: ''
+description: 'ボタンを押すとパネルが開く機能の抽象コンポーネントです。パネルを開くための引き金となるDropdownTriggerとパネル自体を指すDropdownContentから構成されます。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-ボタンを押すとパネルが開く機能の抽象コンポーネントです。大きく分けるとパネルを開くための引き金となる DropdownTrigger とパネル自体を指す DropdownContent から構成されます。
+ボタンを押すとパネルが開く機能の抽象コンポーネントです。大きく分けるとパネルを開くための引き金となるDropdownTriggerとパネル自体を指すDropdownContentから構成されます。
 
 ## Dropdown を使用したコンポーネント
 

--- a/content/articles/products/components/dropdown/sort-dropdown.mdx
+++ b/content/articles/products/components/dropdown/sort-dropdown.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'SortDropdown'
-description: ''
+description: '主に表の並べ替え操作を統一するためのコンポーネントです。並べ替え項目と並び順を指定でき、ボタンラベルとアイコンで現在の並び順を表します。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/field-set.mdx
+++ b/content/articles/products/components/field-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'FieldSet（非推奨）'
-description: ''
+description: 'FieldSetコンポーネントは非推奨です。Fieldsetコンポーネントを使用してください。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/fieldset.mdx
+++ b/content/articles/products/components/fieldset.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Fieldset'
-description: ''
+description: 'フォームにおける複数の入力要素をグルーピングするためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/flash-message.mdx
+++ b/content/articles/products/components/flash-message.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'FlashMessage（非推奨）'
-description: ' '
+description: 'FlashMessageは気づきにくいため、安易な使用はお勧めしません。NotificationBarやDialogの使用を検討してください。'
 ---
 
 import { ComponentPreview } from '@Components/ComponentPreview'
@@ -18,7 +18,7 @@ import {
 <BaseColumn>
   <WarningIcon text={
     <span>
-  FlashMessageは気づきにくいため、安易な使用はお勧めしません。<a href="/products/components/notification-bar/">NotificationBar</a>や<a href="/products/components/dialog/">Dialog</a>の使用を検討してください。
+    FlashMessageは気づきにくいため、安易な使用はお勧めしません。<a href="/products/components/notification-bar/">NotificationBar</a>や<a href="/products/components/dialog/">Dialog</a>の使用を検討してください。
     </span>}
     />
 </BaseColumn>

--- a/content/articles/products/components/float-area.mdx
+++ b/content/articles/products/components/float-area.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'FloatArea'
-description: ''
+description: 'BottomFixedAreaから派生した、より配置の自由度が高いコンポーネントです。画面下部固定ではなく、浮遊しています。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-[BottomFixedArea](../bottom-fixed-area/) から派生した、より配置の自由度が高いコンポーネントです。画面下部固定ではなく、浮遊しています。
+[BottomFixedArea](/products/components/bottom-fixed-area/)から派生した、より配置の自由度が高いコンポーネントです。画面下部固定ではなく、浮遊しています。
 
 <ComponentStory name="FloatArea" />
 

--- a/content/articles/products/components/form-control.mdx
+++ b/content/articles/products/components/form-control.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'FormControl'
-description: ''
+description: 'フォームとしての入力要素に対応するラベルとメッセージテキストを表示するためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/form-group.mdx
+++ b/content/articles/products/components/form-group.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'FormGroup（非推奨）'
-description: ''
+description: 'FormGroupコンポーネントは非推奨です。FormControlかFieldsetコンポーネントを使用してください。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/header.mdx
+++ b/content/articles/products/components/header.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Header'
-description: ''
+description: 'プロダクトをまたいでSmartHRをブラウジングしていることをユーザーが認知するためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-プロダクトをまたいで SmartHRをブラウジングしていることをユーザーが認知するためのコンポーネントです。企業アカウントの切り替えやグローバルな機能の切り替えなどを埋め込めます。
+プロダクトをまたいでSmartHRをブラウジングしていることをユーザーが認知するためのコンポーネントです。企業アカウントの切り替えやグローバルな機能の切り替えなどを埋め込めます。
 
 <ComponentStory name="Header" />
 

--- a/content/articles/products/components/heading.mdx
+++ b/content/articles/products/components/heading.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Heading'
-description: ''
+description: '直後に続くコンテンツの見出しに使うコンポーネントです。'
 ---
 
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/icon.mdx
+++ b/content/articles/products/components/icon.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Icon'
-description: ' '
+description: 'アイデアやアクションを表すための視覚的な要素を表示するためのコンポーネントです。'
 ---
 
 import { ComponentPreview } from '@Components/ComponentPreview'
@@ -13,7 +13,7 @@ import {
 } from 'smarthr-ui'
 
 Iconコンポーネントは、アイデアやアクションを表すための視覚的な要素です。  
-一目でメッセージを伝え、重要な情報への注意を促します。適切なアイコンは、認知を手助けします。
+一目でメッセージを伝え、重要な情報への注意を促します。適切なアイコンは認知を手助けします。
 
 <ComponentStory name="Icon" />
 

--- a/content/articles/products/components/index.mdx
+++ b/content/articles/products/components/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'コンポーネント'
-description: ''
+description: 'SmartHRのUIコンポーネント「SmartHR UI」は、オープンソースとして開発しています。'
 order: 3
 ---
 

--- a/content/articles/products/components/information-panel.mdx
+++ b/content/articles/products/components/information-panel.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'InformationPanel'
-description: ''
+description: 'ユーザーに情報を伝えるために、他の要素より視覚的に目立たせるためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/input-file.mdx
+++ b/content/articles/products/components/input-file.mdx
@@ -5,7 +5,7 @@ description: "input[type='file']要素の代わりに使用するコンポーネ
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-`input[type="file"]` の代わりに使用するコンポーネントです。[DropZone](/products/components/drop-zone/)の内部でも使用されています。
+`input[type="file"]`の代わりに使用するコンポーネントです。[DropZone](/products/components/drop-zone/)の内部でも使用されています。
 
 <ComponentStory name="InputFile" />
 

--- a/content/articles/products/components/input-file.mdx
+++ b/content/articles/products/components/input-file.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'InputFile'
-description: ''
+description: "input[type='file']要素の代わりに使用するコンポーネントです。DropZoneの内部でも使用されています。"
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-`input[type="file"]` の代わりに使用するコンポーネントです。[DropZone](../drop-zone/) の内部でも使用されています。
+`input[type="file"]` の代わりに使用するコンポーネントです。[DropZone](/products/components/drop-zone/)の内部でも使用されています。
 
 <ComponentStory name="InputFile" />
 

--- a/content/articles/products/components/input/index.mdx
+++ b/content/articles/products/components/input/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Input'
-description: ''
+description: 'input要素の代わりに使用するコンポーネントです。入力欄の前後にアイコンを入れられます。'
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 
-`input` の代わりに使用するコンポーネントです。入力欄の前後にアイコンを入れられます。
+`input`の代わりに使用するコンポーネントです。入力欄の前後にアイコンを入れられます。
 
 <ComponentStory name="Input" />
 

--- a/content/articles/products/components/input/search-input.mdx
+++ b/content/articles/products/components/input/search-input.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'SearchInput'
-description: ''
+description: '検索欄のためのInputコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-検索欄のための [Input](../) です。
+検索欄のための[Input](/products/components/input/)です。
 
 <ComponentStory name="SearchInput" />
 

--- a/content/articles/products/components/layout/index.mdx
+++ b/content/articles/products/components/layout/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'Layout'
-description: ''
+description: 'レイアウトのためのコンポーネントです。Every Layoutを参考に作成しています。'
 ---
 import { PageIndex } from '@Components/article/PageIndex'
 
-レイアウトのためのコンポーネントです。[Every Layout](https://every-layout.dev/) を参考に作成しています。
+レイアウトのためのコンポーネントです。[Every Layout](https://every-layout.dev/)を参考に作成しています。
 
 これらのコンポーネントは主に余白を管理しています。内部的には余白のデザイントークンを使用しています。
 

--- a/content/articles/products/components/line-clamp.mdx
+++ b/content/articles/products/components/line-clamp.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'LineClamp'
-description: ''
+description: '内包するテキストが指定した幅や高さを越えて存在するときに、Tooltipを用いて全文を表示するためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-内包するテキストが指定した幅や高さを越えて存在するときに、[Tooltip](/products/components/tooltip/) を用いて全文を表示するためのコンポーネントです。
+内包するテキストが指定した幅や高さを越えて存在するときに、[Tooltip](/products/components/tooltip/)を用いて全文を表示するためのコンポーネントです。
 
 <ComponentStory name="LineClamp" />
 

--- a/content/articles/products/components/loader.mdx
+++ b/content/articles/products/components/loader.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Loader'
-description: ''
+description: '読み込み中や操作中など何らかの操作が仕掛り中であることを伝えるためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/message-screen.mdx
+++ b/content/articles/products/components/message-screen.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'MessageScreen（非推奨）'
-description: ''
+description: 'MessageScreenコンポーネントは非推奨です。ErrorScreenコンポーネントを使用してください。'
 ---
 import { BaseColumn, WarningIcon } from 'smarthr-ui'
 

--- a/content/articles/products/components/notification-bar.mdx
+++ b/content/articles/products/components/notification-bar.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'NotificationBar'
-description: 'NotificationBarは、ユーザーへ伝えたいフィードバックやメッセージを伝えるために使います。'
+description: 'ユーザーへ伝えたいフィードバックやメッセージを伝えるために使うコンポーネントです。'
 ---
 import { useEffect, useState } from 'react'
 import { ComponentPreview } from '@Components/ComponentPreview'
@@ -9,7 +9,7 @@ import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { NotificationBar, Button, Stack} from 'smarthr-ui'
 import { VideoEmbed } from '@Components/article/VideoEmbed/VideoEmbed'
 
-NotificationBarは、フィードバックやメッセージを伝えるために使います。
+NotificationBarコンポーネントは、フィードバックやメッセージを伝えるために使います。
 
 * 操作後に、ダイアログ内や画面全体が切り替わるとき
 * ダイアログで操作し、元の画面に戻るとき

--- a/content/articles/products/components/pagination.mdx
+++ b/content/articles/products/components/pagination.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Pagination'
-description: ''
+description: '主に表形式の一覧におけるページを切り替えるためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/radio-button.mdx
+++ b/content/articles/products/components/radio-button.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'RadioButton'
-description: ''
+description: "input[type='radio']要素の代わりに使用するコンポーネントです。"
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
 
-`input[type="radio"]` の代わりに使用するコンポーネントです。見た目をやや大きく変えているだけでほぼ機能に変わりありません。
+`input[type="radio"]`の代わりに使用するコンポーネントです。見た目をやや大きく変えているだけでほぼ機能に変わりありません。
 
 <ComponentStory name="RadioButton" />
 

--- a/content/articles/products/components/range-separator.mdx
+++ b/content/articles/products/components/range-separator.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'RangeSeparator'
-description: ''
+description: '期間や範囲を表すためのコンポーネントです。〜 や – といった文字に適切な意味を与えられます。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/response-message.mdx
+++ b/content/articles/products/components/response-message.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'ResponseMessage'
-description: ''
+description: '操作に対する結果を表すためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/sectioning-content.mdx
+++ b/content/articles/products/components/sectioning-content.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'SectioningContent'
-description: ''
+description: 'header要素やfooter要素、見出しの範囲を定義するためのコンポーネントです。Headingと組み合わせて使うと、見出しレベルを自動計算します。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-header要素やfooter要素、見出しの範囲を定義するためのコンポーネントです。[Heading](/products/components/heading/)と組み合わせて使うと、見出しレベルを自動計算します。
+`header`や`footer`、見出しの範囲を定義するためのコンポーネントです。[Heading](/products/components/heading/)と組み合わせて使うと、見出しレベルを自動計算します。
 
 <ComponentStory name="SectioningContent" />
 

--- a/content/articles/products/components/select.mdx
+++ b/content/articles/products/components/select.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Select'
-description: ''
+description: 'select要素の代わりに使用するコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-`select` の代わりに使用するコンポーネントです。[Input](/products/components/input/) と見た目を揃えるために存在します。
+`select`の代わりに使用するコンポーネントです。[Input](/products/components/input/)と見た目を揃えるために存在します。
 
 <ComponentStory name="Select" />
 

--- a/content/articles/products/components/spreadsheet-table.mdx
+++ b/content/articles/products/components/spreadsheet-table.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'SpreadsheetTable'
-description: '表データを表計算のように表示します。CSVのインポートなど、利用者にCSVファイルを想像させたい場面で有効です。'
+description: '表データを表計算ソフトのように表示します。CSVのインポートなど、利用者にCSVファイルを想像させたい場面で有効です。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/spreadsheet-table.mdx
+++ b/content/articles/products/components/spreadsheet-table.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'SpreadsheetTable'
-description: ''
+description: '表データを表計算のように表示します。CSVのインポートなど、利用者にCSVファイルを想像させたい場面で有効です。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-SpreadsheetTableコンポーネントは、表データを表計算のように表示します。CSV のインポートなど、利用者に CSV ファイルを想像させたい場面で有効です。
+SpreadsheetTableコンポーネントは、表データを表計算のように表示します。CSVのインポートなど、利用者にCSVファイルを想像させたい場面で有効です。
 
 <ComponentStory name="SpreadsheetTable" />
 

--- a/content/articles/products/components/spreadsheet-table.mdx
+++ b/content/articles/products/components/spreadsheet-table.mdx
@@ -5,7 +5,7 @@ description: '表データを表計算ソフトのように表示します。CSV
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-SpreadsheetTableコンポーネントは、表データを表計算のように表示します。CSVのインポートなど、利用者にCSVファイルを想像させたい場面で有効です。
+SpreadsheetTableコンポーネントは、表データを表計算ソフトのように表示します。CSVのインポートなど、利用者にCSVファイルを想像させたい場面で有効です。
 
 <ComponentStory name="SpreadsheetTable" />
 

--- a/content/articles/products/components/status-label.mdx
+++ b/content/articles/products/components/status-label.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'StatusLabel'
-description: ''
+description: 'オブジェクトの状態を伝えるためのこのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/switch.mdx
+++ b/content/articles/products/components/switch.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Switch'
-description: ''
+description: 'オン・オフを切り替えるコンポーネントです。状態の切り替えは即時で反映されます。'
 ---
 
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'

--- a/content/articles/products/components/tab-bar.mdx
+++ b/content/articles/products/components/tab-bar.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'TabBar'
-description: ''
+description: '特定のオブジェクトに紐づく同じ性質のものを並べて切り替えるためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/table.mdx
+++ b/content/articles/products/components/table.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Table'
-description: ''
+description: '表形式でデータを表示するためのコンポーネントです。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/text-link.mdx
+++ b/content/articles/products/components/text-link.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'TextLink'
-description: ''
+description: 'a要素の代わりに使用するコンポーネントです。前後にアイコンを差し込めます。またリンクであることを表すために下線を強制します。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-`a` 要素の代わりに使用するコンポーネントです。前後にアイコンを差し込めます。またリンクであることを表すために下線を強制します。
+`a`の代わりに使用するコンポーネントです。前後にアイコンを差し込めます。またリンクであることを表すために下線を強制します。
 
 <ComponentStory name="TextLink" />
 

--- a/content/articles/products/components/text.mdx
+++ b/content/articles/products/components/text.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Text'
-description: ''
+description: 'テキストを表示するためのコンポーネントです。タイポグラフィのデザイントークンを使用しています。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'

--- a/content/articles/products/components/textarea.mdx
+++ b/content/articles/products/components/textarea.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Textarea'
-description: ''
+description: 'textarea要素の代わりに使用するコンポーネントです。入力文字数を数える機能や入力に依って自動で領域が広がる機能を備えています。'
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
 
-`textarea` の代わりに使用するコンポーネントです。入力文字数を数える機能や入力に依って自動で領域が広がる機能を備えています。
+`textarea`の代わりに使用するコンポーネントです。入力文字数を数える機能や入力に依って自動で領域が広がる機能を備えています。
 
 <ComponentStory name="Textarea" />
 

--- a/content/articles/products/components/tooltip.mdx
+++ b/content/articles/products/components/tooltip.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Tooltip'
-description: ''
+description: 'UI上のスペースが限られている場合に、補足テキストを一時的に表示するために使うコンポーネントです。'
 ---
 import {
   BaseColumn,
@@ -23,7 +23,7 @@ import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 <BaseColumn>
   <WarningIcon text={
     <span>
-  Tooltipはユーザーが能動的に表示しなければならない、拡大表示時に領域外に表示されてしまうなどの課題があるため、安易な使用はお勧めしません。基本的にはTooltip以外のUIを使用することを検討してください。
+    Tooltipはユーザーが能動的に表示しなければならない、拡大表示時に領域外に表示されてしまうなどの課題があるため、安易な使用はお勧めしません。基本的にはTooltip以外のUIを使用することを検討してください。
     </span>}
     />
 </BaseColumn>


### PR DESCRIPTION
## 課題・背景

<!--
issueをリンクしてね
-->

## やったこと

- これまでmeta要素のdescriptionに表示するテキストを個別に設定していなかったが、 #1100 にて多数ページの本文に概要を示す文章が追加されたため、descriptionのテキストに活用して埋めた。
- 表記の揺れや半角スペースを細かく整えたりした。

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと

- 作業時点で概要文がないページは対象にしていません。
- コンポーネント配下以外のページは触っていません。

<!--
e.g.
- 見た目の調整
-->

## 動作確認

- Previewでみてね。
- ソースを読んだり、Slackなどに貼り付けて概要を表示してみてください。

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
