### PR TITLE
Textの内容を充実、デザイントークンからリンク

### DIFF
--- a/content/articles/products/components/text.mdx
+++ b/content/articles/products/components/text.mdx
@@ -9,6 +9,105 @@ import { ComponentStory } from '@Components/ComponentStory'
 
 <ComponentStory name="Text" />
 
+## 使用上の注意
+
+### 入れ子にしたときの出力要素に注意する
+
+デフォルトの出力要素は`<span>`になるため、入れ子にしたときにValidなHTMLになるように注意してください。
+
+```tsx editable codeBlock
+<Text as="p">
+  <Text emphasis>入れ子</Text>にしたときに
+  <Text color="TEXT_GREY" weight="bold">
+    Valid
+  </Text>
+  なHTMLになるように注意してください。
+</Text>
+```
+
+## 種類
+
+### フォントサイズ
+`size` propsで指定できます。値は[タイポグラフィのフォントサイズ](/products/design-tokens/typography/#h2-1)のデザイントークンを参照してください。
+
+```tsx editable codeBlock
+<Stack>
+  <Text size="XXS">XXSサイズのテキスト</Text>
+  <Text size="XS">XSサイズのテキスト</Text>
+  <Text size="S">Sサイズのテキスト</Text>
+  <Text size="M">Mサイズのテキスト</Text>
+  <Text size="L">Lサイズのテキスト</Text>
+  <Text size="XL">XLサイズのテキスト</Text>
+  <Text size="XXL">XXLサイズのテキスト</Text>
+</Stack>
+```
+
+### ウェイト
+`weight` propsで指定できます。
+
+```tsx editable codeBlock
+<Stack>
+  <Text weight="normal">通常のテキスト</Text>
+  <Text weight="bold">太字のテキスト</Text>
+</Stack>
+```
+
+### 強調、イタリック体
+`emphasis` props、`italic` propsで指定できます。
+
+```tsx editable codeBlock
+<Stack>
+  <Text emphasis>強調されたテキスト</Text>
+  <Text italic>イタリック体のテキスト</Text>
+</Stack>
+```
+
+### 色
+`color` propsで指定できます。値は[色の文字](/products/design-tokens/color/#h3-2)のデザイントークンを参照してください。
+
+```tsx editable codeBlock
+<Stack>
+  <Text color="TEXT_BLACK">色がTEXT_BLACKのテキスト</Text>
+  <Text color="TEXT_GREY">色がTEXT_GREYのテキスト</Text>
+  <Text color="TEXT_LINK">色がTEXT_LINKのテキスト</Text>
+  <Text color="TEXT_DISABLED">色がTEXT_DISABLEDなテキスト</Text>
+  <Text color="TEXT_WHITE">色がTEXT_WHITEのテキスト</Text>
+</Stack>
+```
+
+### 行送り
+`leading` propsで指定できます。値は[行送り](/products/design-tokens/leading/)のデザイントークンを参照してください。
+
+```tsx editable codeBlock
+<Stack>
+  <Text leading="NONE">行送りがないテキスト<br />行送りがないテキスト</Text>
+  <Text leading="TIGHT">行送りが狭いテキスト<br />行送りが狭いテキスト</Text>
+  <Text leading="NORMAL">通常の行送りのテキスト<br />通常の行送りのテキスト</Text>
+  <Text leading="RELEXED">行送りが広いテキスト<br />行送りが広いテキスト</Text>
+</Stack>
+```
+
+### 折り返し
+`whiteSpace` propsで指定できます。
+
+
+### 見出しスタイル
+`styleType` propsで指定できます。
+
+[Headingコンポーネント](/products/components/heading/)の種類に合わせた見た目（フォントサイズ、ウェイト、色）を提供しますが、見出しとして使う場合はTextではなくHeadingを使用してください。
+
+```tsx editable codeBlock
+<Stack>
+  <Text styleType="screenTitle">画面タイトルの見た目のテキスト</Text>
+  <Text styleType="sectionTitle">セクションタイトルの見た目のテキスト</Text>
+  <Text styleType="blockTitle">ブロックタイトルの見た目のテキスト</Text>
+  <Text styleType="subBlockTitle">サブ・ブロックタイトルの見た目のテキスト</Text>
+  <Text styleType="subSubBlockTitle">サブ・サブ・ブロックタイトルの見た目のテキスト</Text>
+</Stack>
+```
+
+
+
 ## Props
 
 <ComponentPropsTable name="Text" />

--- a/content/articles/products/design-tokens/leading.mdx
+++ b/content/articles/products/design-tokens/leading.mdx
@@ -5,7 +5,9 @@ order: 9
 ---
 行送りトークンは、行ボックスの高さを定義します。
 
-CSSでは`line-height`を指しています。
+CSSでは`line-height`を指しています。  
+テキストに行送りを指定する場合は、[Textコンポーネント](/products/components/text/)を使用します。
+
 
 ## セマンティックトークン
 
@@ -13,7 +15,7 @@ CSSでは`line-height`を指しています。
 | :--- | :--- | :--- |
 | `NONE`    | 1    | [ラベルテキスト](/products/design-tokens/typography/#h3-4) |
 | `TIGHT`   | 1.25 | [Dialogのタイトル](/products/components/dialog/)、[Heading](/products/components/heading/)、[NotificationBar](/products/components/notification-bar/) |
-| `NORMAL`  | 1.5  | [段落テキスト](/products/design-tokens/typography/#h3-3) |
+| `NORMAL`（標準）  | 1.5  | [段落テキスト](/products/design-tokens/typography/#h3-3) |
 | `RELAXED` | 1.75 | |
 
 ## ［WIP］コード

--- a/content/articles/products/design-tokens/typography.mdx
+++ b/content/articles/products/design-tokens/typography.mdx
@@ -25,6 +25,8 @@ font-family: system-ui, sans-serif;
 ## フォントサイズ
 基準値は`16px`です。
 
+[Textコンポーネント](/products/components/text/)を使うと、セマンティックトークンを使ってテキストのフォントサイズを指定できます。
+
 ### セマンティックトークン
 
 | トークン名 | 値（rem）| 基準値をもとにした実値（px）|
@@ -32,7 +34,7 @@ font-family: system-ui, sans-serif;
 | `XXS` | 0.667rem | 10.67px |
 | `XS` | 0.75rem | 12px |
 | `S` | 0.857rem | 13.71px |
-| `M` | 1rem | 16px |
+| `M`（標準） | 1rem | 16px |
 | `L` | 1.2rem | 19.2px |
 | `XL` | 1.5rem | 24px |
 | `XXL` | 2rem | 32px |
@@ -70,7 +72,8 @@ font-family: system-ui, sans-serif;
 ## テキストスタイル
 
 ### 見出し
-[Headingコンポーネント](/products/components/heading/)を参照してください。
+[Headingコンポーネント](/products/components/heading/)を参照してください。  
+行送りは、フォントサイズの1.25倍（[`TIGHT`](/products/design-tokens/leading/)）です。
 
 ### 段落テキスト
 段落テキストに使用し、強調やリンクのスタイルを併せてとることがあります。  
@@ -143,8 +146,10 @@ font-family: system-ui, sans-serif;
 - 表の見出し（`th`）の文字揃えは、データ（`td`）の文字揃えに合わせます。
 - 表のデータに数字を表示する場合は、列を縦に読んだときに桁数を比較できるように右揃えにします。
 
-### 強調
-WIP
+### ウェイト、強調
+テキストにウェイトや強調を指定する場合は、[Textコンポーネント](/products/components/text/)を使用します。
+
+[Headingコンポーネント](/products/components/heading/)の見出しのスタイルの一部や、[Buttonコンポーネント](/products/components/button/)のラベルテキストが太字を指定しているように、コンポーネントがウェイトも含めて提供している場合もあります。
 
 ### リンク
 テキストリンクは、以下の場合に[TextLinkコンポーネント](/products/components/text-link/)を使用して表します。  


### PR DESCRIPTION
## 課題・背景

https://smarthr.atlassian.net/browse/SD-692

## やったこと
- コンポーネントとして利用頻度がNo.1のTextのページを充実
  - Storybookにあった注意点を「使用上の注意」に転記
  - propsの説明と実装例を追加
- デザイントークンのページからTextにリンク
  - タイポグラフィ
    - ついでにWIPだった「強調」を埋めた
  - 行送り

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- なし

<!--
e.g.
- 見た目の調整
-->

## 動作確認

- Previewでみてね。
  - https://deploy-preview-1142--smarthr-design-system.netlify.app/products/components/text/
  - https://deploy-preview-1142--smarthr-design-system.netlify.app/products/design-tokens/typography/
  - https://deploy-preview-1142--smarthr-design-system.netlify.app/products/design-tokens/leading/


## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
