### PR TITLE
feat: リンクがビューポートに入ったらprefetchするように

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,7 @@ import remarkIndexIdHeader from './src/remark/remark-index-id-header';
 export default defineConfig({
   prefetch: {
     prefetchAll: true,
+    defaultStrategy: 'viewport',
   },
   integrations: [
     mdx(),


### PR DESCRIPTION
## 課題・背景

Gatsbyのプリフェッチのタイミングがリンクがビューポートに入ったら、だったのでそれに合わせました

> https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/#link-drives-gatsbys-fast-page-navigation

## やったこと

- リンクがビューポートに入ったらprefetchするよう設定を変更
