### PR TITLE
Algoliaのインデックスを更新するスクリプトを修正

### DIFF
--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-prod:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,11 +31,17 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
-      - run: pnpm build
+      - name: Build
+        run: pnpm build
 
-      - run: npx netlify-cli deploy --prod --dir=./dist
+      - name: Deploy
+        run: |
+          npx netlify-cli deploy --prod --dir=./dist
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+      - name: Update Algolia
+        run: pnpm tsx ./scripts/update-algoliasearch.ts

--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -31,7 +31,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build

--- a/scripts/update-algoliasearch.ts
+++ b/scripts/update-algoliasearch.ts
@@ -1,8 +1,84 @@
+// Algoliaのオブジェクトを更新するスクリプト
+//
+// 安全のため、CI環境でのみ実行できるようにしています
+// ローカルで実行する場合は、CI=1 を先頭に付けて実行してください
+//
+// オプション:
+// --replace-all 指定すると全てのオブジェクトを入れ替えます (デフォルトは更新)
+
 import fs from 'node:fs';
 import path from 'node:path';
 
 import { type BatchRequest, algoliasearch } from 'algoliasearch';
 import matter from 'gray-matter';
+
+// コマンドライン引数を取得
+const args = process.argv.slice(2);
+const isReplaceAllMode = args.find((arg) => arg === '--replace-all');
+
+// src/content/articles 以下のmdxファイルを取得
+const filePaths: string[] = [];
+walkDir(path.join(import.meta.dirname, '../src/content/articles'), filePaths);
+
+// ファイルの内容を取得してAlgoliaに送信する形式に変換
+const sendData = filePaths.map((fullpath) => {
+  try {
+    const mdx = fs.readFileSync(fullpath);
+    const { data, content } = matter(mdx);
+
+    const pagePath = getPagePath(fullpath, 'articles');
+    const category = pagePath.split('/').at(0) || '';
+
+    const { title, description } = data;
+
+    return {
+      objectID: pagePath,
+      id: pagePath,
+      title,
+      category,
+      description,
+      body: content,
+      path: pagePath,
+    };
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+});
+
+if (!process.env.CI) {
+  console.warn('🚨 実行環境がCIではないようです。ローカル環境で実行する場合は、CI=1 を先頭に付けて実行してください');
+  process.exit(1);
+}
+
+const client = algoliasearch(process.env.PUBLIC_ALGOLIA_APP_ID ?? '', process.env.ALGOLIA_ADMIN_API_KEY ?? '');
+
+console.log('🚀 Algoliaにデータを送信中');
+
+if (isReplaceAllMode) {
+  // 全てのオブジェクトを入れ替える
+  client.replaceAllObjects({
+    indexName: process.env.PUBLIC_ALGOLIA_INDEX_NAME ?? '',
+    objects: sendData,
+  });
+} else {
+  const requests = sendData.map(
+    (data): BatchRequest => ({
+      action: 'updateObject',
+      body: data,
+    }),
+  );
+
+  // オブジェクトを更新する
+  await client.batch({
+    indexName: process.env.PUBLIC_ALGOLIA_INDEX_NAME ?? '',
+    batchWriteParams: {
+      requests,
+    },
+  });
+}
+
+console.log('✨ 完了');
 
 /**
  * ディレクトリを再帰的に探索して、mdxファイルのパスを取得する
@@ -46,59 +122,3 @@ function getPagePath(fullPath: string, subDir: string): `${string}/` {
 
   return `${pagePath}/`;
 }
-
-// src/content/articles 以下のmdxファイルを取得
-const filePaths: string[] = [];
-walkDir(path.join(import.meta.dirname, '../src/content/articles'), filePaths);
-
-// ファイルの内容を取得してAlgoliaに送信する形式に変換
-const sendData = filePaths.map((fullpath) => {
-  try {
-    const mdx = fs.readFileSync(fullpath);
-    const { data, content } = matter(mdx);
-
-    const pagePath = getPagePath(fullpath, 'articles');
-    const category = pagePath.split('/').at(0) || '';
-
-    const { title, description } = data;
-
-    return {
-      id: pagePath,
-      title,
-      category,
-      description,
-      body: content,
-      path: pagePath,
-    };
-  } catch (e) {
-    console.error(e);
-    throw e;
-  }
-});
-
-if (!process.env.CI) {
-  console.log('🚨 実行環境がCIではないようです');
-  process.exit(1);
-}
-
-// Algoliaにデータを送信
-const client = algoliasearch(process.env.PUBLIC_ALGOLIA_APP_ID ?? '', process.env.PUBLIC_ALGOLIA_SEARCH_API_KEY ?? '');
-
-const requests = sendData.map(
-  (data): BatchRequest => ({
-    action: 'updateObject',
-    body: data,
-  }),
-);
-
-console.log('🚀 Algoliaにデータを送信中');
-
-// TODO: 動作確認
-await client.batch({
-  indexName: process.env.PUBLIC_ALGOLIA_INDEX_NAME ?? '',
-  batchWriteParams: {
-    requests,
-  },
-});
-
-console.log('✨ 完了');

--- a/scripts/update-algoliasearch.ts
+++ b/scripts/update-algoliasearch.ts
@@ -12,6 +12,11 @@ import path from 'node:path';
 import { type BatchRequest, algoliasearch } from 'algoliasearch';
 import matter from 'gray-matter';
 
+if (!process.env.CI) {
+  console.warn('🚨 実行環境がCIではないようです。ローカル環境で実行する場合は、CI=1 を先頭に付けて実行してください');
+  process.exit(1);
+}
+
 // コマンドライン引数を取得
 const args = process.argv.slice(2);
 const isReplaceAllMode = args.find((arg) => arg === '--replace-all');
@@ -45,11 +50,6 @@ const sendData = filePaths.map((fullpath) => {
     throw e;
   }
 });
-
-if (!process.env.CI) {
-  console.warn('🚨 実行環境がCIではないようです。ローカル環境で実行する場合は、CI=1 を先頭に付けて実行してください');
-  process.exit(1);
-}
 
 const client = algoliasearch(process.env.PUBLIC_ALGOLIA_APP_ID ?? '', process.env.ALGOLIA_ADMIN_API_KEY ?? '');
 


### PR DESCRIPTION
## 課題・背景

- Astro化

## やったこと

- スクリプトが動作するよう修正
- デプロイのワークフローで実行するよう追加

## 変更点について

Gatsby のプラグインでは ObjectID に内部で生成された ID が使われていましたが、移行に伴い ObjectID にページのパスを使うよう変更しました。

これにより、同じインデックスが2重で登録されてしまうので、初回デプロイ時のみ手元でコマンドを実行して本番環境のインデックスをまるごと入れ替える必要がありそうです。

インデックスの入れ替えは
```
pnpm tsx ./scripts/update-algoliasearch.ts --replace-all
```
で実行できるようにしています。
