### PR TITLE
写真・動画 > コンテンツ内容のURLを変更

### DIFF
--- a/content/articles/communication/photography/index.mdx
+++ b/content/articles/communication/photography/index.mdx
@@ -14,7 +14,7 @@ SmartHRのサービス全体で利用できる写真・動画です。
 - [オフィス写真](/photography/photography-office/)
     - SmartHRのオフィスの写真についてまとめています。
 - [ジングルムービー](/photography/jingle-movie/)
-    - イベントやライブストリーミングで利用できるジングルムービーです。
+    - イベントやライブストリーミングで利用できるジングルムービーです
         <VideoEmbed
         poster="/images/jingle_movie_thumb.png"
         source="/video/jingle_movie.mp4"

--- a/content/articles/communication/photography/index.mdx
+++ b/content/articles/communication/photography/index.mdx
@@ -14,7 +14,7 @@ SmartHRのサービス全体で利用できる写真・動画です。
 - [オフィス写真](https://smarthr.design/communication/photography/photography-office/)
     - SmartHRのオフィスの写真についてまとめています。
 - [ジングルムービー](https://smarthr.design/communication/photography/jingle-movie/)
-    - イベントやライブストリーミングで利用できるジングルムービーです
+    - イベントやライブストリーミングで利用できるジングルムービーです。
         <VideoEmbed
         poster="/images/jingle_movie_thumb.png"
         source="/video/jingle_movie.mp4"

--- a/content/articles/communication/photography/index.mdx
+++ b/content/articles/communication/photography/index.mdx
@@ -11,9 +11,9 @@ SmartHRのサービス全体で利用できる写真・動画です。
 
 ## コンテンツ
 
-- [オフィス写真](/photography/photography-office/)
+- [オフィス写真](https://smarthr.design/communication/photography/photography-office/)
     - SmartHRのオフィスの写真についてまとめています。
-- [ジングルムービー](/photography/jingle-movie/)
+- [ジングルムービー](https://smarthr.design/communication/photography/jingle-movie/)
     - イベントやライブストリーミングで利用できるジングルムービーです
         <VideoEmbed
         poster="/images/jingle_movie_thumb.png"

--- a/content/articles/communication/photography/index.mdx
+++ b/content/articles/communication/photography/index.mdx
@@ -11,9 +11,9 @@ SmartHRのサービス全体で利用できる写真・動画です。
 
 ## コンテンツ
 
-- [オフィス写真](/photography-office/)
+- [オフィス写真](/photography/photography-office/)
     - SmartHRのオフィスの写真についてまとめています。
-- [ジングルムービー](/jingle-movie/)
+- [ジングルムービー](/photography/jingle-movie/)
     - イベントやライブストリーミングで利用できるジングルムービーです。
         <VideoEmbed
         poster="/images/jingle_movie_thumb.png"

--- a/content/articles/communication/photography/index.mdx
+++ b/content/articles/communication/photography/index.mdx
@@ -14,7 +14,7 @@ SmartHRのサービス全体で利用できる写真・動画です。
 - [オフィス写真](/photography/photography-office/)
     - SmartHRのオフィスの写真についてまとめています。
 - [ジングルムービー](/photography/jingle-movie/)
-    - イベントやライブストリーミングで利用できるジングルムービーです
+    - イベントやライブストリーミングで利用できるジングルムービーです。
         <VideoEmbed
         poster="/images/jingle_movie_thumb.png"
         source="/video/jingle_movie.mp4"


### PR DESCRIPTION
## 課題・背景
- 「[写真・動画](https://smarthr.design/communication/photography/)」内のテキストリンクのURLがリンク切れになっていたので、正しいURLに変更

## やったこと
- 「オフィス写真」と「ジングルムービー」のリンク先に、正しいURLを指定
  -掲載場所：コミュニケーション > 写真・動画
![CleanShot 2024-07-11 at 14 58 12](https://github.com/kufu/smarthr-design-system/assets/101125529/94f3cf19-f612-4a9f-acf3-f4aad9407d55)

## やらなかったこと
- とくになし

## 動作確認
https://deploy-preview-1243--smarthr-design-system.netlify.app/communication/photography/
