### PR TITLE
アイランドコンポーネント部分のレイアウトシフトを軽減・改善

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -28,7 +28,7 @@ const { isIndex } = Astro.props;
       <ul>
         <HeaderItems />
       </ul>
-      <MobileMenuContainer client:only="react">
+      <MobileMenuContainer client:load>
         <ul class="categoryUl">
           <HeaderItems isMobileMenu />
         </ul>

--- a/src/components/Header/MobileMenuContainer.tsx
+++ b/src/components/Header/MobileMenuContainer.tsx
@@ -28,39 +28,41 @@ export default function MobileMenuContainer({ children }: Props) {
         >
           <FaBarsIcon />
         </button>
-        <Dialog
-          className={styles.dialog}
-          isOpen={isOpen}
-          onPressEscape={() => {
-            setIsOpen(false);
-          }}
-          ariaLabel="メニュー"
-          id="panel-menu"
-        >
-          <div className={styles.contentContainer}>
-            {/* eslint-disable-next-line smarthr/a11y-clickable-element-has-text */}
-            <button className={styles.closeButton} type="button" title="メニューを閉じる" onClick={() => setIsOpen(false)}>
-              <svg width="32" height="33" viewBox="0 0 32 33" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <g clipPath="url(#clip0_1090_7843)">
-                  <path
-                    d="M6.70542 25.7015C6.19286 25.189 6.23395 24.3168 6.79721 23.7536L22.4351 8.11563C22.9984 7.55238 23.8705 7.51128 24.3831 8.02385L25.0018 8.64256C25.5144 9.15513 25.4733 10.0273 24.91 10.5905L9.27208 26.2284C8.70883 26.7917 7.8367 26.8328 7.32414 26.3202L6.70542 25.7015Z"
-                    fill="#23221F"
-                  />
-                  <path
-                    d="M24.3851 25.9665C23.8725 26.479 23.0004 26.4379 22.4372 25.8747L6.79923 10.2367C6.23597 9.67347 6.19488 8.80135 6.70744 8.28878L7.32616 7.67007C7.83872 7.1575 8.71085 7.1986 9.2741 7.76185L24.912 23.3998C25.4753 23.963 25.5164 24.8352 25.0038 25.3477L24.3851 25.9665Z"
-                    fill="#23221F"
-                  />
-                </g>
-                <defs>
-                  <clipPath id="clip0_1090_7843">
-                    <rect width="32" height="32" fill="white" transform="translate(0 0.996094)" />
-                  </clipPath>
-                </defs>
-              </svg>
-            </button>
-            <div className={styles.linkContainer}>{children}</div>
-          </div>
-        </Dialog>
+        {typeof window !== 'undefined' && (
+          <Dialog
+            className={styles.dialog}
+            isOpen={isOpen}
+            onPressEscape={() => {
+              setIsOpen(false);
+            }}
+            ariaLabel="メニュー"
+            id="panel-menu"
+          >
+            <div className={styles.contentContainer}>
+              {/* eslint-disable-next-line smarthr/a11y-clickable-element-has-text */}
+              <button className={styles.closeButton} type="button" title="メニューを閉じる" onClick={() => setIsOpen(false)}>
+                <svg width="32" height="33" viewBox="0 0 32 33" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <g clipPath="url(#clip0_1090_7843)">
+                    <path
+                      d="M6.70542 25.7015C6.19286 25.189 6.23395 24.3168 6.79721 23.7536L22.4351 8.11563C22.9984 7.55238 23.8705 7.51128 24.3831 8.02385L25.0018 8.64256C25.5144 9.15513 25.4733 10.0273 24.91 10.5905L9.27208 26.2284C8.70883 26.7917 7.8367 26.8328 7.32414 26.3202L6.70542 25.7015Z"
+                      fill="#23221F"
+                    />
+                    <path
+                      d="M24.3851 25.9665C23.8725 26.479 23.0004 26.4379 22.4372 25.8747L6.79923 10.2367C6.23597 9.67347 6.19488 8.80135 6.70744 8.28878L7.32616 7.67007C7.83872 7.1575 8.71085 7.1986 9.2741 7.76185L24.912 23.3998C25.4753 23.963 25.5164 24.8352 25.0038 25.3477L24.3851 25.9665Z"
+                      fill="#23221F"
+                    />
+                  </g>
+                  <defs>
+                    <clipPath id="clip0_1090_7843">
+                      <rect width="32" height="32" fill="white" transform="translate(0 0.996094)" />
+                    </clipPath>
+                  </defs>
+                </svg>
+              </button>
+              <div className={styles.linkContainer}>{children}</div>
+            </div>
+          </Dialog>
+        )}
       </div>
       <div className={clsx(styles.overlay, isOpen && styles.isOpen)} />
     </>

--- a/src/components/search/Search/SearchResultOuter.module.scss
+++ b/src/components/search/Search/SearchResultOuter.module.scss
@@ -21,7 +21,7 @@
   color: black;
   overflow-y: scroll;
 
-  >p {
+  > p {
     font-size: 0.9rem;
     margin: 0;
   }

--- a/src/content/articles/products/usability/_components/UsabilityCheckListWarning.tsx
+++ b/src/content/articles/products/usability/_components/UsabilityCheckListWarning.tsx
@@ -2,13 +2,13 @@ import { BaseColumn, WarningIcon } from 'smarthr-ui';
 
 export default function UsabilityCheckListWarning() {
   return (
-      <BaseColumn>
-        <WarningIcon
-          text={
-              <span>
-              コンテンツの「No.19 SmartHRの基本的な概念（用語）に合わせた命名をしているか」および「No.20
+    <BaseColumn>
+      <WarningIcon
+        text={
+          <span>
+            コンテンツの「No.19 SmartHRの基本的な概念（用語）に合わせた命名をしているか」および「No.20
             操作の導線やアクション名が基準に沿っているか」のチェックは任意とします。（現時点では確認作業が大きくなりすぎる可能性があるため）
-            </span>
+          </span>
         }
       />
     </BaseColumn>

--- a/src/data/indexContent.json
+++ b/src/data/indexContent.json
@@ -5,7 +5,8 @@
     "path": "/foundation/",
     "imagePath": "/images/thumbnail-foundations.png",
     "items": []
-  }, {
+  },
+  {
     "title": "基本要素",
     "description": "SmartHRのデザインを構成している基本的な要素です。",
     "path": "/basics/",
@@ -14,17 +15,20 @@
         "title": "ロゴ",
         "path": "/basics/logos/",
         "imagePath": "/images/thumbnail-logo.png"
-      }, {
+      },
+      {
         "title": "色",
         "path": "/basics/colors/",
         "imagePath": "/images/thumbnail-color.png"
-      }, {
+      },
+      {
         "title": "イラストレーション",
         "path": "/basics/illustration/",
         "imagePath": "/images/thumbnail-illustration.png"
       }
     ]
-  }, {
+  },
+  {
     "title": "アクセシビリティ",
     "description": "「だれでも」SmartHRを使える・コミュニケーションできるようにするための考え方、ガイドラインやチェックツールを提供しています。",
     "path": "/accessibility/",
@@ -35,7 +39,8 @@
         "imagePath": "/images/thumbnail-accessibility.png"
       }
     ]
-  }, {
+  },
+  {
     "title": "プロダクト",
     "description": "スケーラブルで一貫性のあるプロダクトを設計をするためのガイドラインです。オープンソース「SmartHR UI」の利用方法も示しています。",
     "path": "/products/",
@@ -44,13 +49,15 @@
         "title": "デザイントークン",
         "path": "/products/design-tokens/",
         "imagePath": "/images/thumbnail-design-token.png"
-      }, {
+      },
+      {
         "title": "コンポーネント",
         "path": "/products/components/",
         "imagePath": "/images/thumbnail-components.png"
       }
     ]
-  }, {
+  },
+  {
     "title": "コミュニケーション",
     "description": "一貫性のあるサービスコミュニケーションのためのアイテムとガイドラインです。マーケティング、セールス、カスタマーサクセスなどに利用します。",
     "path": "/communication/",
@@ -59,7 +66,8 @@
         "title": "写真・動画",
         "path": "/communication/photography/",
         "imagePath": "/images/thumbnail-photography.png"
-      }, {
+      },
+      {
         "title": "スライド資料",
         "path": "/communication/slides/",
         "imagePath": "/images/thumbnail-slides-templates.png"

--- a/src/data/navigationItem.json
+++ b/src/data/navigationItem.json
@@ -1,32 +1,32 @@
 [
   {
-    "title":"はじめに",
-    "key":"introduction",
-    "path":"/introduction/"
+    "title": "はじめに",
+    "key": "introduction",
+    "path": "/introduction/"
   },
   {
-    "title":"基本原則",
-    "key":"foundation",
-    "path":"/foundation/"
+    "title": "基本原則",
+    "key": "foundation",
+    "path": "/foundation/"
   },
   {
-    "title":"基本要素",
-    "key":"basics",
-    "path":"/basics/"
+    "title": "基本要素",
+    "key": "basics",
+    "path": "/basics/"
   },
   {
-    "title":"アクセシビリティ",
-    "key":"accessibility",
-    "path":"/accessibility/"
+    "title": "アクセシビリティ",
+    "key": "accessibility",
+    "path": "/accessibility/"
   },
   {
-    "title":"プロダクト",
-    "key":"products",
-    "path":"/products/"
+    "title": "プロダクト",
+    "key": "products",
+    "path": "/products/"
   },
   {
-    "title":"コミュニケーション",
-    "key":"communication",
-    "path":"/communication/"
+    "title": "コミュニケーション",
+    "key": "communication",
+    "path": "/communication/"
   }
 ]

--- a/src/lib/throttle.ts
+++ b/src/lib/throttle.ts
@@ -1,28 +1,28 @@
 export const throttle = <T extends unknown[]>(func: (...args: T) => void, wait: number) => {
-  let timeout: number | null = null
-  let previous = 0
+  let timeout: number | null = null;
+  let previous = 0;
 
   return (...args: T) => {
-    const now = Date.now()
-    const remaining = wait - (now - previous)
+    const now = Date.now();
+    const remaining = wait - (now - previous);
 
     if (remaining <= 0 || remaining > wait) {
       if (timeout !== null) {
-        window.clearTimeout(timeout)
-        timeout = null
+        window.clearTimeout(timeout);
+        timeout = null;
       }
 
-      previous = now
-      func(...args)
+      previous = now;
+      func(...args);
     } else if (!timeout) {
       timeout = window.setTimeout(() => {
-        previous = Date.now()
+        previous = Date.now();
         if (timeout !== null) {
-          window.clearTimeout(timeout)
-          timeout = null
+          window.clearTimeout(timeout);
+          timeout = null;
         }
-        func(...args)
-      }, remaining)
+        func(...args);
+      }, remaining);
     }
-  }
-}
+  };
+};

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -16,8 +16,14 @@ import SearchBox from '@/components/search/Search/SearchBox';
       <div class="search ais-SearchBox__root">
         <SearchBox
           isAvailable={import.meta.env.PUBLIC_ALGOLIA_APP_ID && import.meta.env.PUBLIC_ALGOLIA_SEARCH_API_KEY ? true : false}
-          client:load
-        />
+          client:only="react"
+        >
+          {
+            // client:loadでもSearchBoxが遅れて表示されCLSが起こるので、
+            // client:onlyを使い同じ高さのフォールバックを表示することでCLSを軽減しています
+          }
+          <div class="fallback" slot="fallback"></div>
+        </SearchBox>
       </div>
     </main>
     <IndexList />
@@ -57,5 +63,9 @@ import SearchBox from '@/components/search/Search/SearchBox';
     display: flex;
     flex-direction: column;
     align-items: center;
+  }
+
+  .fallback {
+    height: 110px;
   }
 </style>


### PR DESCRIPTION
## 課題・背景

- Astro化

## やったこと

- SearchBoxと同じ高さをフォールバック要素に指定し、検索ページのレイアウトシフトを軽減
- スマホヘッダーのハンバーガーメニューをビルド時にもレンダリングするように変更し、ヘッダーのレイアウトシフトを改善

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## キャプチャ

### 検索ページ

|Before|After|
| --- | --- |
| ![before](https://github.com/user-attachments/assets/3841374a-3dd2-4315-9a65-9121a48896da) | ![after](https://github.com/user-attachments/assets/a14870d7-a7e5-4512-abb9-2b7b04afa9db) |

### スマホヘッダー

|Before|After|
| --- | --- |
| ![sp-before](https://github.com/user-attachments/assets/0224cc26-3231-476c-b97e-74307c008690) | ![sp-after](https://github.com/user-attachments/assets/448e7463-e9ba-4ee8-b6ca-f2de1a14618b) |

