### PR TITLE
PropTableのタグが適切に改行されず突き抜ける場合がある

### DIFF
--- a/src/components/article/ComponentPropsTableTag.astro
+++ b/src/components/article/ComponentPropsTableTag.astro
@@ -36,6 +36,7 @@ const { content } = Astro.props;
 
 <style lang="scss">
   span {
+    word-break: break-word;
     font-size: var(--font-size-14);
     color: var(--color-white);
     padding: 4px 8px;


### PR DESCRIPTION
## 課題・背景

- Astro化
- PropTable のタグが適切に改行されず突き抜ける場合がある問題を修正しました

## やったこと

- ComponentPropsTableTag の span に `word-break: break-word` を付け、適切に改行されるように

## キャプチャ

(tertiaryLinks の箇所)

|Before|After|
| --- | --- |
| ![image](https://github.com/user-attachments/assets/43910a32-3fdd-418e-a345-88d1e5807755) | ![image](https://github.com/user-attachments/assets/791ae3fb-01f9-4f69-adfd-6ba5d4a0c2aa) |
