### PR TITLE
fix: 実装に合わせて`isNarrowScreen` を `isNarrowView` に修正

### DIFF
--- a/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
+++ b/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
@@ -222,17 +222,17 @@ SmartHR UIは基本的にレスポンシブに実装されているため、配�
 
 ### useDevice
 
-`useDevice` フックを使って `isNarrowScreen` を取得し、必要に応じてコンポーネントに割り当ててください。SmartHRにおける頻出パターンはSmartHR UIでアダプティブなレイアウトを実装予定です。各プロダクト側でユーザーエージェントの判定を実装する必要はありません。
+`useDevice` フックを使って `isNarrowView` を取得し、必要に応じてコンポーネントに割り当ててください。SmartHRにおける頻出パターンはSmartHR UIでアダプティブなレイアウトを実装予定です。各プロダクト側でユーザーエージェントの判定を実装する必要はありません。
 
 ### [Dialog](/products/components/dialog/)
 
-（WIP）SmartHR UIで実装するため `isNarrowScreen` を渡してください。基本的にプロダクトで考慮することはありません。
+（WIP）SmartHR UIで実装するため `isNarrowView` を渡してください。基本的にプロダクトで考慮することはありません。
 
 ### [BottomFixedArea](/products/components/bottom-fixed-area/)と[FloatArea](/products/components/float-area/)
 
 そのままレスポンシブに折り返して使うと表示領域を圧迫するため、モバイル向けに再設計が必要です。[1画面で複雑な操作をさせない](#h3-1)ように調整してください。
 
-SmartHR UI でも最低限のレイアウトを実装するため `isNarrowScreen` を渡してください。
+SmartHR UI でも最低限のレイアウトを実装するため `isNarrowView` を渡してください。
 
 ### [Pagination](/products/components/pagination/)
 
@@ -248,7 +248,7 @@ SmartHR UI でも最低限のレイアウトを実装するため `isNarrowScree
 
 モバイルでは、画面幅を越えたテーブルは[2次元スクロール](#h3-3)を招くため、垂直方向に積みあげることを推奨します。
 
-（WIP）SmartHR UIで `isNarrowScreen` を用いたレイアウトの切り替えを検討中です。
+（WIP）SmartHR UIで `isNarrowView` を用いたレイアウトの切り替えを検討中です。
 
 ### [Tooltip](/products/components/tooltip/)と[LineClamp](/products/components/line-clamp/)
 


### PR DESCRIPTION
## 課題・背景

<!--
issueをリンクしてね
-->

実装では `isNarrowView` になっているため修正

## やったこと
- `isNarrowScreen` を`isNarrowView` に修正

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- なし

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
