### PR TITLE
fix: Netlifyでのビルド時にAlgoliaのインデックスを更新するように

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "pnpm run build"
+  command = "pnpm run build:prod"
   publish = "dist"
 [dev]
   command = 'pnpm run dev'

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev": "pnpm update:ui-data && astro dev",
     "start": "pnpm dev",
     "build": "pnpm update:ui-data && astro build",
+    "build:prod": "pnpm build && pnpm tsx ./scripts/update-algoliasearch.ts",
     "preview": "astro preview",
     "astro": "astro",
     "lint:ts": "eslint 'src/**/*.{astro,ts,tsx}'",


### PR DESCRIPTION
## 課題・背景

Netlifyでのビルド時にAlgoliaのインデックスを更新するスクリプトを走らせていなかったので修正しました

## やったこと

- `build:prod` を追加し、Netlifyではこれを実行するよう変更しました

<!--
- 〇〇に追記
- 〇〇ページを追加
-->
