### PR TITLE
ActionDialogを分離

### DIFF
--- a/content/articles/products/components/dialog/action-dialog.mdx
+++ b/content/articles/products/components/dialog/action-dialog.mdx
@@ -1,4 +1,52 @@
 ---
 title: 'ActionDialog'
-description: ''
+description: 'ユーザーに入力や選択などの操作を求めるためのダイアログです。ユーザーは操作を完了するか、操作を中断してダイアログを閉じることができます。'
 ---
+import { ComponentPropsTable } from '@Components/ComponentPropsTable'
+import { ComponentStory } from '@Components/ComponentStory'
+
+ユーザーに入力や選択などの操作を求めるためのダイアログです。ユーザーは操作を完了するか、操作を中断してダイアログを閉じることができます。
+
+モーダルなダイアログです。ダイアログの表示中、ダイアログの裏側の領域はスクリム（幕）で隠され、操作を受け付けません。
+
+
+<ComponentStory name="ActionDialog" />
+
+## レイアウト
+
+### 基準サイズ
+
+ダイアログの横幅サイズの基準値は以下のとおりです。  
+サイズに意図がない場合は、下記の値から想定に近い値を選択してください。
+
+#### デスクトップ、タブレット（`TABLET`）
+
+| サイズ | 値 | 補足説明 |
+| :--- | :--- | :--- |
+| S | 480px | Dialogの最小値として使います。 |
+| M | 640px |  |
+| L | 768px |  |
+| MAX | calc(100% - 32px) | Dialogの最大値として使います。 |
+
+#### スマートフォン（`SP`）
+
+スマートフォンは表示領域が狭いため、サイズの最大値/最小値は同じとします。
+
+| サイズ | 値 | 補足説明 |
+| :--- | :--- | :--- |
+| 標準 | calc(100% - 32px) | Dialogの最大値/最小値として使います。 |
+
+
+### 表示位置
+意図的な場合をのぞき、画面の天地中央（上下左右中央）に表示します。
+
+## デザインパターン
+
+削除操作をする際の確認のダイアログについては、[削除ダイアログ](/products/design-patterns/delete-dialog/)を参照してください。
+
+それ以外のパターンについては、[モーダルなUI](/products/design-patterns/modal-ui/)を参照してください。
+
+
+## Props
+
+<ComponentPropsTable name="ActionDialog" />


### PR DESCRIPTION
## 課題・背景

旧Dialogを、

```
dialog/
├ index
├ ActionDialog
├ MessageDialog
└ ModelessDialog
```

の4つに分けたうちの、ActionDialogの分です。

関連PR
#1201 
#1203 
#1204

## やったこと
-

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
