### PR TITLE
アクセシビリティのトップページから品質基準ページ（プロダクト内）へリンクさせる

### DIFF
--- a/content/articles/accessibility/index.mdx
+++ b/content/articles/accessibility/index.mdx
@@ -17,9 +17,10 @@ order: 1
 SmartHRは「well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会を作る。」というミッションを掲げ、働くすべての人を後押しするプラットフォームをつくっています。
 誰もがその人らしく働ける社会を実現するため、SmartHRはアクセシビリティの向上に取り組んでいます。
 
-SmartHRの開発方針や、JIS 8341-3:2016に基づくアクセシビリティ方針は、別サイト「[SmartHR ACCESSIBILITY](https://accessibility.smarthr.co.jp/)」に掲載しています。
+高いアクセシビリティ品質の達成に向けて[開発方針](https://accessibility.smarthr.co.jp/development/)や、[アクセシビリティの品質基準](https://smarthr.design/products/usability/accessibility/)を定めています。
 
-[開発方針｜SmartHR ACCESSIBILITY(外部サイト)](https://accessibility.smarthr.co.jp/development/)
+- [開発方針｜SmartHR ACCESSIBILITY(外部サイト)](https://accessibility.smarthr.co.jp/development/)
+- [アクセシビリティの品質基準 | ユーザビリティ（使用性） | SmartHR Design System](https://smarthr.design/products/usability/accessibility/)
 
 ## 機能ごとの検証結果
 SmartHRは、製品のアクセシビリティ向上を進めています。SmartHR製品の各機能のアクセシビリティ検証の結果を公開しています。

--- a/content/articles/accessibility/index.mdx
+++ b/content/articles/accessibility/index.mdx
@@ -17,7 +17,7 @@ order: 1
 SmartHRは「well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会を作る。」というミッションを掲げ、働くすべての人を後押しするプラットフォームをつくっています。
 誰もがその人らしく働ける社会を実現するため、SmartHRはアクセシビリティの向上に取り組んでいます。
 
-高いアクセシビリティ品質の達成に向けた[開発方針](https://accessibility.smarthr.co.jp/development/)や、[アクセシビリティの品質基準](https://smarthr.design/products/usability/accessibility/)を定めています。
+高いアクセシビリティ品質を実現するために、[開発方針](https://accessibility.smarthr.co.jp/development/)や、[アクセシビリティの品質基準](https://smarthr.design/products/usability/accessibility/)を定めています。
 
 - [開発方針｜SmartHR ACCESSIBILITY(外部サイト)](https://accessibility.smarthr.co.jp/development/)
 - [アクセシビリティの品質基準 | ユーザビリティ（使用性） | SmartHR Design System](https://smarthr.design/products/usability/accessibility/)

--- a/content/articles/accessibility/index.mdx
+++ b/content/articles/accessibility/index.mdx
@@ -17,7 +17,7 @@ order: 1
 SmartHRは「well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会を作る。」というミッションを掲げ、働くすべての人を後押しするプラットフォームをつくっています。
 誰もがその人らしく働ける社会を実現するため、SmartHRはアクセシビリティの向上に取り組んでいます。
 
-高いアクセシビリティ品質の達成に向けて[開発方針](https://accessibility.smarthr.co.jp/development/)や、[アクセシビリティの品質基準](https://smarthr.design/products/usability/accessibility/)を定めています。
+高いアクセシビリティ品質の達成に向けた[開発方針](https://accessibility.smarthr.co.jp/development/)や、[アクセシビリティの品質基準](https://smarthr.design/products/usability/accessibility/)を定めています。
 
 - [開発方針｜SmartHR ACCESSIBILITY(外部サイト)](https://accessibility.smarthr.co.jp/development/)
 - [アクセシビリティの品質基準 | ユーザビリティ（使用性） | SmartHR Design System](https://smarthr.design/products/usability/accessibility/)


### PR DESCRIPTION
## 課題・背景
アクセシビリティディレクトリ内のページから、アクセシビリティの品質基準のページへの動線が一個もなかった

<!--
issueをリンクしてね
-->

## やったこと
- アクセシビリティのトップページに、品質基準へのリンクを追加した

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
