### PR TITLE
DoAndDontのslot名をtextからlabelに変更

### DIFF
--- a/src/components/article/DoAndDont.astro
+++ b/src/components/article/DoAndDont.astro
@@ -31,7 +31,7 @@ const actualWidth = typeof width === 'number' ? `${width}px` : width;
         )
       }
     </div>
-    <slot name="text" />
+    <slot name="label" />
   </div>
 </div>
 

--- a/src/content/articles/operational-guideline/page-template/style-template.mdx
+++ b/src/content/articles/operational-guideline/page-template/style-template.mdx
@@ -212,10 +212,10 @@ import imageUrl from './images/sample.jpg';
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={imageUrl} alt="Do" />
-    <Text slot="text">ほげほげ</Text>
+    <Text slot="label">ほげほげ</Text>
   </DoAndDont>
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={imageUrl} alt="Dont" />
-    <Text slot="text">ほげほげ</Text>
+    <Text slot="label">ほげほげ</Text>
   </DoAndDont>
 </Cluster>

--- a/src/content/articles/products/components/check-box/index.mdx
+++ b/src/content/articles/products/components/check-box/index.mdx
@@ -63,11 +63,11 @@ import checkBoxDont2 from './images/check-box-dont2.png';
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={checkBoxDo} alt="Do" />
-    <Text slot="text">すべての選択肢が明示的に表示されているため、現在の状態が把握しやすい</Text>
+    <Text slot="label">すべての選択肢が明示的に表示されているため、現在の状態が把握しやすい</Text>
   </DoAndDont>
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={checkBoxDont} alt="Dont" />
-    <Text slot="text">「無効」という選択肢が暗黙的であり、現在の状態をラベルとチェック状態から推測しなければならない</Text>
+    <Text slot="label">「無効」という選択肢が暗黙的であり、現在の状態をラベルとチェック状態から推測しなければならない</Text>
   </DoAndDont>
 </Cluster>
 
@@ -88,12 +88,12 @@ import checkBoxDont2 from './images/check-box-dont2.png';
 <Cluster gap={1}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={checkBoxDo2} alt="Do" width="346" />
-    <Text slot="text">ユーザーは選択する操作に集中でき、それ以外の操作と区別しやすい</Text>
+    <Text slot="label">ユーザーは選択する操作に集中でき、それ以外の操作と区別しやすい</Text>
   </DoAndDont>
 
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={checkBoxDont2} alt="Dont" width="346" />
-    <Text slot="text">ユーザーが選択操作に集中できず、操作難易度が上がる</Text>
+    <Text slot="label">ユーザーが選択操作に集中できず、操作難易度が上がる</Text>
   </DoAndDont>
 </Cluster>
 

--- a/src/content/articles/products/components/combo-box/multi-combo-box.mdx
+++ b/src/content/articles/products/components/combo-box/multi-combo-box.mdx
@@ -38,11 +38,11 @@ MultiComboBoxで入力補助のヒントメッセージを表示したい場合�
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={multiComboBoxDo} alt="Do" width="346" />
-    <Text slot="text">ユーザーがテキストを入力しても入力補助としてヒントメッセージを確認できる</Text>
+    <Text slot="label">ユーザーがテキストを入力しても入力補助としてヒントメッセージを確認できる</Text>
   </DoAndDont>
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={multiComboBoxDont} alt="Dont" width="346" />
-    <Text slot="text">ユーザーがテキストを入力するとプレースホルダが確認できなくなり、入力補助として機能しない</Text>
+    <Text slot="label">ユーザーがテキストを入力するとプレースホルダが確認できなくなり、入力補助として機能しない</Text>
   </DoAndDont>
 </Cluster>
 

--- a/src/content/articles/products/components/combo-box/single-combo-box.mdx
+++ b/src/content/articles/products/components/combo-box/single-combo-box.mdx
@@ -38,12 +38,12 @@ SingleComboBoxで入力補助のヒントメッセージを表示したい場合
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={singleComboBoxDo} alt="Do" width="346" />
-    <Text slot="text">ユーザーがテキストを入力しても入力補助としてヒントメッセージを確認できる</Text>
+    <Text slot="label">ユーザーがテキストを入力しても入力補助としてヒントメッセージを確認できる</Text>
   </DoAndDont>
 
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={singleComboBoxDont} alt="Dont" width="346" />
-    <Text slot="text">ユーザーがテキストを入力するとプレースホルダが確認できなくなり、入力補助として機能しない</Text>
+    <Text slot="label">ユーザーがテキストを入力するとプレースホルダが確認できなくなり、入力補助として機能しない</Text>
   </DoAndDont>
 </Cluster>
 

--- a/src/content/articles/products/components/drop-zone/index.mdx
+++ b/src/content/articles/products/components/drop-zone/index.mdx
@@ -23,11 +23,11 @@ DropZoneは操作しやすさを担保するため一定以上の大きさでレ
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={InputFileDo} alt="Do" width="346" />
-    <Text slot="text">入力項目の大きさが揃っており、閲覧性が高い</Text>
+    <Text slot="label">入力項目の大きさが揃っており、閲覧性が高い</Text>
   </DoAndDont>
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={InputFileDont} alt="Dont" width="346" />
-    <Text slot="text">入力項目の大きさに差があり、項目を見落とす恐れがある</Text>
+    <Text slot="label">入力項目の大きさに差があり、項目を見落とす恐れがある</Text>
   </DoAndDont>
 </Cluster>
 

--- a/src/content/articles/products/components/information-panel/index.mdx
+++ b/src/content/articles/products/components/information-panel/index.mdx
@@ -32,11 +32,11 @@ InformationPanelの[レイヤー順序](/products/design-tokens/z-index/#h2-1)�
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={imageDo} alt="Do" />
-    <Text slot="text">BaseのなかでBaseColumnとResponseMessageを用いて代替されている</Text>
+    <Text slot="label">BaseのなかでBaseColumnとResponseMessageを用いて代替されている</Text>
   </DoAndDont>
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={imageDont} alt="Dont" />
-    <Text slot="text">Baseのなかに直接InformationPanelが置かれている</Text>
+    <Text slot="label">Baseのなかに直接InformationPanelが置かれている</Text>
   </DoAndDont>
 </Cluster>
 

--- a/src/content/articles/products/components/input/index.mdx
+++ b/src/content/articles/products/components/input/index.mdx
@@ -25,11 +25,11 @@ import inputWidthDont from './images/input-width-dont.png'
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={inputWidthDo} alt="Do" />
-    <Text slot="text">入力する内容の量が精査され、幅が調整されている</Text>
+    <Text slot="label">入力する内容の量が精査され、幅が調整されている</Text>
   </DoAndDont>
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={inputWidthDont} alt="Dont" />
-    <Text slot="text">入力する内容の量が精査されず、幅が調整されていない</Text>
+    <Text slot="label">入力する内容の量が精査されず、幅が調整されていない</Text>
   </DoAndDont>
 </Cluster>
 
@@ -105,7 +105,7 @@ import SearchInputDont from './_components/SearchInputDont'
   <BaseColumn slot="img">
     <SearchInputDont />
   </BaseColumn>
-  <Text slot="text">検索ボタンのあるフォーム内のSearchInputで、入力内容のクリアボタンを押すと検索まで実行される</Text>
+  <Text slot="label">検索ボタンのあるフォーム内のSearchInputで、入力内容のクリアボタンを押すと検索まで実行される</Text>
 </DoAndDont>
 
 ## レイアウト

--- a/src/content/articles/products/components/radio-button-panel/index.mdx
+++ b/src/content/articles/products/components/radio-button-panel/index.mdx
@@ -44,12 +44,12 @@ import RadioButtonPanelDont from './images/radio-button-panel-dont.png';
 <Cluster gap={1}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={RadioButtonPanelDo} alt="Do" width="346" />
-    <Text slot="text">ユーザーは選択する操作に集中でき、それ<br/>以外の操作と区別しやすい</Text>
+    <Text slot="label">ユーザーは選択する操作に集中でき、それ<br/>以外の操作と区別しやすい</Text>
   </DoAndDont>
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={RadioButtonPanelDont} alt="Dont" width="346" />
     {/* textlint-disable */}
-    <Text slot="text">ユーザーが選択操作に集中できず、操作難<br/>易度が上がる</Text>
+    <Text slot="label">ユーザーが選択操作に集中できず、操作難<br/>易度が上がる</Text>
     {/* textlint-enable */}
   </DoAndDont>
 </Cluster>

--- a/src/content/articles/products/components/radio-button/index.mdx
+++ b/src/content/articles/products/components/radio-button/index.mdx
@@ -52,11 +52,11 @@ import RadioButtonDont from './images/radio-button-dont.png';
 <Cluster gap={1}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={RadioButtonDo} alt="Do" width="346" />
-    <Text slot="text">ユーザーは選択する操作に集中でき、それ以外の操作と区別しやすい</Text>
+    <Text slot="label">ユーザーは選択する操作に集中でき、それ以外の操作と区別しやすい</Text>
   </DoAndDont>
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={RadioButtonDont} alt="Dont" width="346" />
-    <Text slot="text">ユーザーが選択操作に集中できず、操作難易度が上がる</Text>
+    <Text slot="label">ユーザーが選択操作に集中できず、操作難易度が上がる</Text>
   </DoAndDont>
 </Cluster>
 

--- a/src/content/articles/products/components/textarea/index.mdx
+++ b/src/content/articles/products/components/textarea/index.mdx
@@ -24,12 +24,12 @@ import textareaSizeDont from './images/textarea-size-dont.png'
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={textareaSizeDo} alt="Do" />
-    <Text slot="text">入力する内容の量が精査され、幅と高さが調整されている</Text>
+    <Text slot="label">入力する内容の量が精査され、幅と高さが調整されている</Text>
   </DoAndDont>
 
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={textareaSizeDont} alt="Dont" />
-    <Text slot="text">入力する内容の量が精査されず、幅と高さが調整されていない</Text>
+    <Text slot="label">入力する内容の量が精査されず、幅と高さが調整されていない</Text>
   </DoAndDont>
 </Cluster>
 

--- a/src/content/articles/products/design-patterns-core-features/access-control-setting-pattern.mdx
+++ b/src/content/articles/products/design-patterns-core-features/access-control-setting-pattern.mdx
@@ -107,12 +107,12 @@ SmartHR基本機能の共通設定おける、操作権限を設定する項目�
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={imageUrl6Do} alt="スクリーンショット: 設定項目の縦横に配置するレイアウトのDo" />
-    <Text slot="text">横幅に十分なスペースがある場合は、基本的に横並びにします。</Text>
+    <Text slot="label">横幅に十分なスペースがある場合は、基本的に横並びにします。</Text>
   </DoAndDont>
 
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={imageUrl6Dont} alt="スクリーンショット: 設定項目の縦横に配置するレイアウトのDon't" />
-    <Text slot="text">縦並びにすると、親項目の幅に対して要素の配置が偏ってしまい、視認性が低下する恐れがあります。</Text>
+    <Text slot="label">縦並びにすると、親項目の幅に対して要素の配置が偏ってしまい、視認性が低下する恐れがあります。</Text>
   </DoAndDont>
 </Cluster>
 
@@ -128,12 +128,12 @@ CRUDなど、設定項目の組み合わせが決まっている操作権限項�
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={imageUrl13Do} alt="スクリーンショット: 対応しない設定項目を空白として残すレイアウトのDo" />
-    <Text slot="text">対応していない設定項目が表示されていた箇所は、そのまま空白として残します。</Text>
+    <Text slot="label">対応していない設定項目が表示されていた箇所は、そのまま空白として残します。</Text>
   </DoAndDont>
 
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={imageUrl13Dont} alt="スクリーンショット: 対応しない設定項目を空白として残すレイアウトのDon't" />
-    <Text slot="text">詰めずに配置すると、どの設定項目が対応していないのか把握しづらくなるため、空白が必要です。</Text>
+    <Text slot="label">詰めずに配置すると、どの設定項目が対応していないのか把握しづらくなるため、空白が必要です。</Text>
   </DoAndDont>
 </Cluster>
 

--- a/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
+++ b/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
@@ -62,7 +62,7 @@ SmartHRにおいて、従業員のモバイルからの利用は全体の7割以
         </Stack>
       </Base>
     </BaseColumn>
-    <figcaption slot="text" id="caption1">
+    <figcaption slot="label" id="caption1">
       <Caption>コンテンツが読みにくく、構造を把握しにくい。</Caption>
     </figcaption>
   </DoAndDont>
@@ -81,7 +81,7 @@ SmartHRにおいて、従業員のモバイルからの利用は全体の7割以
         </Stack>
       </Base>
     </BaseColumn>
-    <figcaption slot="text" id="caption2">
+    <figcaption slot="label" id="caption2">
       <Caption>垂直方向に積み上げると最低限の可読性を保てます。</Caption>
     </figcaption>
   </DoAndDont>
@@ -127,7 +127,7 @@ SmartHRにおいて、従業員のモバイルからの利用は全体の7割以
         </div>
       </Stack>
     </BaseColumn>
-    <figcaption slot="text" id="caption3">
+    <figcaption slot="label" id="caption3">
       <Caption>ボタンが小さいと利用者の環境に依っては操作しにくい。</Caption>
     </figcaption>
   </DoAndDont>
@@ -142,7 +142,7 @@ SmartHRにおいて、従業員のモバイルからの利用は全体の7割以
         <Button variant="primary">保存</Button>
       </Stack>
     </BaseColumn>
-    <figcaption slot="text" id="caption4">
+    <figcaption slot="label" id="caption4">
       <Caption>幅いっぱいに広げ、十分に操作領域を取る。</Caption>
     </figcaption>
   </DoAndDont>
@@ -168,7 +168,7 @@ PrimaryボタンとSecondaryボタンなど複数の操作を水平方向に並�
         </Stack>
       </Base>
     </BaseColumn>
-    <figcaption slot="text" id="caption5">
+    <figcaption slot="label" id="caption5">
       <Caption>水平方向に並べる場合は後方にPrimaryボタンを置く。</Caption>
     </figcaption>
   </DoAndDont>
@@ -186,7 +186,7 @@ PrimaryボタンとSecondaryボタンなど複数の操作を水平方向に並�
         </Stack>
       </Base>
     </BaseColumn>
-    <figcaption slot="text" id="caption6">
+    <figcaption slot="label" id="caption6">
       <Caption>垂直方向に並べる場合はPrimaryボタンを上に置く。</Caption>
     </figcaption>
   </DoAndDont>

--- a/src/content/articles/products/design-patterns/modal-ui/index.mdx
+++ b/src/content/articles/products/design-patterns/modal-ui/index.mdx
@@ -138,7 +138,7 @@ SmartHR UIでは[ActionDialog](/products/components/dialog/action-dialog/)と[Me
 
 <DoAndDont type="dont">
   <Image slot="img" src={imageUrlUpwardDont} alt="Dont" />
-  <Text slot="text">「上に戻るリンク」と［キャンセル］ボタンが両方配置されている。</Text>
+  <Text slot="label">「上に戻るリンク」と［キャンセル］ボタンが両方配置されている。</Text>
 </DoAndDont>
 
 ## エラー状態のアクセシビリティ
@@ -153,12 +153,12 @@ SmartHR UIでは[ActionDialog](/products/components/dialog/action-dialog/)と[Me
 
 <DoAndDont type="do">
   <Image slot="img" src={imageUrlAccessibilityDo} alt="必須項目が空欄のまま完了ボタンを押すとエラーが返り、どの項目にどんな問題があるかが示される。" />
-  <Text slot="text">必須項目が空欄のまま完了ボタンを押すとエラーが返り、どの項目にどんな問題があるかが示される。</Text>
+  <Text slot="label">必須項目が空欄のまま完了ボタンを押すとエラーが返り、どの項目にどんな問題があるかが示される。</Text>
 </DoAndDont>
 
 <DoAndDont type="dont">
   <Image slot="img" src={imageUrlAccessibilityDont} alt="必須条件を満たさない限り完了ボタンが無効化され押せない。" />
-  <Text slot="text">必須条件を満たさない限り完了ボタンが無効化され押せない。</Text>
+  <Text slot="label">必須条件を満たさない限り完了ボタンが無効化され押せない。</Text>
 </DoAndDont>
 
 ## 参考文献

--- a/src/content/articles/products/design-patterns/smarthr-table.mdx
+++ b/src/content/articles/products/design-patterns/smarthr-table.mdx
@@ -107,12 +107,12 @@ OOUIにおける`コレクション`と、コレクションに関連するア�
 <Cluster gap={1}>
   <DoAndDont type="do">
     <Image slot="img" src={noTitleDo} alt="Do" />
-    <Text slot="text">画面タイトルとテーブルの間に余白ができない場合は省略できる</Text>
+    <Text slot="label">画面タイトルとテーブルの間に余白ができない場合は省略できる</Text>
   </DoAndDont>
 
   <DoAndDont type="dont" width="auto">
     <Image slot="img" src={noTitleDont} alt="Dont" />
-    <Text slot="text">画面タイトルとテーブルの間にテーブル操作エリアがあり、テーブルの左上に不要な余白ができる</Text>
+    <Text slot="label">画面タイトルとテーブルの間にテーブル操作エリアがあり、テーブルの左上に不要な余白ができる</Text>
   </DoAndDont>
 </Cluster>
 
@@ -169,12 +169,12 @@ OOUIにおける`コレクション`と、コレクションに関連するア�
 <Cluster gap={1}>
   <DoAndDont type="do">
     <Image slot="img" src={onlyPaginationDo} alt="Do" />
-    <Text slot="text">Base内の上部のエリアごと非表示にする。</Text>
+    <Text slot="label">Base内の上部のエリアごと非表示にする。</Text>
   </DoAndDont>
 
   <DoAndDont type="dont">
     <Image slot="img" src={onlyPaginationDont} alt="Dont" />
-    <Text slot="text">テーブルのページ送りのみ配置すると、左に不要な余白ができるため、視線誘導として不適切。</Text>
+    <Text slot="label">テーブルのページ送りのみ配置すると、左に不要な余白ができるため、視線誘導として不適切。</Text>
   </DoAndDont>
 </Cluster>
 

--- a/src/content/articles/products/design-patterns/visual-guidance/index.mdx
+++ b/src/content/articles/products/design-patterns/visual-guidance/index.mdx
@@ -144,11 +144,11 @@ import Sample3Dont from './images/Sample3_DONT.png'
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={Sample1Do} alt="Do" />
-    <Text slot="text"><a href="#h4-0">F型の視線移動</a>を考慮した配置になっている</Text>
+    <Text slot="label"><a href="#h4-0">F型の視線移動</a>を考慮した配置になっている</Text>
   </DoAndDont>
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={Sample1Dont} alt="Dont" />
-    <Text slot="text">
+    <Text slot="label">
       <a href="#h4-0">F型の視線移動</a>を考慮した配置になっていない
       <List>
         <li>見出しがフォーム領域（<a href="/products/components/base/">Base</a>）に対して左側に配置されていない</li>
@@ -164,14 +164,14 @@ import Sample3Dont from './images/Sample3_DONT.png'
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={Sample2Do} alt="Do" />
-    <Text slot="text">
+    <Text slot="label">
       <a href="#h4-1">Z型の視線移動</a>を考慮した配置になっており、主要な情報とアクションが見逃されにくい
     </Text>
   </DoAndDont>
 
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={Sample2Dont} alt="Dont" />
-    <Text slot="text">
+    <Text slot="label">
       <a href="/products/components/float-area/">FloatArea</a>の採用から<a href="#h4-1">Z型の視線移動</a>を期待するレイアウトだが、［操作ボタン1］［目的となるボタン］が「Z」の視線上に配置されていない
     </Text>
   </DoAndDont>
@@ -182,14 +182,14 @@ import Sample3Dont from './images/Sample3_DONT.png'
 <Cluster gap={{ row: 0, column: 1 }}>
   <DoAndDont type="do" width="calc(50% - 8px)">
     <Image slot="img" src={Sample3Do} alt="Do" />
-    <Text slot="text">
+    <Text slot="label">
       <a href="#h4-0">F型の視線移動</a>を考慮した配置になっている
     </Text>
   </DoAndDont>
 
   <DoAndDont type="dont" width="calc(50% - 8px)">
     <Image slot="img" src={Sample3Dont} alt="Dont" />
-    <Text slot="text">
+    <Text slot="label">
       オブジェクトの一覧画面から<a href="#h4-0">F型の視線移動</a>を期待するレイアウトだが、視線の流れが途切れやすい配置になっている
       <List>
         <li>検索フォームがなく空白であるため、視線を横に移動する起点がなく<a href="/products/components/pagination/">Pagination</a>が見逃される可能性がある</li>


### PR DESCRIPTION
## 課題・背景

- Astro化

## やったこと

- DoAndDontコンポーネントのslot名をlabelに変更
  - 移植前の該当するProp名がLabelだったため
