### PR TITLE
DoAndDontコンポーネントにwidthプロパティを追加、使用ページの修正

### DIFF
--- a/content/articles/basics/illustration/index.mdx
+++ b/content/articles/basics/illustration/index.mdx
@@ -6,7 +6,6 @@ order: 5
 import { Grid } from '@Components/shared/Grid/Grid'
 import { ImgWithDesc } from '@Components/article/ImgWithDesc/ImgWithDesc'
 import { Cluster, Stack } from 'smarthr-ui'
-import { DoAndDont } from '@Components/DoAndDont'
 import { AnchorButton } from 'smarthr-ui'
 
 SmartHRのサービス全体で利用するイラストレーションです。

--- a/content/articles/basics/illustration/smarthr-co.mdx
+++ b/content/articles/basics/illustration/smarthr-co.mdx
@@ -4,7 +4,6 @@ description: 'SmartHR社の人物に関連するイラストレーションで�
 order: 1
 ---
 
-import { DoAndDont } from '@Components/DoAndDont'
 import { ImgWithDesc } from '@Components/article/ImgWithDesc/ImgWithDesc'
 import { Grid } from '@Components/shared/Grid/Grid'
 import { AnchorButton, Cluster , Stack } from 'smarthr-ui'

--- a/content/articles/operational-guideline/page-template/style-template.mdx
+++ b/content/articles/operational-guideline/page-template/style-template.mdx
@@ -113,9 +113,9 @@ SmartHR UI Layoutコンポーネントを使用できます。
 
 * 入れ子にして`align`や`justify`を組み合わせるとメディアクエリを使用せずに柔軟なレイアウトを作れます。
 * 幅を狭めて収まり切らなくなると折返します。
-* `gap`に使える値は`XXS`,`XS`,`S`,`M`,`L`,`XL`、他`1`,`0.5`などの数値です。詳しくはsmarthr-uiのドキュメントを参照してください。
+* `gap`に使える値は16pxを基準に`1`,`0.5`などの数値です。詳しくはsmarthr-uiのドキュメントを参照してください。
 
-<Cluster gap="XS">
+<Cluster gap={1}>
   {[...Array(10)].map((_, i) => (
     <div key={i} style={{background: 'black', width: `${100}px`, height: '100px'}} />
   ))}
@@ -125,9 +125,9 @@ SmartHR UI Layoutコンポーネントを使用できます。
 
 * 等間隔に隙間を保ち、積み重ねるレイアウトが作れます。
 * 各要素の間隔は`1rem`が標準です。
-* `gap`に使える値は`XXS`,`XS`,`S`,`M`,`L`,`XL`、他`1`,`0.5`などの数値です。詳しくはsmarthr-uiのドキュメントを参照してください。
+* `gap`に使える値は16pxを基準に`1`,`0.5`などの数値です。詳しくはsmarthr-uiのドキュメントを参照してください。
 
-<Stack gap="XS">
+<Stack gap={1}>
   {[...Array(4)].map((_, i) => (
     <div key={i} style={{background: 'black', width: '100px', height: '100px'}} />
   ))}
@@ -169,7 +169,7 @@ import { StaticImage } from '@Components/StaticImage'
 import { Cluster } from 'smarthr-ui'
 import imageUrl from './images/sample.jpg';
 
-<Cluster gap="XS">
+<Cluster gap={1}>
   <StaticImage src={imageUrl} width="200" alt="Image Sample" />
   <StaticImage src={imageUrl} width="200" alt="Image Sample" />
 </Cluster>
@@ -179,7 +179,7 @@ import imageUrl from './images/sample.jpg';
 
 import imageUrl from './images/sample.jpg';
 
-<Cluster gap="XS">
+<Cluster gap={1}>
   <StaticImage src={imageUrl} width="200" alt="Image Sample" />
   <StaticImage src={imageUrl} width="200" alt="Image Sample" />
 </Cluster>
@@ -213,16 +213,18 @@ import imageUrl from './images/sample.jpg';
 
 ## Do And Don&apos;t
 
-<Cluster gap="XS">
+<Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont
     type="do"
-    img={<StaticImage src={imageUrl} alt="Do" width="200" />}
+    img={<StaticImage src={imageUrl} alt="Do" />}
     label={<Text>ほげほげ</Text>}
+    width="calc(50% - 8px)"
   />
   <DoAndDont
     type="dont"
-    img={<StaticImage src={imageUrl} alt="Dont" width="200" />}
+    img={<StaticImage src={imageUrl} alt="Dont" />}
     label={<Text>ほげほげ</Text>}
+    width="calc(50% - 8px)"
   />
 </Cluster>
 

--- a/content/articles/products/components/check-box/index.mdx
+++ b/content/articles/products/components/check-box/index.mdx
@@ -35,16 +35,18 @@ import checkBoxDont from './images/check-box-dont.png';
 「ON/OFF」などのブール値で制御できる項目にチェックボックスを使用した場合、一方の選択肢が暗黙的になりチェック状態から現在の選択状態が認識しづらくなる場合があります。
 こうした場合には、選択肢を明示的に表示できる[RadioButton](/products/components/radio-button/)を使用してください。
 
-<Cluster gap={1}>
+<Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont
     type="do"
-    img={<StaticImage src={checkBoxDo} alt="Do" width="320" />}
-    label={<Text>すべての選択肢が明示的に表示されてい<br/>るため、現在の状態が把握しやすい</Text>}
+    img={<StaticImage src={checkBoxDo} alt="Do" />}
+    label={<Text>すべての選択肢が明示的に表示されているため、現在の状態が把握しやすい</Text>}
+    width="calc(50% - 8px)"
   />
   <DoAndDont
     type="dont"
-    img={<StaticImage src={checkBoxDont} alt="Dont" width="320" />}
-    label={<Text>「無効」という選択肢が暗黙的であり、<br/>現在の状態をラベルとチェック状態から<br/>推測しなければならない</Text>}
+    img={<StaticImage src={checkBoxDont} alt="Dont" />}
+    label={<Text>「無効」という選択肢が暗黙的であり、現在の状態をラベルとチェック状態から推測しなければならない</Text>}
+    width="calc(50% - 8px)"
   />
 </Cluster>
 

--- a/content/articles/products/components/combo-box/multi-combo-box.mdx
+++ b/content/articles/products/components/combo-box/multi-combo-box.mdx
@@ -38,16 +38,18 @@ MultiComboBoxで入力補助のヒントメッセージを表示したい場合�
 
 `dropdownHelpMessage`はドロップダウンパネルを表示したときのみ表示されるため、ヒントメッセージを常に表示したい場合は、[FormControl](/products/components/form-control/)の`helpMessage`を使用してください。
 
-<Cluster gap={1}>
+<Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont
     type="do"
-    img={<StaticImage src={multiComboBoxDo} alt="Do" width="346" />}
-    label={<Text>ユーザーがテキストを入力しても入力補助<br/>としてヒントメッセージを確認できる</Text>}
+    img={<StaticImage src={multiComboBoxDo} alt="Do" />}
+    label={<Text>ユーザーがテキストを入力しても入力補助としてヒントメッセージを確認できる</Text>}
+    width="calc(50% - 8px)"
   />
   <DoAndDont
     type="dont"
-    img={<StaticImage src={multiComboBoxDont} alt="Dont" width="346" />}
-    label={<Text>ユーザーがテキストを入力するとプレース<br/>ホルダが確認できなくなり、入力補助とし<br/>て機能しない</Text>}
+    img={<StaticImage src={multiComboBoxDont} alt="Dont" />}
+    label={<Text>ユーザーがテキストを入力するとプレースホルダが確認できなくなり、入力補助として機能しない</Text>}
+    width="calc(50% - 8px)"
   />
 </Cluster>
 

--- a/content/articles/products/components/combo-box/single-combo-box.mdx
+++ b/content/articles/products/components/combo-box/single-combo-box.mdx
@@ -38,16 +38,18 @@ SingleComboBoxで入力補助のヒントメッセージを表示したい場合
 
 `dropdownHelpMessage`はドロップダウンパネルを表示したときのみ表示されるため、ヒントメッセージを常に表示したい場合は、[FormControl](/products/components/form-control/)の`helpMessage`を使用してください。
 
-<Cluster gap={1}>
+<Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont
     type="do"
-    img={<StaticImage src={singleComboBoxDo} alt="Do" width="346" />}
-    label={<Text>ユーザーがテキストを入力しても入力補助<br/>としてヒントメッセージを確認できる</Text>}
+    img={<StaticImage src={singleComboBoxDo} alt="Do" />}
+    label={<Text>ユーザーがテキストを入力しても入力補助としてヒントメッセージを確認できる</Text>}
+    width="calc(50% - 8px)"
   />
   <DoAndDont
     type="dont"
-    img={<StaticImage src={singleComboBoxDont} alt="Dont" width="346" />}
-    label={<Text>ユーザーがテキストを入力するとプレース<br/>ホルダが確認できなくなり、入力補助とし<br/>て機能しない</Text>}
+    img={<StaticImage src={singleComboBoxDont} alt="Dont" />}
+    label={<Text>ユーザーがテキストを入力するとプレースホルダが確認できなくなり、入力補助として機能しない</Text>}
+    width="calc(50% - 8px)"
   />
 </Cluster>
 

--- a/content/articles/products/design-patterns-core-features/access-control-setting-pattern.mdx
+++ b/content/articles/products/design-patterns-core-features/access-control-setting-pattern.mdx
@@ -5,6 +5,7 @@ order: 2
 ---
 
 import { DoAndDont } from '@Components/DoAndDont'
+import { StaticImage } from '@Components/StaticImage'
 import { FaExclamationTriangleIcon, Cluster} from 'smarthr-ui'
 
 import imageUrl6Do from './images/access-control-setting-pattern6-do.png'
@@ -103,16 +104,18 @@ SmartHR基本機能の共通設定おける、操作権限を設定する項目�
 
 横幅に十分なスペースがある場合は、基本的に横並びにすることで縦幅が長くなりすぎることを防ぎます。
 
-<Cluster gap="XS">
+<Cluster gap={{ row: 0, column: 1 }}>
     <DoAndDont
         type="do"
-        img={<img src={imageUrl6Do} alt="スクリーンショット: 設定項目の縦横に配置するレイアウトのDo"/>}
+        img={<StaticImage src={imageUrl6Do} alt="スクリーンショット: 設定項目の縦横に配置するレイアウトのDo" />}
         label="横幅に十分なスペースがある場合は、基本的に横並びにします。"
+        width="calc(50% - 8px)"
     />
     <DoAndDont
         type="dont"
-        img={<img src={imageUrl6Dont} alt="スクリーンショット: 設定項目の縦横に配置するレイアウトのDon't"/>}
+        img={<StaticImage src={imageUrl6Dont} alt="スクリーンショット: 設定項目の縦横に配置するレイアウトのDon't"/>}
         label="縦並びにすると、親項目の幅に対して要素の配置が偏ってしまい、視認性が低下する恐れがあります。"
+        width="calc(50% - 8px)"
     />
 </Cluster>
 
@@ -125,16 +128,18 @@ SmartHR基本機能の共通設定おける、操作権限を設定する項目�
 CRUDなど、設定項目の組み合わせが決まっている操作権限項目が連続して複数並ぶケースで、一部の設定項目が対応していない場合は該当の設定項目を非表示にします。その際、設定項目が表示されていた箇所はそのまま空白として残します。  
 この場合のコンテンツ領域の横幅は、選択肢が存在しているときと同じ横幅になるように固定します。
 
-<Cluster gap="XS">
+<Cluster gap={{ row: 0, column: 1 }}>
     <DoAndDont
         type="do"
-        img={<img src={imageUrl13Do} alt="スクリーンショット: 対応しない設定項目を空白として残すレイアウトのDo"/>}
+        img={<StaticImage src={imageUrl13Do} alt="スクリーンショット: 対応しない設定項目を空白として残すレイアウトのDo"/>}
         label="対応していない設定項目が表示されていた箇所は、そのまま空白として残します。"
+        width="calc(50% - 8px)"
     />
     <DoAndDont
         type="dont"
-        img={<img src={imageUrl13Dont} alt="スクリーンショット: 対応しない設定項目を空白として残すレイアウトのDon't"/>}
+        img={<StaticImage src={imageUrl13Dont} alt="スクリーンショット: 対応しない設定項目を空白として残すレイアウトのDon't"/>}
         label="詰めずに配置すると、どの設定項目が対応していないのか把握しづらくなるため、空白が必要です。"
+        width="calc(50% - 8px)"
     />
 </Cluster>
 

--- a/content/articles/products/design-patterns/modal-ui/index.mdx
+++ b/content/articles/products/design-patterns/modal-ui/index.mdx
@@ -131,7 +131,7 @@ SmartHR UIでは[ActionDialog](/products/components/dialog/#h3-1)と[MessageDial
 また、タスクを中断して元のページに戻る操作は［キャンセル］ボタンが担います。そのため、基本的に[上に戻るリンク](/products/design-patterns/upward-navigation/)は配置しません。
 
 <DoAndDont
-  type="「上に戻るリンク」と［キャンセル］ボタンが両方配置されている。"
+  type="dont"
   img={<StaticImage src={imageUrlUpwardDont} alt="Dont" />}
   label="「上に戻るリンク」と［キャンセル］ボタンが両方配置されている。"
 />

--- a/src/components/DoAndDont/DoAndDont.tsx
+++ b/src/components/DoAndDont/DoAndDont.tsx
@@ -1,37 +1,49 @@
 import React, { FC } from 'react'
-import { FaCheckCircleIcon, FaTimesCircleIcon, defaultColor, defaultSpacing } from 'smarthr-ui'
+import { FaCircleCheckIcon, FaCircleXmarkIcon, defaultBreakpoint, defaultColor, defaultSpacing } from 'smarthr-ui'
 import styled, { css } from 'styled-components'
 
 type Props = {
   type: 'do' | 'dont'
   img: React.ReactNode
   label: React.ReactNode
+  width?: string | number
 }
 
-export const DoAndDont: FC<Props> = ({ type, img, label }) => (
-  <Wrapper>
-    <ImageArea>{img}</ImageArea>
-    <LabelArea $type={type}>
-      <Status $type={type}>
-        {type === 'do' ? (
-          <>
-            <FaCheckCircleIcon className="icon" />
-            Do
-          </>
-        ) : (
-          <>
-            <FaTimesCircleIcon className="icon" />
-            Don&apos;t
-          </>
-        )}
-      </Status>
-      {label}
-    </LabelArea>
-  </Wrapper>
-)
+export const DoAndDont: FC<Props> = ({ type, img, label, width }) => {
+  const actualWidth = typeof width === 'number' ? `${width}px` : width
 
-const Wrapper = styled.div`
-  margin-block: 16px 0;
+  return (
+    <Wrapper $width={actualWidth ? actualWidth : undefined}>
+      <ImageArea>{img}</ImageArea>
+      <LabelArea $type={type}>
+        <Status $type={type}>
+          {type === 'do' ? (
+            <>
+              <FaCircleCheckIcon className="icon" />
+              Do
+            </>
+          ) : (
+            <>
+              <FaCircleXmarkIcon className="icon" />
+              Don&apos;t
+            </>
+          )}
+        </Status>
+        {label}
+      </LabelArea>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div<{ $width: string | undefined }>`
+  ${({ $width }) => css`
+    margin-block: 24px 0;
+    width: ${$width !== undefined ? $width : 'auto'};
+
+    @media (max-width: ${defaultBreakpoint.SP}px) {
+      min-width: 100%;
+    }
+  `}
 `
 
 const ImageArea = styled.div`

--- a/src/components/DoAndDont/DoAndDont.tsx
+++ b/src/components/DoAndDont/DoAndDont.tsx
@@ -41,6 +41,7 @@ const Wrapper = styled.div<{ $width: string | undefined }>`
     width: ${$width !== undefined ? $width : 'auto'};
 
     @media (max-width: ${defaultBreakpoint.SP}px) {
+      /* MEMO: スマホだと幅いっぱいにする */
       min-width: 100%;
     }
   `}


### PR DESCRIPTION
## 課題・背景

<!--
issueをリンクしてね
-->

## やったこと
- `DoAndDont`コンポーネントにwidthプロパティを追加
  - `StaticImage`コンポーネントのwidthではなく、`DoAndDont`コンポーネントのwidthを使うことで、labelが適切に折り返すようになります。
- モバイル表示時は幅いっぱい表示するように
<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
https://deploy-preview-1188--smarthr-design-system.netlify.app/operational-guideline/page-template/style-template/#h2-12

<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
