### PR TITLE
fix: GitHubのリンク先がファイルになっていたので修正

### DIFF
--- a/src/components/ComponentStory/index.tsx
+++ b/src/components/ComponentStory/index.tsx
@@ -35,7 +35,8 @@ export default function ComponentStory({ code, stories, noMargin = false }: Comp
   const iframeViewModeUrl = new URL(iframeUrl);
   iframeViewModeUrl.searchParams.append('viewMode', 'story');
 
-  const githubUrl = new URL(`v${UI_VERSION}/${stories.filePath}`, SHRUI_GITHUB_PATH);
+  const githubSourcePath = stories.filePath.replace(/^\.\//, '').replace(/[^/]*?\.tsx$/, '');
+  const githubUrl = new URL(`v${UI_VERSION}/${githubSourcePath}`, SHRUI_GITHUB_PATH);
 
   const onClickTabItem = (itemId: string) => {
     if (itemId === currentIframe) {


### PR DESCRIPTION
## 課題・背景

- Astro化

## やったこと

- ファイルではなく、その親ディレクトリを開くようリンクを修正

↓この部分
![スクリーンショット 2024-10-29 16 40 06](https://github.com/user-attachments/assets/8e7519c3-3805-4ad7-b12d-62610a56a7a8)

