### PR TITLE
画像のフォーマットと圧縮率を変更

### DIFF
--- a/src/components/article/ResponsiveImage.astro
+++ b/src/components/article/ResponsiveImage.astro
@@ -18,7 +18,7 @@ const imageUrl = typeof src === 'string' ? src : src.src;
       typeof src === 'string' ? (
         <img src={src} alt={alt} />
       ) : (
-        <Picture src={src} widths={[256, 512, 1024, 1536, 1600]} formats={['webp']} alt={alt} />
+        <Picture src={src} widths={[256, 512, 1024, 1536, 1600]} formats={['png']} quality="high" alt={alt} />
       )
     }
   </a>


### PR DESCRIPTION
## 課題・背景

フィードバック: 7
> プレビューで表示される画像全般、現行サイトに比べて画質が落ちている気がする

## やったこと

画像のフォーマットを webp から png に変更し、画像のクオリティを優先するように変更しました

また、サイズは 13KB -> 9KB と減少しました

| Before | After |
|-|-|
| <img width="503" alt="image" src="https://github.com/user-attachments/assets/a98c1359-e7e3-49db-846f-22d6738450c1"> |<img width="709" alt="image" src="https://github.com/user-attachments/assets/e4283249-1a61-4731-98fa-9b5ac4b8d79a"> |

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
