### PR TITLE
fix: smarthr-ui の追従によるモバイルメニュー崩れを修正

### DIFF
--- a/src/components/shared/Header/Header.tsx
+++ b/src/components/shared/Header/Header.tsx
@@ -61,12 +61,6 @@ export const Header: FC<Props> = ({ isIndex = false }) => {
               {typeof window !== 'undefined' ? (
                 <Dialog
                   isOpen={isOpen}
-                  // 上下左右の余白は、smarthr-ui側がnumber型のみ対応しているので15pxの固定値にする
-                  // smarthr-uiへの対応などの経緯は：https://github.com/kufu/smarthr-design-system-issues/issues/1311
-                  top={15}
-                  right={15}
-                  left={15}
-                  bottom={15}
                   onPressEscape={() => {
                     setIsOpen(false)
                   }}
@@ -288,6 +282,9 @@ const StyledOpenButton = styled.button`
 `
 
 const Dialog = styled(shrDialog)`
+  position: absolute;
+  inset: 15px;
+
   > div {
     height: 100%;
   }


### PR DESCRIPTION
## 課題・背景

smarthr-ui の Dialog に top / right / bottom / left を指定できなくなったため、styled-components で上書きました。

<!--
issueをリンクしてね
-->

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/d066d68f-1539-4047-84a0-1b29a9ccdf9d) |  ![image](https://github.com/user-attachments/assets/47f1390a-ce3d-44f3-af15-e41e5e1d6fc1)