### PR TITLE
buildでastro checkを実行しないように

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "dev": "pnpm update:ui-data && astro dev",
     "start": "astro dev",
-    "build": "pnpm update:ui-data && astro check && astro build",
+    "build": "pnpm update:ui-data && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "lint:ts": "eslint 'src/**/*.{astro,ts,tsx}'",


### PR DESCRIPTION
## 課題・背景

- Astro化

## やったこと

- `pnpm build` で `astro check` を実行しないように
  - ESLint を導入している & husky や CI で実行しているので、ビルド時に動かす必要はないはず