### PR TITLE
RadioButtonページのリンクミスを修正

### DIFF
--- a/content/articles/products/components/radio-button/index.mdx
+++ b/content/articles/products/components/radio-button/index.mdx
@@ -24,7 +24,7 @@ import RadioButtonDont from './images/radio-button-dont.png';
 
 基本的に、選択肢の中から単一の値を選択して入力させる場合は、初期状態で選択肢が一覧しやすいラジオボタンを使用します。
 
-- 選択肢のラベルテキストが長大になる場合や、選択肢が表示領域内にすべて表示しきれないほど存在する場合では、[Select](/products/components/select/)や[SingleComboBox](/products/components/combo-box/singe-combo-box)も検討します。
+- 選択肢のラベルテキストが長大になる場合や、選択肢が表示領域内にすべて表示しきれないほど存在する場合では、[Select](/products/components/select/)や[SingleComboBox](/products/components/combo-box/single-combo-box/)も検討します。
   - ただし選択肢の一覧性が下がり、操作の手間が増えるので、選択肢の数が不定で予測できないなどの理由がない限りはラジオボタンの使用を推奨します。
 
 #### 選択肢のラベルテキストはなるべく簡潔に同程度の文量で収める


### PR DESCRIPTION
## 課題・背景

https://kufuinc.slack.com/archives/CJX59GJFR/p1725504495865029

## やったこと
- RadioButtonページのSingleComboBoxへのリンクがtypoしてたので修正した

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
https://deploy-preview-1260--smarthr-design-system.netlify.app/products/components/radio-button/#h4-0

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
