### PR TITLE
除外するディレクトリを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,15 @@ pnpm-debug.log*
 # jetbrains setting folder
 .idea/
 
-# ページ生成用のデータの一時キャッシュ
+# Cache
+.cache
 src/cache/
+
+# Storybook static build files
+storybook-static/
+
+# Local Netlify folder
+.netlify
+
+# Gatsbyのなごり
+public


### PR DESCRIPTION
## 課題・背景

`.cache` `.netlify` `public` を除外したい

## やったこと

- .gitignoreに上記ディレクトリを追加しました
- また、Gatsby版の .gitignore を参考に `storybook-static/` を追加しました

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
