### PR TITLE
Dropdownの派生コンポーネントへのリンク切れを修正

### DIFF
--- a/content/articles/products/components/dropdown/index.mdx
+++ b/content/articles/products/components/dropdown/index.mdx
@@ -11,9 +11,9 @@ import { ComponentStory } from '@Components/ComponentStory'
 
 開発で頻繁に利用する実装をコンポーネント化しています。
 
-- [DropdownMenuButton](../dropdown-menu-button)
-- [FilterDropdown](../filter-dropdown)
-- [SortDropdown](../sort-dropdown)
+- [DropdownMenuButton](./dropdown-menu-button/)
+- [FilterDropdown](./filter-dropdown/)
+- [SortDropdown](./sort-dropdown/)
 
 <ComponentStory name="Dropdown" />
 


### PR DESCRIPTION
## 課題・背景

<!--
issueをリンクしてね
-->

- https://smarthr.design/products/components/dropdown/ の派生コンポーネントへのリンク切れを修正

## やったこと

- リンク切れを修正

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと


<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

以下のリンクの遷移先にある3つのリンクが機能することを確認してください。

https://deploy-preview-1170--smarthr-design-system.netlify.app/products/components/dropdown/#h2-0

比較対象は以下のリンクより確認できます。
(なぜかFilterDropdownはうごく 全ては謎…)

https://smarthr.design/products/components/dropdown/#h2-0

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
