### PR TITLE
コードブロック (ライブエディタ) を移植

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
 import { defineConfig } from 'astro/config';
 
+import remarkCodeBlock from './src/remark/remark-code-block';
 import remarkIndexIdHeader from './src/remark/remark-index-id-header';
 
 // https://astro.build/config
@@ -10,6 +11,6 @@ export default defineConfig({
   integrations: [mdx(), react()],
   markdown: {
     syntaxHighlight: false,
-    remarkPlugins: [remarkIndexIdHeader],
+    remarkPlugins: [remarkIndexIdHeader, remarkCodeBlock],
   },
 });

--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
     "@types/react": "^18.3.8",
     "@types/react-dom": "^18.3.0",
     "astro": "^4.15.8",
+    "prism-react-renderer": "^2.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-frame-component": "^5.2.7",
+    "react-live": "^4.1.7",
+    "smarthr-normalize-css": "^1.1.0",
     "smarthr-ui": "^58.0.2",
     "styled-components": "^6.1.13",
     "typescript": "^5.6.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,12 +26,24 @@ importers:
       astro:
         specifier: ^4.15.8
         version: 4.15.8(rollup@4.22.0)(typescript@5.6.2)
+      prism-react-renderer:
+        specifier: ^2.4.0
+        version: 2.4.0(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-frame-component:
+        specifier: ^5.2.7
+        version: 5.2.7(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-live:
+        specifier: ^4.1.7
+        version: 4.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      smarthr-normalize-css:
+        specifier: ^1.1.0
+        version: 1.1.0(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       smarthr-ui:
         specifier: ^58.0.2
         version: 58.0.2(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -748,6 +760,9 @@ packages:
 
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
+
+  '@types/prismjs@1.26.4':
+    resolution: {integrity: sha512-rlAnzkW2sZOjbqZ743IHUhFcvzaGbqijwOu8QZnZCjfQzBqFE3s4lOTJEsxikImav9uzz/42I+O7YUs1mWgMlg==}
 
   '@types/prop-types@15.7.13':
     resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
@@ -1897,6 +1912,11 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prism-react-renderer@2.4.0:
+    resolution: {integrity: sha512-327BsVCD/unU4CNLZTWVHyUHKnsqcvj2qbPlQ8MiBE2eq2rgctjigPA1Gp9HLF83kZ20zNN6jgizHJeEsyFYOw==}
+    peerDependencies:
+      react: '>=16.0.0'
+
   prismjs@1.29.0:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
@@ -1925,6 +1945,13 @@ packages:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
 
+  react-frame-component@5.2.7:
+    resolution: {integrity: sha512-ROjHtSLoSVYUBfTieazj/nL8jIX9rZFmHC0yXEU+dx6Y82OcBEGgU9o7VyHMrBFUN9FuQ849MtIPNNLsb4krbg==}
+    peerDependencies:
+      prop-types: ^15.5.9
+      react: '>= 16.3'
+      react-dom: '>= 16.3'
+
   react-icons@5.3.0:
     resolution: {integrity: sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==}
     peerDependencies:
@@ -1938,6 +1965,13 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-live@4.1.7:
+    resolution: {integrity: sha512-NTzl0POOAW3dkp7+QL30duOrIu2Vzf2LHdx4TaQ0BqOAtQcSTKEXujfm9jR2VoCHko0oi35PYp38yKQBXz4mrg==}
+    engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -2096,6 +2130,9 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  smarthr-normalize-css@1.1.0:
+    resolution: {integrity: sha512-RNi5bkp8dYvZs/yqOihZ+an5Wf3oXiBMRRvSYhCKNhV+Qkg1otqIxmP3ELUWVwMZx9v+zZG1LLAJ0sxPkHXOcg==}
+
   smarthr-ui@58.0.2:
     resolution: {integrity: sha512-hOsKKQDDsGl2WL+D8AK7J0S+L6hbh0emPgK7ca11xVx/nQh+I/PpIXoYrCSEqSMrSrlaKuH1IpA5addbtmim0A==}
     peerDependencies:
@@ -2168,6 +2205,12 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
       react-dom: '>= 16.8.0'
+
+  styled-reset@4.5.2:
+    resolution: {integrity: sha512-dbAaaVEhweBs2FGfqGBdW6oMcMK8238C2X5KCxBhUQJX92m/QyUfzRADOXhdXiXNkIPELtMCd72YY9eCdORfIw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      styled-components: '>=4.0.0 || >=5.0.0 || >=6.0.0'
 
   stylis@4.3.2:
     resolution: {integrity: sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==}
@@ -2301,6 +2344,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-editable@2.3.3:
+    resolution: {integrity: sha512-7wVD2JbfAFJ3DK0vITvXBdpd9JAz5BcKAAolsnLBuBn6UDDwBGuCIAGvR3yA2BNKm578vAMVHFCWaOcA+BhhiA==}
+    peerDependencies:
+      react: '>= 16.8.0'
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3262,6 +3310,8 @@ snapshots:
   '@types/nlcst@2.0.3':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/prismjs@1.26.4': {}
 
   '@types/prop-types@15.7.13': {}
 
@@ -4813,6 +4863,12 @@ snapshots:
 
   prettier@3.3.3: {}
 
+  prism-react-renderer@2.4.0(react@18.3.1):
+    dependencies:
+      '@types/prismjs': 1.26.4
+      clsx: 2.1.1
+      react: 18.3.1
+
   prismjs@1.29.0: {}
 
   prompts@2.4.2:
@@ -4843,6 +4899,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  react-frame-component@5.2.7(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react-icons@5.3.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -4853,6 +4915,14 @@ snapshots:
       react: 18.3.1
 
   react-is@16.13.1: {}
+
+  react-live@4.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      prism-react-renderer: 2.4.0(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      sucrase: 3.35.0
+      use-editable: 2.3.3(react@18.3.1)
 
   react-refresh@0.14.2: {}
 
@@ -5107,6 +5177,12 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  smarthr-normalize-css@1.1.0(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      styled-reset: 4.5.2(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+    transitivePeerDependencies:
+      - styled-components
+
   smarthr-ui@58.0.2(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@smarthr/wareki': 1.2.0
@@ -5195,6 +5271,10 @@ snapshots:
       shallowequal: 1.1.0
       stylis: 4.3.2
       tslib: 2.6.2
+
+  styled-reset@4.5.2(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      styled-components: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   stylis@4.3.2: {}
 
@@ -5356,6 +5436,10 @@ snapshots:
       browserslist: 4.23.3
       escalade: 3.2.0
       picocolors: 1.1.0
+
+  use-editable@2.3.3(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 

--- a/src/components/ComponentPreview/ComponentPreview.tsx
+++ b/src/components/ComponentPreview/ComponentPreview.tsx
@@ -1,0 +1,48 @@
+import React, { type CSSProperties, useMemo } from 'react';
+import { Cluster } from 'smarthr-ui';
+import type { Gap, SeparateGap } from 'smarthr-ui/lib/types';
+import styled, { css } from 'styled-components';
+
+import { ProductWrapper } from './ProductWrapper';
+import { WrapperBase } from './WrapperBase';
+
+type Props = {
+  children: React.ReactNode;
+  gap?: Gap | SeparateGap;
+  align?: CSSProperties['alignItems'];
+  layout?: 'none' | 'product';
+};
+
+export const ComponentPreview = ({
+  children,
+  gap = 1,
+  align = 'center', // 無指定で stretch されると困るため
+  layout,
+}: Props) =>
+  useMemo(() => {
+    switch (layout) {
+      default: {
+        return (
+          <Wrapper>
+            <Cluster gap={gap} align={align}>
+              {children}
+            </Cluster>
+          </Wrapper>
+        );
+      }
+      case 'product': {
+        return <ProductWrapper>{children}</ProductWrapper>;
+      }
+      case 'none': {
+        return <NoLayoutWrapper>{children}</NoLayoutWrapper>;
+      }
+    }
+  }, [layout, align, children, gap]);
+
+const Wrapper = styled(WrapperBase)(
+  ({ theme: { space } }) => css`
+    padding: ${space(1.5)};
+  `,
+);
+
+const NoLayoutWrapper = WrapperBase;

--- a/src/components/ComponentPreview/ProductWrapper.tsx
+++ b/src/components/ComponentPreview/ProductWrapper.tsx
@@ -1,0 +1,96 @@
+// TODO: 後で移植
+// import { ResizableContainer } from '@/Components/ComponentStory';
+import React from 'react';
+import { Header } from 'smarthr-ui';
+import styled, { css } from 'styled-components';
+
+import { WrapperBase } from './WrapperBase';
+
+export const ProductWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <Wrapper>
+    {/* <ResizableContainer defaultWidth="100%" defaultHeight="300px"> */}
+    <BodyWrapper>
+      <Header logoHref="#" />
+      <Body>{children}</Body>
+    </BodyWrapper>
+    {/* </ResizableContainer> */}
+  </Wrapper>
+);
+
+const Wrapper = styled(WrapperBase)(
+  ({ theme: { leading } }) => css`
+    border-width: 0 0 1px; /* CodeBlockには上ボーダーがないので、下のみボーダーをつける */
+
+    /* FIXME: @scope が来たら書き直したい! */
+
+    /* src/templates/article.tsx の無効化 */
+    h2,
+    h3,
+    h4,
+    h5,
+    h2 + h5,
+    p,
+    ul,
+    ol,
+    table,
+    table th,
+    code {
+      margin-block: revert;
+      font-size: revert;
+      line-height: revert;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      line-height: ${leading.TIGHT};
+    }
+
+    p {
+      margin-block: 0;
+      line-height: ${leading.NORMAL};
+    }
+
+    ul {
+      list-style-type: none;
+      padding-inline-start: unset;
+    }
+
+    /* FIXME!: プロダクトのスタイルを反映できていません。
+     * line-height など継承されるスタイルを当てる必要があります。
+     */
+  `,
+);
+const padding = css(
+  ({ theme: { space } }) => css`
+    padding-inline: ${space(1.5)};
+
+    @media (max-width: 1440px) {
+      padding-inline: ${space(1.25)};
+    }
+
+    @media (max-width: 1024px) {
+      padding-inline: ${space(1)};
+    }
+
+    @media (max-width: 768px) {
+      padding-inline: ${space(0.75)};
+    }
+
+    @media (max-width: 480px) {
+      padding-inline: ${space(0.5)};
+    }
+  `,
+);
+const Body = styled.div`
+  ${padding}
+`;
+
+const BodyWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  overflow: scroll;
+`;

--- a/src/components/ComponentPreview/README.md
+++ b/src/components/ComponentPreview/README.md
@@ -1,0 +1,14 @@
+# UIコンポーネントをプレビューするコンポーネント
+
+`/content/articles/products/component/`以下のページなどで、UIコンポーネントの実際のレンダリング結果を表示するためのコンポーネントです。
+
+## 使い方
+
+MDXファイルで`import`して使うのは`<ComponentPreview>`コンポーネントです（`WrapperBase.tsx`と`ProductWrapper.tsx`は、`ComponentPreview.tsx`から`import`されている）。
+
+## レンダリング
+
+基本的には`children`として受け取ったJSX（TSX）をそのままレンダリングします。この際、`WrapperBase.tsx`と`ProductWrapper.tsx`で、スタイルの適用や、`SmartHR`のヘッダーの表示などを行なっています。
+
+### オプション指定
+`layout`propsでヘッダー表示の有無を切り替えるなどのオプションを指定できます。

--- a/src/components/ComponentPreview/WrapperBase.tsx
+++ b/src/components/ComponentPreview/WrapperBase.tsx
@@ -1,0 +1,10 @@
+import styled, { css } from 'styled-components'
+
+export const WrapperBase = styled.div(
+  ({ theme: { border, color, space } }) => css`
+    margin-block-start: ${space(0.5)};
+    border: ${border.shorthand};
+    background-color: ${color.WHITE};
+    font-family: system-ui, sans-serif;
+  `,
+)

--- a/src/components/ComponentPreview/index.ts
+++ b/src/components/ComponentPreview/index.ts
@@ -1,0 +1,1 @@
+export { ComponentPreview } from './ComponentPreview'

--- a/src/components/MDXComponents/CodeBlock.astro
+++ b/src/components/MDXComponents/CodeBlock.astro
@@ -1,0 +1,17 @@
+---
+import { CodeBlock } from '@/components/article/CodeBlock';
+
+type Props = {
+  code: string;
+  language?: string;
+  meta?: string;
+};
+
+const { code, language, meta } = Astro.props;
+
+// スペース区切りの meta 文字列を、その文字列をキーとしたオブジェクトに変換
+// 例: ```tsx editable -> { editable: true }
+const props = meta ? Object.fromEntries(meta.split(' ').map((key) => [key, true])) : {};
+---
+
+<CodeBlock code={code} language={language} {...props} client:only="react" />

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -97,7 +97,7 @@ export const CodeBlock: FC<Props> = ({
   }
 
   return (
-    <Highlight code={codeString} language={language} theme={isStorybook ? themes.vsDark : theme}>
+    <Highlight code={codeString} language={language ?? ''} theme={isStorybook ? themes.vsDark : theme}>
       {({ style, tokens, getLineProps, getTokenProps }) => (
         <CodeWrapper>
           <PreContainer $isStorybook={isStorybook}>

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -62,10 +62,7 @@ export const CodeBlock: FC<Props> = ({
   language,
   ...componentProps // 残りのpropsはLivePreviewするコンポーネントに渡す
 }) => {
-  // const language = className ? className.replace(/language-/, '') : '';
   // Storybookとのコード共通化のため、childrenで渡ってくるコードには`render()`が含まれていない。LivePreviewでコンポーネントのレンダリングが必要な場合には、末尾に追加する。
-  //
-  console.log(editable, noIframe, withStyled, componentProps);
 
   const renderingPropsText = Object.keys(componentProps)
     .map((key) => `${key}="${componentProps[key as keyof typeof componentProps]}"`)

--- a/src/components/article/CodeBlock/CodeBlock.tsx
+++ b/src/components/article/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,176 @@
+import { PATTERNS_STORYBOOK_URL } from '@/constants/application';
+import { CSS_COLOR } from '@/constants/style';
+import { Highlight, themes } from 'prism-react-renderer';
+import React, { type CSSProperties, type FC } from 'react';
+import type { LiveProvider } from 'react-live';
+import * as ui from 'smarthr-ui';
+import type { Gap, SeparateGap } from 'smarthr-ui/lib/types';
+import styled from 'styled-components';
+
+// TODO SmartHR な Dark テーマほしいな!!!
+import { CopyButton } from './CopyButton';
+import { LiveContainer } from './LiveContainer';
+
+type LiveProviderProps = React.ComponentProps<typeof LiveProvider>;
+
+export type LiveContainerProps = {
+  code?: string;
+  language?: string;
+  withStyled?: boolean;
+  /**
+   * @deprecated noIframe は非推奨です。iframeが原因で表示が崩れるなどやむを得ない場合のみ使用してください。
+   */
+  noIframe?: boolean;
+} & Pick<LiveProviderProps, 'scope'> & {
+    gap?: Gap | SeparateGap;
+    align?: CSSProperties['alignItems'];
+    layout?: 'none' | 'product';
+  };
+
+type Props = {
+  children: string;
+  className?: string;
+  editable?: boolean;
+  isStorybook?: boolean;
+  renderingComponent?: string;
+  componentTitle?: string;
+} & LiveContainerProps;
+
+const theme = {
+  ...themes.github,
+  ...{
+    plain: {
+      backgroundColor: CSS_COLOR.SEMANTICS_COLUMN,
+    },
+  },
+};
+
+export const CodeBlock: FC<Props> = ({
+  children,
+  className,
+  editable = false,
+  noIframe = false,
+  isStorybook = false,
+  scope,
+  withStyled = false,
+  renderingComponent,
+  componentTitle,
+  gap,
+  align,
+  layout,
+  code,
+  language,
+  ...componentProps // 残りのpropsはLivePreviewするコンポーネントに渡す
+}) => {
+  // const language = className ? className.replace(/language-/, '') : '';
+  // Storybookとのコード共通化のため、childrenで渡ってくるコードには`render()`が含まれていない。LivePreviewでコンポーネントのレンダリングが必要な場合には、末尾に追加する。
+  //
+  console.log(editable, noIframe, withStyled, componentProps);
+
+  const renderingPropsText = Object.keys(componentProps)
+    .map((key) => `${key}="${componentProps[key as keyof typeof componentProps]}"`)
+    .join(' ');
+
+  const rawCode = code || children;
+  const codeString = renderingComponent ? `${rawCode}\nrender(<${renderingComponent} ${renderingPropsText} />)` : rawCode.trim();
+
+  const TextLink = ui.TextLink;
+
+  if (editable) {
+    return (
+      <Wrapper>
+        {renderingComponent && (
+          <LinkWrapper>
+            <TextLink href={`${PATTERNS_STORYBOOK_URL}?path=/story/${componentTitle}/`} target="_blank">
+              別画面で開く
+            </TextLink>
+          </LinkWrapper>
+        )}
+        <LiveContainer
+          code={code}
+          language={language}
+          withStyled={withStyled}
+          noIframe={noIframe}
+          gap={gap}
+          align={align}
+          layout={layout}
+        />
+      </Wrapper>
+    );
+  }
+
+  return (
+    <Highlight code={codeString} language={language} theme={isStorybook ? themes.vsDark : theme}>
+      {({ style, tokens, getLineProps, getTokenProps }) => (
+        <CodeWrapper>
+          <PreContainer $isStorybook={isStorybook}>
+            <CopyButton text={codeString} />
+            <pre className={className} style={style}>
+              {tokens.map((line, i) => (
+                <div {...getLineProps({ line, key: i })} key={i}>
+                  {line.map((token, key) => (
+                    <span {...getTokenProps({ token, key })} key={key} />
+                  ))}
+                </div>
+              ))}
+            </pre>
+          </PreContainer>
+        </CodeWrapper>
+      )}
+    </Highlight>
+  );
+};
+
+const Wrapper = styled.div`
+  margin-block: 16px 0;
+`;
+
+const LinkWrapper = styled.div`
+  font-size: 0.8rem;
+  text-align: right;
+`;
+
+const CodeWrapper = styled.div`
+  position: relative;
+`;
+
+const PreContainer = styled.div<{ $isStorybook?: boolean }>`
+  font-family: monospace;
+  margin-block: 16px 0;
+  border: 1px solid ${CSS_COLOR.SEMANTICS_BORDER};
+  background-color: ${CSS_COLOR.LIGHT_GREY_3};
+  overflow-x: scroll;
+
+  & > button {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+  }
+
+  /* preのデフォルトは display: block; で幅100%になるが、100%を超えられるように上書き(祖先要素には横スクロールを適用) */
+  pre {
+    width: max-content;
+    min-width: 100%;
+    min-height: 100%;
+    margin: 0;
+    padding: 2.75rem 1.5rem 1.5rem;
+    box-sizing: border-box;
+  }
+
+  /* LiveEditor内で preに white-space: pre-wrap; が適用されているため、文字を強制的に折り返すようにする */
+  * {
+    word-break: break-all;
+  }
+
+  ${({ $isStorybook }) =>
+    $isStorybook &&
+    `
+      margin: 0;
+      height: 300px;
+      border: 0;
+      overflow: scroll;
+      resize: vertical;
+    `};
+`;
+
+export { PreContainer };

--- a/src/components/article/CodeBlock/CopyButton.tsx
+++ b/src/components/article/CodeBlock/CopyButton.tsx
@@ -1,0 +1,38 @@
+import { CSS_COLOR, CSS_FONT_SIZE } from '@/constants/style';
+import { type FC, useState } from 'react';
+import { FaCheckIcon, FaCopyIcon } from 'smarthr-ui';
+import styled from 'styled-components';
+
+type CopyButtonProps = {
+  text: string;
+};
+
+export const CopyButton: FC<CopyButtonProps> = ({ text }) => {
+  const [copied, setCopied] = useState(false);
+  return (
+    <StyledButton
+      type="button"
+      onClick={() => {
+        navigator.clipboard.writeText(text).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        });
+      }}
+      title={`${text}をクリップボードにコピーする`}
+      disabled={copied}
+    >
+      {copied ? <FaCheckIcon /> : <FaCopyIcon />}
+    </StyledButton>
+  );
+};
+
+const StyledButton = styled.button`
+  appearance: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  color: ${CSS_COLOR.TEXT_GREY};
+  background: transparent;
+  cursor: pointer;
+  font-size: ${CSS_FONT_SIZE.PX_20};
+`;

--- a/src/components/article/CodeBlock/DesignPatternCodeBlock.tsx
+++ b/src/components/article/CodeBlock/DesignPatternCodeBlock.tsx
@@ -1,0 +1,42 @@
+import { CodeBlock } from '@/components/article/CodeBlock';
+import { type FC } from 'react';
+
+type Props = {
+  componentName: string;
+  componentTitle: string;
+};
+
+// const query = graphql`
+//   query PatternCode {
+//     allMdx(filter: { frontmatter: { patternName: { ne: null } } }) {
+//       nodes {
+//         frontmatter {
+//           patternName
+//         }
+//         fields {
+//           patternCode
+//         }
+//       }
+//     }
+//   }
+// `
+
+export const DesignPatternCodeBlock: FC<Props> = ({ componentName, componentTitle, ...componentProps }) => {
+  // const { allMdx } = useStaticQuery<Queries.PatternCodeQuery>(query)
+  // const patternCode = allMdx.nodes.find((node) => node.frontmatter?.patternName === componentName)?.fields?.patternCode || ''
+  const patternCode = 'WIP';
+
+  return (
+    <CodeBlock
+      {...componentProps}
+      className="tsx"
+      editable={true}
+      withStyled={true}
+      renderingComponent={componentName}
+      componentTitle={componentTitle}
+      layout="product"
+    >
+      {patternCode}
+    </CodeBlock>
+  );
+};

--- a/src/components/article/CodeBlock/LiveContainer.tsx
+++ b/src/components/article/CodeBlock/LiveContainer.tsx
@@ -1,0 +1,125 @@
+import { CSS_COLOR } from '@/constants/style';
+import { themes } from 'prism-react-renderer';
+import React, { type FC, type RefCallback, useState } from 'react';
+import Frame, { FrameContextConsumer } from 'react-frame-component';
+import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live';
+import { CssBaseLine } from 'smarthr-normalize-css';
+import * as ui from 'smarthr-ui';
+import 'smarthr-ui/smarthr-ui.css';
+import styled, { StyleSheetManager, ThemeProvider, css } from 'styled-components';
+
+import { ComponentPreview } from '../../ComponentPreview';
+import { PreContainer } from './CodeBlock';
+import type { LiveContainerProps } from './CodeBlock';
+import { CopyButton } from './CopyButton';
+
+type Props = LiveContainerProps;
+
+const smarthrTheme = ui.createTheme();
+
+const transformCode = (snippet: string) => {
+  // Storybookでも利用するため、コード内に`import`・`export`が記述されているが、ここではエラーになるので削除する。
+  return snippet.replace(/^import\s.*\sfrom\s.*$/gm, '').replace(/^export\s/gm, '');
+};
+
+export const LiveContainer: FC<Props> = ({ code, language, scope, noIframe, withStyled, gap, align, layout }) => {
+  const [iframeHeight, setIframeHeight] = useState(600); // デフォルトの高さを設定
+
+  // iframeの高さをコンテンツに合わせて変更する
+  const handleIframeMounted: RefCallback<HTMLIFrameElement> = (current) => {
+    const innerWindow = current?.contentWindow;
+
+    if (!innerWindow) {
+      return; // ここに該当することはないはず
+    }
+
+    // レンダリングが終わるのを待ってから高さを計算・セットする
+    setTimeout(() => {
+      const height = innerWindow.document.body.scrollHeight;
+      if (height > 0) {
+        setIframeHeight(height + 8); // ComponentPreviewコンポーネントに`margin-block-start: 8px`が指定されているため
+      }
+    }, 500);
+  };
+
+  return (
+    <ThemeProvider theme={smarthrTheme}>
+      <LiveProvider
+        code={code}
+        language={language}
+        scope={{ ...React, ...ui, styled, css, ...scope }}
+        theme={{
+          ...themes.vsDark,
+          plain: {
+            color: CSS_COLOR.LIGHT_GREY_3,
+            backgroundColor: CSS_COLOR.TEXT_BLACK,
+          },
+        }}
+        noInline={withStyled}
+        transformCode={transformCode}
+        enableTypeScript
+      >
+        {/* smarthr-ui側が対応したらnoIframeの条件分岐は削除し、iframeのdocument.bodyをLiveEditorに渡してportalにする予定です。 */}
+        {!noIframe ? (
+          <Frame
+            ref={handleIframeMounted}
+            width="100%"
+            height={`${iframeHeight}px`}
+            style={{ border: 'none', overflow: 'hidden', display: 'block' }}
+            referrerPolicy="same-origin"
+            head={<link href="/smarthr-ui.css" rel="stylesheet" />}
+          >
+            <FrameContextConsumer>
+              {({ document }) => (
+                <StyleSheetManager target={document?.head}>
+                  <ComponentPreview gap={gap} align={align} layout={layout}>
+                    <CssBaseLine />
+                    <LivePreview Component={React.Fragment} />
+                  </ComponentPreview>
+                </StyleSheetManager>
+              )}
+            </FrameContextConsumer>
+          </Frame>
+        ) : (
+          <ComponentPreview gap={gap} align={align} layout={layout}>
+            <LivePreview Component={React.Fragment} />
+          </ComponentPreview>
+        )}
+        <CodeWrapper>
+          <StyledLiveEditorContainer>
+            <PreContainer>
+              <CopyButton text={code || ''} />
+              {/* @ts-ignore -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
+              <LiveEditor padding={0} />
+            </PreContainer>
+          </StyledLiveEditorContainer>
+        </CodeWrapper>
+        <LiveError />
+      </LiveProvider>
+    </ThemeProvider>
+  );
+};
+
+const CodeWrapper = styled.div`
+  position: relative;
+
+  /* bodyに指定があるが、Frame内には効かないので再指定 */
+  line-height: 1.75;
+  overflow-wrap: break-word;
+`;
+
+const StyledLiveEditorContainer = styled.div`
+  & > div {
+    overflow: auto;
+    margin-block: 0;
+
+    /* LiveEditor内のpreにはpaddingの一括指定しかできないので親要素で設定 */
+    padding: 2.75rem 1.5rem 1.5rem;
+    border-width: 0 1px 1px;
+    background-color: ${CSS_COLOR.TEXT_BLACK};
+    max-height: 40em;
+    pre {
+      width: fit-content;
+    }
+  }
+`;

--- a/src/components/article/CodeBlock/README.md
+++ b/src/components/article/CodeBlock/README.md
@@ -1,0 +1,44 @@
+# コードを表示するコンポーネント
+
+## CodeBlockコンポーネント
+
+MDX内で、`codeBlock`つき記述したコードフェンスは、`article.tsx`テンプレートでこの`<CodeBlock>`コンポーネントに変換されます（`codeBlock`を付けていないコードフェンスには、`<code>`タグが適用されます）。
+
+`<CodeBlock>`が適用されるマークダウンの記載例：
+````
+```typescript codeBlock
+// コード
+```
+````
+
+### レンダリングの分岐
+
+`<CodeBlock>`コンポーネント内でも、指定されたprops（MDX内で"```"に続いて指定されたinfo string）により、どのようにレンダリングするかを分岐しています。
+
+#### editableが指定された場合
+[react-live](https://github.com/FormidableLabs/react-live)を使って、ライブエディタをレンダリングします。コードの上には実行結果が表示され、コードの編集が反映されます。
+
+さらに、`renderingComponent`が指定されている場合は、[デザインパターンのStorybook](https://main--62f0ae48c21b0728fd1a5c85.chromatic.com/)へのリンクも表示します。
+
+#### editableが指定されていない場合
+シンタックスハイライトを適用した（静的な）コードブロックを表示します。
+
+### ライブエディタ
+
+iframe内にreact-liveが提供するライブエディタを表示します。このフレーム内にはsmarthr-normalize-cssが適用されています。
+
+#### react-frame-component
+iframeの表示には[react-frame-component](https://www.npmjs.com/package/react-frame-component)を利用しています。
+
+#### TypeScript
+ライブエディタでは、コードをTypeScriptとしてトランスパイルするようになっています。TypeScript自体のコードは容量が大きいためGatsbyフレームワークのビルドには含めず、クライアントでのみCDNから読み込むようにしています（`<script>`タグです）。
+
+## DesignPatternCodeBlockコンポーネント
+
+`/content/articles/products/design-patterns`以下のMDXファイルから直接`import`して使用されるコンポーネントです。
+
+ビルド時に、[smarthr-patterns](https://github.com/kufu/smarthr-patterns)のGitHubリポジトリから読み込んだコードが、GraphQL Data Layerに登録されているため、デザインパターンの名前を指定するだけでコードを表示するようになっています。
+
+### 関連するファイル
+- `/src/gatsby-node/index.ts`
+- `/src/lib/fetchPatternCode.ts`

--- a/src/components/article/CodeBlock/index.ts
+++ b/src/components/article/CodeBlock/index.ts
@@ -1,0 +1,2 @@
+export { CodeBlock, type LiveContainerProps } from './CodeBlock';
+export { DesignPatternCodeBlock } from './DesignPatternCodeBlock';

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import ArticleLayout from '@/layouts/ArticleLayout.astro';
 import CustomLink from '@/components/MDXComponents/CustomLink.astro';
+import CodeBlock from '@/components/MDXComponents/CodeBlock.astro';
 import FragmentTitle from '@/components/MDXComponents/FragmentTitle.astro';
 
 export async function getStaticPaths() {
@@ -24,6 +25,7 @@ const { title, description } = article.data;
 
 const components = {
   pre: 'div',
+  'code-block': CodeBlock,
   h2: FragmentTitle,
   h3: FragmentTitle,
   h4: FragmentTitle,

--- a/src/remark/remark-code-block.ts
+++ b/src/remark/remark-code-block.ts
@@ -1,0 +1,36 @@
+import type { Code, Paragraph } from 'mdast';
+import type { Node } from 'unist';
+import { type Visitor, visit } from 'unist-util-visit';
+
+/**
+ * 「```tsx editable」のようなコードブロックから、コードと言語・メタ情報を取り出すプラグイン
+ * 参考: https://blog.mono0x.net/2023/07/10/astro-syntax-highlight-with-title/
+ */
+const remarkCodeBlock = () => {
+  return (tree: Node) => {
+    const visitor: Visitor<Code> = (node, index, parent) => {
+      if (!parent || index === undefined) {
+        return;
+      }
+
+      const { lang, meta, value } = node;
+
+      parent.children.splice(index, 1, {
+        type: 'paragraph',
+        data: {
+          hName: 'code-block',
+          hProperties: {
+            code: value,
+            ...(lang ? { language: lang } : {}),
+            ...(meta ? { meta } : {}),
+          },
+        },
+        children: [],
+      } as Paragraph);
+    };
+
+    visit(tree, 'code', visitor);
+  };
+};
+
+export default remarkCodeBlock;


### PR DESCRIPTION
## 課題・背景

Astro 移行

## やったこと

- 記事内のコードブロック部分のコンポーネントを移植しました

## やらなかったこと

- Storybook の部分のコンポーネントは移植していないので、 ResizableContainer を利用している箇所はコメントアウトしています

## スクリーンショット

![image](https://github.com/user-attachments/assets/8eb414b7-af09-439a-91d2-f470ace03bc8)
