### PR TITLE
[RadioButton]Select推奨の一文を削除

### DIFF
--- a/content/articles/products/components/radio-button/index.mdx
+++ b/content/articles/products/components/radio-button/index.mdx
@@ -71,8 +71,6 @@ import RadioButtonDont from './images/radio-button-dont.png';
 
 RadioButtonは常に1つの選択肢が選択されているコンポーネントのため、選択肢の中から1つデフォルト値に設定するものを決めてください。（参考：[デフォルト値に設定する値](/products/design-patterns/default_value/#h3-0)）
 
-何も入力しない状態を選択肢として用意したい場合にはSelectの使用を推奨します。
-
 ![radiobuttonに１つの選択肢が選択されているイメージ](./images/radio-button-unselected-option.png)
 
 


### PR DESCRIPTION
何も入力しない場合は、「選択しない」をつくれる

## 課題・背景

- [スレ](https://kufuinc.slack.com/archives/CDG1XRPTP/p1730784640694019?thread_ts=1730773802.634249&cid=CDG1XRPTP)をうけて、何も選択しない選択肢はありなので、実態に合わせるように変更

## やったこと
- 以下の文章を削除
`何も入力しない状態を選択肢として用意したい場合にはSelectの使用を推奨します。` 

## やらなかったこと
- なし

<!--
e.g.
- 見た目の調整
-->

## 動作確認
https://deploy-preview-1363--smarthr-design-system.netlify.app/products/components/radio-button/


## キャプチャ

|Before|After|
| --- | --- |
| <img width="754" alt="スクリーンショット 2024-11-05 15 23 22" src="https://github.com/user-attachments/assets/b8c4c73b-4c10-41ae-95ac-cc3d38481d74"> | <img width="750" alt="image" src="https://github.com/user-attachments/assets/973b6b32-a6f5-4f51-a7ee-220dd8db0d56"> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
