### PR TITLE
Dialog群のStoryを一時的に変更

### DIFF
--- a/content/articles/products/components/dialog/action-dialog.mdx
+++ b/content/articles/products/components/dialog/action-dialog.mdx
@@ -10,7 +10,7 @@ import { ComponentStory } from '@Components/ComponentStory'
 モーダルなダイアログです。ダイアログの表示中、ダイアログの裏側の領域はスクリム（幕）で隠され、操作を受け付けません。
 
 
-<ComponentStory name="ActionDialog" />
+<ComponentStory name="Dialog" />
 
 ## 使用上の注意
 

--- a/content/articles/products/components/dialog/message-dialog.mdx
+++ b/content/articles/products/components/dialog/message-dialog.mdx
@@ -10,7 +10,7 @@ import { ComponentStory } from '@Components/ComponentStory'
 モーダルなダイアログです。ダイアログの表示中、ダイアログの裏側の領域はスクリム（幕）で隠され、操作を受け付けません。
 
 
-<ComponentStory name="MessageDialog" />
+<ComponentStory name="Dialog" />
 
 ## 使用上の注意
 

--- a/content/articles/products/components/dialog/modeless-dialog.mdx
+++ b/content/articles/products/components/dialog/modeless-dialog.mdx
@@ -10,7 +10,7 @@ import { ComponentStory } from '@Components/ComponentStory'
 基本的に、ダイアログと裏側の画面を同時並行で閲覧・操作する場合に使います。
 
 
-<ComponentStory name="ModelessDialog" />
+<ComponentStory name="Dialog" />
 
 ## 使用上の注意
 


### PR DESCRIPTION
## 課題・背景

Dialogの子コンポーネントの、Storybook側の分割対応が終わるまでの暫定処置
<!--
issueをリンクしてね
-->

## やったこと

ActionDialog、MessageDialog、ModelessDialogのStory埋め込み部分を、一時的にDialogのStory（子コンポーネントも全部含まれている）にしました。


<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
