### PR TITLE
GitHubのリンク先がコンポーネントのルートを指すように

### DIFF
--- a/src/components/ComponentStory/index.tsx
+++ b/src/components/ComponentStory/index.tsx
@@ -35,7 +35,8 @@ export default function ComponentStory({ code, stories, noMargin = false }: Comp
   const iframeViewModeUrl = new URL(iframeUrl);
   iframeViewModeUrl.searchParams.append('viewMode', 'story');
 
-  const githubSourcePath = stories.filePath.replace(/^\.\//, '').replace(/[^/]*?\.tsx$/, '');
+  // パスからstories/*.tsxを削除
+  const githubSourcePath = stories.filePath.replace(/(stories\/)?[^/]*?\.tsx$/, '');
   const githubUrl = new URL(`v${UI_VERSION}/${githubSourcePath}`, SHRUI_GITHUB_PATH);
 
   const onClickTabItem = (itemId: string) => {


### PR DESCRIPTION
## 課題・背景

フィードバック 11
> コンポーネントのプレビュー部分の [GitHub] ボタンを押すと、stories ディレクトリがあるコンポーネントはそこに飛んでしまう (コンポーネントのrootに飛んでほしい)

## やったこと

- `stories.filePath` から `stories/` も削除するようにして、リンク先は常にコンポーネントのルートを指すように修正しました

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
