### PR TITLE
BottomFixedAreaの非推奨メッセージを修正

### DIFF
--- a/content/articles/products/components/bottom-fixed-area.mdx
+++ b/content/articles/products/components/bottom-fixed-area.mdx
@@ -4,12 +4,12 @@ description: 'BottomFixedAreaは非推奨です。FloatAreaを使ってくださ
 ---
 import { ComponentPropsTable } from '@Components/ComponentPropsTable'
 import { ComponentStory } from '@Components/ComponentStory'
-import { BaseColumn, ResponseMessage } from 'smarthr-ui'
+import { BaseColumn, WarningIcon} from 'smarthr-ui'
 
 <BaseColumn>
-  <ResponseMessage type="warning">
+  <WarningIcon text={<span>
     BottomFixedAreaは非推奨です。<a href="/products/components/float-area/">FloatArea</a>を使ってください。
-  </ResponseMessage>
+  </span>}/>
 </BaseColumn>
 
 画面下部に固定で表示する操作パネルです。主に[モーダルなUI](/products/design-patterns/modal-ui/)を作るために使います。


### PR DESCRIPTION
## 課題・背景・やったこと

非推奨メッセージをResponseMessageで実装したら、Flexで意図しない形になってしまっていたので Icon with Text での実装に変えました

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認

スクショとコードだけ見ていただければ


## キャプチャ

|Before|After|
| --- | --- |
| <img width="420" alt="image" src="https://github.com/user-attachments/assets/685364c3-e086-4fbc-b13b-51add7bcd011"> | <img width="402" alt="image" src="https://github.com/user-attachments/assets/f33c78eb-5333-4c49-890c-efd75e83b646"> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
