### PR TITLE
検索に必要なenvが不足している場合警告を表示するように

### DIFF
--- a/src/components/search/Search/SearchBox.tsx
+++ b/src/components/search/Search/SearchBox.tsx
@@ -7,11 +7,7 @@ import HitComponent from './HitComponent';
 import styles from './SearchBox.module.scss';
 import SearchResultOuter from './SearchResultOuter';
 
-type Props = {
-  isAvailable: boolean;
-};
-
-function CustomSearchBox({ isAvailable, ...props }: UseSearchBoxProps & Props) {
+function CustomSearchBox(props: UseSearchBoxProps) {
   const { refine } = useSearchBox(props);
   const [searchState, setSearchState] = useState<string | undefined>();
   const { search } = window.location;
@@ -59,9 +55,6 @@ function CustomSearchBox({ isAvailable, ...props }: UseSearchBoxProps & Props) {
           aria-describedby="desc-for-search-input"
           name="query"
         />
-        {!isAvailable && searchState && (
-          <div className={styles.warningMessage}>検索処理を実行するにはAlgoliaのAPIキーの設定が必要です</div>
-        )}
       </div>
       {/* 検索結果 */}
       {searchState && (
@@ -73,9 +66,13 @@ function CustomSearchBox({ isAvailable, ...props }: UseSearchBoxProps & Props) {
   );
 }
 
-const searchClient = liteClient(import.meta.env.PUBLIC_ALGOLIA_APP_ID || '', import.meta.env.PUBLIC_ALGOLIA_SEARCH_API_KEY || '');
+export default function SearchBox(props: UseSearchBoxProps) {
+  if (!import.meta.env.PUBLIC_ALGOLIA_APP_ID || !import.meta.env.PUBLIC_ALGOLIA_SEARCH_API_KEY) {
+    return <div className={styles.warningMessage}>検索処理を実行するにはAlgoliaのAPIキーの設定が必要です</div>;
+  }
 
-export default function SearchBox(props: Props) {
+  const searchClient = liteClient(import.meta.env.PUBLIC_ALGOLIA_APP_ID, import.meta.env.PUBLIC_ALGOLIA_SEARCH_API_KEY);
+
   return (
     <InstantSearch
       indexName={import.meta.env.PUBLIC_ALGOLIA_INDEX_NAME || ''}

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -14,10 +14,7 @@ import SearchBox from '@/components/search/Search/SearchBox';
     <main class="main">
       <PageHeading className="pageHeading" id="label-for-search-input">SmartHR Design Systemを検索</PageHeading>
       <div class="search ais-SearchBox__root">
-        <SearchBox
-          isAvailable={import.meta.env.PUBLIC_ALGOLIA_APP_ID && import.meta.env.PUBLIC_ALGOLIA_SEARCH_API_KEY ? true : false}
-          client:only="react"
-        >
+        <SearchBox client:only="react">
           {
             // client:loadでもSearchBoxが遅れて表示されCLSが起こるので、
             // client:onlyを使い同じ高さのフォールバックを表示することでCLSを軽減しています


### PR DESCRIPTION
## 課題・背景

AlgoliaのAPIキーが無い場合、検索ページが壊れているように見える

## やったこと

- clientの作成前に環境変数を確認して、無い場合警告を表示するように
  - 移行により `isAvailable` が機能しなくなっていたため削除

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## キャプチャ

![image](https://github.com/user-attachments/assets/9ed34c8b-9bed-47c8-8616-e67c2a81b2ca)

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
