### PR TITLE
📝: レイヤー順序に FloatArea を追加

### DIFF
--- a/content/articles/products/design-tokens/z-index.mdx
+++ b/content/articles/products/design-tokens/z-index.mdx
@@ -25,7 +25,7 @@ CSSでは`z-index`を指しています。
 | :--- | :--- | :--- |
 | `AUTO` | auto |  |
 | `DEFAULT` | 0 |  |
-| `FIXED_MENU` | 100 | [BottomFixedArea](/products/components/bottom-fixed-area/)<br />[thead](/products/components/table/)（`fixedHead={true}`） |
+| `FIXED_MENU` | 100 | [BottomFixedArea](/products/components/bottom-fixed-area/)<br />[FloatArea](/products/components/float-area/)<br />[thead](/products/components/table/)（`fixedHead={true}`） |
 | *chatplus*（外部サービス） | 9999 | ChatPlusが利用している値。root設置の前提で、この要素よりも上位レイヤーにコンポーネントを配置したい場合、9999以上の値を設定する。 |
 | `OVERLAP_BASE` | 10000 | [Dropdown](/products/components/dropdown/)<br />[Dialog](/products/components/dialog/) |
 | *ヘルプセンター*（基本機能） | 10001 | 基本機能で使用されているヘルプセンターを表示するモードレスダイアログの値 |


### PR DESCRIPTION
## 課題・背景

FloatArea の z-index 値がマジックナンバーだったため、定義しました。

smarthr-ui を同時修正中。 https://github.com/kufu/smarthr-ui/pull/5066

<!--
issueをリンクしてね
-->

## やったこと

レイヤー順序の FIXED_MENU に FloatArea へのリンクを追加。

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
