### PR TITLE
ComponentStoryのレイアウトシフトを軽減

### DIFF
--- a/src/components/article/ComponentStory.astro
+++ b/src/components/article/ComponentStory.astro
@@ -20,4 +20,14 @@ if (!stories) {
 const code = await fetchStoryCode(UI_VERSION, stories.filePath);
 ---
 
-<ReactComponentStory {...props} stories={stories} code={code} client:only="react" />
+<ReactComponentStory {...props} stories={stories} code={code} client:only="react">
+  <div class="fallback" slot="fallback"></div>
+</ReactComponentStory>
+
+<style lang="scss">
+  // レイアウトシフトを軽減するため
+  .fallback {
+    margin-block: 48px 0;
+    height: 751px;
+  }
+</style>


### PR DESCRIPTION
## 課題・背景

- Astro化

## やったこと

- 特に PC で ComponentStory のレイアウトシフトが大きかったので軽減しました

## やらなかったこと

- スマホではプレースホルダーの高さと実際の高さが異なり、若干のレイアウトシフトが起きますが、ファーストビューに ComponentStory 全体が入ることはほぼないので考慮していません

## キャプチャ

|Before|After|
| --- | --- |
| ![before](https://github.com/user-attachments/assets/9d7c614f-84a9-4a16-b713-37d2faba14c3) | ![after](https://github.com/user-attachments/assets/a778ee5f-4846-4f7f-924b-5e4a28ce188e) |
