### PR TITLE
StatusLabelのコンポーネントのガイドラインに使用上の注意を追加する

### DIFF
--- a/content/articles/products/components/status-label.mdx
+++ b/content/articles/products/components/status-label.mdx
@@ -9,6 +9,15 @@ import { ComponentStory } from '@Components/ComponentStory'
 
 <ComponentStory name="StatusLabel" />
 
+## 使用上の注意
+### オブジェクト名自体をStatusLabelで表現しない
+
+StatusLabelはオブジェクトの状態を伝えるために利用し、オブジェクト名そのものをStatusLabelで表現しないでください。
+
+### StatusLabelをリンクやアクションボタンの代替にしない
+
+StatusLabel単体でリンクやアクションボタンの機能を持たないようにしてください。オブジェクト名とStatusLabelをまとめてリンクとする場合は許容します。
+
 ## 種類
 
 特殊なステータスを表す場合は、背景色に警告色やエラー色を使います。  
@@ -101,15 +110,6 @@ import { ComponentStory } from '@Components/ComponentStory'
 #### 例
 - `差し戻し`、`要○○`：ユーザーがアクションを取ったが、管理者などの第三者が確認した結果、不備があったため、やり直しを依頼している状態
 - `失敗`、`○○失敗`：ユーザーがアクションを取ったが、不備によりシステムエラーが発生し、処理が完了しなかった状態
-
-## 使用上の注意
-### オブジェクト名自体をStatusLabelで表現しない
-
-StatusLabelはオブジェクトの状態を伝えるために利用し、オブジェクト名そのものをStatusLabelで表現しないでください。
-
-### StatusLabelをリンクやアクションボタンの代替にしない
-
-StatusLabel単体でリンクやアクションボタンの機能を持たないようにしてください。オブジェクト名とStatusLabelをまとめてリンクとする場合は許容します。
 
 ## Props
 

--- a/content/articles/products/components/status-label.mdx
+++ b/content/articles/products/components/status-label.mdx
@@ -102,6 +102,15 @@ import { ComponentStory } from '@Components/ComponentStory'
 - `差し戻し`、`要○○`：ユーザーがアクションを取ったが、管理者などの第三者が確認した結果、不備があったため、やり直しを依頼している状態
 - `失敗`、`○○失敗`：ユーザーがアクションを取ったが、不備によりシステムエラーが発生し、処理が完了しなかった状態
 
+## 使用上の注意
+### オブジェクト名自体をStatusLabelで表現しない
+
+StatusLabelはオブジェクトの状態を伝えるために利用し、オブジェクト名そのものをStatusLabelで表現しないでください。
+
+### StatusLabelをリンクやアクションボタンの代替にしない
+
+StatusLabel単体でリンクやアクションボタンの機能を持たないようにしてください。オブジェクト名とStatusLabelをまとめてリンクとする場合は許容します。
+
 ## Props
 
 <ComponentPropsTable name="StatusLabel" />


### PR DESCRIPTION
## 課題・背景

## やったこと

StatusLabelコンポーネントのガイドラインに使用上の注意を追加しました。
https://deploy-preview-1131--smarthr-design-system.netlify.app/products/components/status-label

パッと思いついたものを記述しました。過不足ふくめレビューお願いいたします。