### PR TITLE
fix: Markdownの書式でCodeBlockのlayout="product"が指定できない

### DIFF
--- a/src/components/CodeBlock/ComponentPreview.tsx
+++ b/src/components/CodeBlock/ComponentPreview.tsx
@@ -39,11 +39,11 @@ export default function ComponentPreview({ layout, children, ...props }: Props) 
 // iframe内に配置されるため引き続き styled-components を利用しています
 const StyledWrapperBase = styled(WrapperBase)(
   ({ theme: { leading } }) => css`
-    border-width: 0 0 1px; /* CodeBlockには上ボーダーがないので、下のみボーダーをつける */
+    border-width: 0 0 1px !important; /* CodeBlockには上ボーダーがないので、下のみボーダーをつける */
 
     /* FIXME: @scope が来たら書き直したい! */
 
-    /* src/templates/article.tsx の無効化 */
+    /* ArticleLayoutで指定されているスタイルの無効化 */
     h2,
     h3,
     h4,

--- a/src/components/article/CodeBlock.astro
+++ b/src/components/article/CodeBlock.astro
@@ -7,11 +7,33 @@ type Props = {
   meta?: string;
 };
 
-const { code, language, meta } = Astro.props;
+type MetaProps = {
+  [key: string]: string | boolean;
+};
 
-// スペース区切りの meta 文字列を、その文字列をキーとしたオブジェクトに変換
-// 例: ```tsx editable -> { editable: true }
-const props = meta ? Object.fromEntries(meta.split(' ').map((key) => [key, true])) : {};
+/**
+ * ```tsx editable layout="product" のようなメタ情報をパースする
+ * @param meta - スペース区切りのメタ情報
+ * @returns メタ情報をキーとしたオブジェクト
+ */
+const parseMeta = (meta: string | undefined): MetaProps => {
+  if (!meta) {
+    return {};
+  }
+
+  const result: MetaProps = {};
+  const items = meta.split(' ');
+
+  for (const item of items) {
+    const [key, value] = item.split('=');
+    result[key] = value ? value : true;
+  }
+
+  return result;
+};
+
+const { code, language, meta } = Astro.props;
+const props = parseMeta(meta);
 ---
 
 <ReactCodeBlock code={code} language={language} {...props} client:only="react" />


### PR DESCRIPTION
## 課題・背景

- Astro化

## やったこと

- ```tsx layout="product"` のような指定ができない問題を修正しました
