### PR TITLE
CompactInformationPanelを非推奨にする

### DIFF
--- a/content/articles/products/components/compact-information-panel.mdx
+++ b/content/articles/products/components/compact-information-panel.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'CompactInformationPanel（非推奨）'
-description: "CompactInformationPanelは、NotificationBar[base='base']で代替が可能になったため非推奨です。"
+description: "ユーザーに情報を伝えるために、他の要素より視覚的に目立たせるためのInformationPanelよりもコンパクトなコンポーネントです。NotificationBar[base='base']で代替が可能になったため非推奨です。"
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
@@ -13,6 +13,11 @@ import { BaseColumn, WarningIcon } from 'smarthr-ui'
     </span>}
     />
 </BaseColumn>
+
+ユーザーに情報を伝えるために、他の要素より視覚的に目立たせるための[InformationPanel](/products/components/information-panel/)よりもコンパクトなコンポーネントです。
+InformationPanelとは異なり、パネルを閉じることはできません。
+
+伝えたい情報の種類によってアイコンを切り替えて使います。
 
 <ComponentStory name="CompactInformationPanel" />
 

--- a/content/articles/products/components/compact-information-panel.mdx
+++ b/content/articles/products/components/compact-information-panel.mdx
@@ -1,9 +1,18 @@
 ---
-title: 'CompactInformationPanel'
-description: ''
+title: 'CompactInformationPanel（非推奨）'
+description: "CompactInformationPanelは、NotificationBar[base='base']で代替が可能になったため非推奨です。"
 ---
 import { ComponentStory } from '@Components/ComponentStory'
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
+import { BaseColumn, WarningIcon } from 'smarthr-ui'
+
+<BaseColumn>
+  <WarningIcon text={
+    <span>
+    CompactInformationPanelは<a href="/products/components/notification-bar/">NotificationBar[base="base"]</a>で代替が可能になったため非推奨です。
+    </span>}
+    />
+</BaseColumn>
 
 <ComponentStory name="CompactInformationPanel" />
 

--- a/content/articles/products/components/compact-information-panel.mdx
+++ b/content/articles/products/components/compact-information-panel.mdx
@@ -9,7 +9,7 @@ import { BaseColumn, WarningIcon } from 'smarthr-ui'
 <BaseColumn>
   <WarningIcon text={
     <span>
-    CompactInformationPanelは<a href="/products/components/notification-bar/">NotificationBar[base="base"]</a>で代替が可能になったため非推奨です。
+    CompactInformationPanelは非推奨です。<a href="/products/components/notification-bar/">NotificationBar[base="base"]</a>を利用してください。
     </span>}
     />
 </BaseColumn>


### PR DESCRIPTION
## 課題・背景

https://smarthr.atlassian.net/browse/SD-641


## やったこと
- `CompactInformationPanel`は`NotificationBar[base="base"]`で代替が可能になったため非推奨にします。
  - smarthr-uiも平行して対応中です。
  - https://github.com/kufu/smarthr-ui/pull/4622

<!--
- 〇〇に追記
- 〇〇ページを追加
-->


## 動作確認
- Previewでみてね。
- https://deploy-preview-1150--smarthr-design-system.netlify.app/products/components/compact-information-panel/

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
