### PR TITLE
default exportに統一

### DIFF
--- a/src/components/CodeBlock/CopyButton.tsx
+++ b/src/components/CodeBlock/CopyButton.tsx
@@ -1,13 +1,14 @@
-import { type FC, useState } from 'react';
+import { useState } from 'react';
 import { FaCheckIcon, FaCopyIcon } from 'smarthr-ui';
 import styles from './CopyButton.module.css';
 
-type CopyButtonProps = {
+type Props = {
   text: string;
 };
 
-export const CopyButton: FC<CopyButtonProps> = ({ text }) => {
+export default function CopyButton({ text }: Props) {
   const [copied, setCopied] = useState(false);
+
   return (
     <button
       className={styles.button}
@@ -24,4 +25,4 @@ export const CopyButton: FC<CopyButtonProps> = ({ text }) => {
       {copied ? <FaCheckIcon /> : <FaCopyIcon />}
     </button>
   );
-};
+}

--- a/src/components/CodeBlock/LiveContainer.tsx
+++ b/src/components/CodeBlock/LiveContainer.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, type RefCallback, useState } from 'react';
+import React, { type RefCallback, useState } from 'react';
 import { themes } from 'prism-react-renderer';
 import Frame, { FrameContextConsumer } from 'react-frame-component';
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live';
@@ -8,9 +8,9 @@ import styled, { StyleSheetManager, ThemeProvider, css } from 'styled-components
 import { CSS_COLOR } from '@/constants/style';
 import styles from './LiveContainer.module.css';
 import sharedStyles from './shared.module.css';
-import { ComponentPreview } from '../ComponentPreview';
+import ComponentPreview from '../ComponentPreview';
 import type { LiveContainerProps } from './';
-import { CopyButton } from './CopyButton';
+import CopyButton from './CopyButton';
 
 type Props = LiveContainerProps;
 
@@ -21,7 +21,7 @@ const transformCode = (snippet: string) => {
   return snippet.replace(/^import\s.*\sfrom\s.*$/gm, '').replace(/^export\s/gm, '');
 };
 
-export const LiveContainer: FC<Props> = ({ code, language, scope, noIframe, withStyled, gap, align, layout }) => {
+export default function LiveContainer({ code, language, scope, noIframe, withStyled, gap, align, layout }: Props) {
   const [iframeHeight, setIframeHeight] = useState(600); // デフォルトの高さを設定
 
   // iframeの高さをコンテンツに合わせて変更する
@@ -97,4 +97,4 @@ export const LiveContainer: FC<Props> = ({ code, language, scope, noIframe, with
       </LiveProvider>
     </ThemeProvider>
   );
-};
+}

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -1,4 +1,4 @@
-import React, { type CSSProperties, type FC } from 'react';
+import React, { type CSSProperties } from 'react';
 import clsx from 'clsx';
 // TODO SmartHR な Dark テーマほしいな!!!
 import { Highlight, themes } from 'prism-react-renderer';
@@ -9,8 +9,8 @@ import { PATTERNS_STORYBOOK_URL } from '@/constants/application';
 import { CSS_COLOR } from '@/constants/style';
 import styles from './index.module.css';
 import sharedStyles from './shared.module.css';
-import { CopyButton } from './CopyButton';
-import { LiveContainer } from './LiveContainer';
+import CopyButton from './CopyButton';
+import LiveContainer from './LiveContainer';
 
 type LiveProviderProps = React.ComponentProps<typeof LiveProvider>;
 
@@ -46,7 +46,7 @@ const theme = {
   },
 };
 
-export const CodeBlock: FC<Props> = ({
+export default function CodeBlock({
   children,
   className,
   editable = false,
@@ -62,7 +62,7 @@ export const CodeBlock: FC<Props> = ({
   code,
   language,
   ...componentProps // 残りのpropsはLivePreviewするコンポーネントに渡す
-}) => {
+}: Props) {
   // Storybookとのコード共通化のため、childrenで渡ってくるコードには`render()`が含まれていない。LivePreviewでコンポーネントのレンダリングが必要な場合には、末尾に追加する。
 
   const renderingPropsText = Object.keys(componentProps)
@@ -117,4 +117,4 @@ export const CodeBlock: FC<Props> = ({
       )}
     </Highlight>
   );
-};
+}

--- a/src/components/ComponentPreview/ProductWrapper.tsx
+++ b/src/components/ComponentPreview/ProductWrapper.tsx
@@ -1,19 +1,25 @@
-import React from 'react';
+import { type ReactNode } from 'react';
 import { Header } from 'smarthr-ui';
 import styled, { css } from 'styled-components';
-import { ResizableContainer } from '../ResizableContainer';
+import ResizableContainer from '../ResizableContainer';
 import { WrapperBase } from './WrapperBase';
 
-export const ProductWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <Wrapper>
-    <ResizableContainer defaultWidth="100%" defaultHeight="300px">
-      <BodyWrapper>
-        <Header logoHref="#" />
-        <Body>{children}</Body>
-      </BodyWrapper>
-    </ResizableContainer>
-  </Wrapper>
-);
+type Props = {
+  children: ReactNode;
+};
+
+export default function ProductWrapper({ children }: Props) {
+  return (
+    <Wrapper>
+      <ResizableContainer defaultWidth="100%" defaultHeight="300px">
+        <BodyWrapper>
+          <Header logoHref="#" />
+          <Body>{children}</Body>
+        </BodyWrapper>
+      </ResizableContainer>
+    </Wrapper>
+  );
+}
 
 const Wrapper = styled(WrapperBase)(
   ({ theme: { leading } }) => css`

--- a/src/components/ComponentPreview/index.tsx
+++ b/src/components/ComponentPreview/index.tsx
@@ -2,7 +2,7 @@ import React, { type CSSProperties, useMemo } from 'react';
 import { Cluster } from 'smarthr-ui';
 import type { Gap, SeparateGap } from 'smarthr-ui/lib/types';
 import styled, { css } from 'styled-components';
-import { ProductWrapper } from './ProductWrapper';
+import ProductWrapper from './ProductWrapper';
 import { WrapperBase } from './WrapperBase';
 
 type Props = {
@@ -12,12 +12,12 @@ type Props = {
   layout?: 'none' | 'product';
 };
 
-export const ComponentPreview = ({
+export default function ComponentPreview({
   children,
   gap = 1,
   align = 'center', // 無指定で stretch されると困るため
   layout,
-}: Props) => {
+}: Props) {
   return useMemo(() => {
     switch (layout) {
       default: {
@@ -37,7 +37,7 @@ export const ComponentPreview = ({
       }
     }
   }, [layout, align, children, gap]);
-};
+}
 
 const Wrapper = styled(WrapperBase)(
   ({ theme: { space } }) => css`

--- a/src/components/ComponentStory/index.tsx
+++ b/src/components/ComponentStory/index.tsx
@@ -1,11 +1,11 @@
-import { type FC, useState } from 'react';
+import { useState } from 'react';
 import { AnchorButton, Cluster, FaExternalLinkAltIcon, Loader, TabBar, TabItem, TextLink } from 'smarthr-ui';
 import { SHRUI_CHROMATIC_ID, SHRUI_GITHUB_PATH } from '@/constants/application';
 import type { UIStories } from '@/types/ui';
 import { UI_COMMIT_HASH, UI_VERSION } from '@/lib/getUIData';
 import styles from './index.module.css';
-import { CodeBlock } from '../CodeBlock';
-import { ResizableContainer } from '../ResizableContainer';
+import CodeBlock from '../CodeBlock';
+import ResizableContainer from '../ResizableContainer';
 
 type Props = {
   code: string;
@@ -14,7 +14,7 @@ type Props = {
 
 const STORYBOOK_BASE_URL = `https://${UI_COMMIT_HASH}--${SHRUI_CHROMATIC_ID}.chromatic.com/`;
 
-export const ComponentStory: FC<Props> = ({ code, stories }) => {
+export default function ComponentStory({ code, stories }: Props) {
   const [currentIframe, setCurrentIframe] = useState(stories.storyItems.at(0)?.iframeName ?? '');
   const [isLoadedIframe, setIsLoadedIframe] = useState(false);
 
@@ -99,4 +99,4 @@ export const ComponentStory: FC<Props> = ({ code, stories }) => {
       </div>
     </div>
   );
-};
+}

--- a/src/components/ResizableContainer/index.tsx
+++ b/src/components/ResizableContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { FaGripLinesIcon, FaGripLinesVerticalIcon } from 'smarthr-ui';
 import styled from 'styled-components';
 import { CSS_COLOR } from '@/constants/style';
@@ -9,7 +9,7 @@ type Props = {
   children: React.ReactNode;
 };
 
-export const ResizableContainer: FC<Props> = ({ defaultWidth, defaultHeight, children }) => {
+export default function ResizableContainer({ defaultWidth, defaultHeight, children }: Props) {
   const [pointerPosition, setPointerPosition] = useState<{ x: number | null; y: number | null }>({ x: null, y: null });
   const pointerPositionRef = useRef<{ x: number | null; y: number | null }>({ x: null, y: null });
   pointerPositionRef.current = pointerPosition;
@@ -114,7 +114,7 @@ export const ResizableContainer: FC<Props> = ({ defaultWidth, defaultHeight, chi
       </ResizeArea>
     </Container>
   );
-};
+}
 
 const Container = styled.div`
   user-select: none;

--- a/src/components/article/Article.astro
+++ b/src/components/article/Article.astro
@@ -1,8 +1,8 @@
 ---
-import styles from './Article.module.css';
 // NOTE: as はこの Issue の回避のため
 // https://github.com/withastro/language-tools/issues/580
 import { Article as UIArticle } from 'smarthr-ui';
+import styles from './Article.module.css';
 
 type Props = {
   title: string;

--- a/src/components/article/CodeBlock.astro
+++ b/src/components/article/CodeBlock.astro
@@ -1,7 +1,5 @@
 ---
-// NOTE: as はこの Issue の回避のため
-// https://github.com/withastro/language-tools/issues/580
-import { CodeBlock as ReactCodeBlock } from '@/components/CodeBlock';
+import ReactCodeBlock from '@/components/CodeBlock';
 
 type Props = {
   code: string;

--- a/src/components/article/ComponentPropsTable/TypeTag.tsx
+++ b/src/components/article/ComponentPropsTable/TypeTag.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import styles from './TypeTag.module.css';
 
 const TYPE_COLOR = {
@@ -25,13 +24,15 @@ type Props = {
   content: string;
 };
 
-export const TypeTag: FC<Props> = ({ content }) => (
-  <span
-    className={styles.typeTag}
-    style={{
-      backgroundColor: pickTypeColor(content),
-    }}
-  >
-    {content}
-  </span>
-);
+export default function TypeTag({ content }: Props) {
+  return (
+    <span
+      className={styles.typeTag}
+      style={{
+        backgroundColor: pickTypeColor(content),
+      }}
+    >
+      {content}
+    </span>
+  );
+}

--- a/src/components/article/ComponentPropsTable/index.tsx
+++ b/src/components/article/ComponentPropsTable/index.tsx
@@ -1,10 +1,9 @@
-import { type FC } from 'react';
 import { marked } from 'marked';
 import { StatusLabel, Text, WarningIcon } from 'smarthr-ui';
 import { getUIProps } from '@/lib/getUIData';
 import styles from './index.module.css';
 import { FragmentTitle } from '../FragmentTitle';
-import { TypeTag } from './TypeTag';
+import TypeTag from './TypeTag';
 
 export type ComponentPropsTableProps = {
   name: string;
@@ -12,7 +11,7 @@ export type ComponentPropsTableProps = {
   showTitle?: string;
 };
 
-export const ComponentPropsTable: FC<ComponentPropsTableProps> = ({ name, dirName, showTitle }) => {
+export default function ComponentPropsTable({ name, dirName, showTitle }: ComponentPropsTableProps) {
   // StoryのPropsを取得
   const data = getUIProps(name, dirName);
   if (!data) {
@@ -54,4 +53,4 @@ export const ComponentPropsTable: FC<ComponentPropsTableProps> = ({ name, dirNam
       </div>
     </>
   );
-};
+}

--- a/src/components/article/ComponentStory.astro
+++ b/src/components/article/ComponentStory.astro
@@ -3,7 +3,7 @@ import { getUIStories, UI_VERSION } from '@/lib/getUIData';
 import { fetchStoryCode } from '@/lib/fetchStoryCode';
 // NOTE: as はこの Issue の回避のため
 // https://github.com/withastro/language-tools/issues/580
-import { ComponentStory as ReactComponentStory } from '@/components/ComponentStory';
+import ReactComponentStory from '@/components/ComponentStory';
 
 export type Props = {
   name: string;

--- a/src/components/article/CustomLink/index.tsx
+++ b/src/components/article/CustomLink/index.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from 'react';
+import React from 'react';
 import { FaExternalLinkAltIcon } from 'smarthr-ui';
 import styles from './index.module.css';
 
@@ -9,7 +9,7 @@ type Props = {
 
 // 外部リンクの場合に、自動的に`target="_blank"`を付与するためのコンポーネントです。
 
-export const CustomLink: FC<Props> = ({ children, href, ...props }) => {
+export default function CustomLink({ children, href, ...props }: Props) {
   const isExternal = href.match(/^https?:\/\/(?!smarthr\.design).*?$/) !== null;
   const attrs: { [key: string]: string } = isExternal
     ? Object.assign(
@@ -31,4 +31,4 @@ export const CustomLink: FC<Props> = ({ children, href, ...props }) => {
       {children}
     </a>
   );
-};
+}

--- a/src/components/article/DesignPatternCodeBlock/index.tsx
+++ b/src/components/article/DesignPatternCodeBlock/index.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { CodeBlock } from '@/components/CodeBlock';
 
 type Props = {
@@ -21,7 +20,7 @@ type Props = {
 //   }
 // `
 
-export const DesignPatternCodeBlock: FC<Props> = ({ componentName, componentTitle, ...componentProps }) => {
+export default function DesignPatternCodeBlock({ componentName, componentTitle, ...componentProps }: Props) {
   // const { allMdx } = useStaticQuery<Queries.PatternCodeQuery>(query)
   // const patternCode = allMdx.nodes.find((node) => node.frontmatter?.patternName === componentName)?.fields?.patternCode || ''
   const patternCode = 'WIP';
@@ -39,4 +38,4 @@ export const DesignPatternCodeBlock: FC<Props> = ({ componentName, componentTitl
       {patternCode}
     </CodeBlock>
   );
-};
+}

--- a/src/components/article/FragmentTitle/index.tsx
+++ b/src/components/article/FragmentTitle/index.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from 'react';
+import React from 'react';
 import { FaLinkIcon } from 'smarthr-ui';
 import styles from './index.module.css';
 
@@ -10,7 +10,7 @@ type Props = {
   tag?: HeadingTagTypes;
 };
 
-export const FragmentTitle: FC<Props> = ({ tag = 'h2', id, children }) => {
+export default function FragmentTitle({ tag = 'h2', id, children }: Props) {
   const Wrapper = tag as keyof JSX.IntrinsicElements;
 
   return (
@@ -21,4 +21,4 @@ export const FragmentTitle: FC<Props> = ({ tag = 'h2', id, children }) => {
       </a>
     </Wrapper>
   );
-};
+}

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,9 +1,9 @@
 ---
 import { getCollection } from 'astro:content';
 import ArticleLayout from '@/layouts/ArticleLayout.astro';
-import { CustomLink } from '@/components/article/CustomLink';
+import CustomLink from '@/components/article/CustomLink';
 import CodeBlock from '@/components/article/CodeBlock.astro';
-import { FragmentTitle } from '@/components/article/FragmentTitle';
+import FragmentTitle from '@/components/article/FragmentTitle';
 import ResponsiveImage from '@/components/article/ResponsiveImage.astro';
 
 export async function getStaticPaths() {


### PR DESCRIPTION
## 課題・背景

- Astro移行

Astroコンポーネントが実質的にdefault exportなので、named exportが混ざっているとMDXでimportする際に戸惑う場面があったので統一しました

## やったこと

- Reactコンポーネントをdefault exportに統一

![image](https://github.com/user-attachments/assets/e5d3086e-be5e-4a35-92c5-a465ee8b2fc8)

↓
<img width="506" alt="image" src="https://github.com/user-attachments/assets/04bf603a-506f-40e2-bf63-a218db7cb806">

