### PR TITLE
💬: 同期処理の “同期” を読み違える可能性があったので “同期的な” に修正

### DIFF
--- a/content/articles/products/design-patterns/feedback/index.mdx
+++ b/content/articles/products/design-patterns/feedback/index.mdx
@@ -36,8 +36,8 @@ order: 13
 なお、非同期処理のフィードバックについては、[バックグラウンド処理](/products/design-patterns/background-jobs-results/)を参照してください。
 
 - フォームを入力・送信するとき
-- 同期処理を開始したとき
-- 同期処理が完了したとき
+- 同期的な処理を開始したとき
+- 同期的な処理が完了したとき
 - ページ・要素の読み込みを開始したとき
 - ページ・要素の読み込みが完了したとき
 
@@ -61,11 +61,11 @@ order: 13
 
 ![スクリーンショット: Inputを持つFormControlを内包するActionDialog。Inputの枠線は赤く表示され、Inputの上部に「利用できない文字「$」が含まれています。」というエラーメッセージが表示されたResponseMessageがある。ActionDialogのPrimaryボタンの下部に「入力内容に不備があります。」というエラーメッセージが表示されたResponseMessageがある。](./images/form-control-error-on-submit.png)
 
-### 同期処理を開始したとき
+### 同期的な処理を開始したとき
 
 実行した[Button](/products/components/button/)を`loading`状態に変化させます（[ActionDialog](/products/components/dialog/)の場合は`responseMessage`を利用）。
 
-処理が完了したら表示を切り替え、[同期処理が完了したとき](#h3-5)のフィードバックを表示します。
+処理が完了したら表示を切り替え、[同期的な処理が完了したとき](#h3-5)のフィードバックを表示します。
 
 ![スクリーンショット: Inputを持つFormControlを内包するActionDialog。ActionDialogのPrimaryボタンがloading状態で表示されている。](./images/button-loading.png)
 
@@ -73,11 +73,11 @@ order: 13
 
 操作後に画面全体の切り替えが発生する場合など、処理を実行したButtonの状態変化で伝えることが難しい場合は、`sync`状態の[NotificationBar](/products/components/notification-bar/)を表示します。
 
-処理が完了したら表示を切り替え、[同期処理が完了したとき](#h3-5)のフィードバックを表示します。
+処理が完了したら表示を切り替え、[同期的な処理が完了したとき](#h3-5)のフィードバックを表示します。
 
 ![スクリーンショット: HeaderとAppNaviとNotificationBarが表示されている。NotificationBarはsync状態で、「処理を実行中です。」というメッセージが表示されている。](./images/notification-bar-loading.png)
 
-### 同期処理が完了したとき
+### 同期的な処理が完了したとき
 
 ユーザーが直前に操作していたButtonなどの近くに、成功時には`success`状態、失敗時には`error`状態で[ResponseMessage](/products/components/response-message/)を表示します。
 


### PR DESCRIPTION
読んでて気になったので提案しましたが、棄却でも問題ないです!