### PR TITLE
「ほぐす」「解す」のルールを削除する

### DIFF
--- a/content/articles/products/contents/idiomatic-usage/ichiran.mdx
+++ b/content/articles/products/contents/idiomatic-usage/ichiran.mdx
@@ -182,7 +182,6 @@ ignoreH3Nav: true
 | ヘッダー | ヘッダ |  [‐er、‐or、‐arで終わる単語は「長音あり」、-yで終わる単語は「長音なし」とする（例外あり）](/products/contents/idiomatic-usage/katakana/#h2-2)  |
 | ホーム | トップ |  [アプリケーションで最初に表示される画面は「ホーム」と表現し、「トップ」「トップページ」の使用は控える](/products/contents/idiomatic-usage/usage/#h2-0)|
 | ほか | 他 | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#h2-0) |
-| ほぐす | 解す | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#h2-0) |
 | ポリシー | ポリシィ, ポリシ | 例外： [‐er、‐or、‐arで終わる単語は「長音あり」、-yで終わる単語は「長音なし」とする（例外あり）](/products/contents/idiomatic-usage/katakana/#h2-2) |
 
 ## ま行


### PR DESCRIPTION
## 課題・背景

- [SD-876](https://smarthr.atlassian.net/browse/SD-876)に記載
  - 「『解す』は『ほぐす』と表記する」ルールが、「理**解す**る」の場合にもLintで引っかかることがわかった
  - そもそも「ほぐす」はあまりプロダクトの文言としては使用しなさそうなため、Lint側で例外を設定するよりも、ガイドラインとしては削除してよいのではないかとUXW内で議論した

## やったこと
- 「解す」「ほぐす」のルールを削除

## やらなかったこと

## 動作確認
- ファイルでの確認で十分だよ。


## キャプチャ

|Before|After|
| --- | --- |
| <img width="658" alt="変更前のキャプチャ" src="https://github.com/user-attachments/assets/a56a6c92-ae79-4fe0-9b44-4902f3c5be7f"> | <img width="658" alt="変更後のキャプチャ" src="https://github.com/user-attachments/assets/888b415f-09b0-418a-90e3-d6e663ca1d20"> |

[SD-876]: https://smarthr.atlassian.net/browse/SD-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ