### PR TITLE
lighthouseのアクセシビリティスコア向上のため、ガチャのリンク部分のスペースを広くする

### DIFF
--- a/src/components/index/Gotcha/index.module.scss
+++ b/src/components/index/Gotcha/index.module.scss
@@ -222,6 +222,9 @@
   }
 
   > ul {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
     margin: 0;
     padding: 0;
     list-style: none;


### PR DESCRIPTION
## 課題・背景
![Pasted_Image_2024_11_19__2_29](https://github.com/user-attachments/assets/9709e680-e091-4ba9-a1f3-e6b4ae8cb5fb)

lighthouseのアクセシビリティスコアがガチャのリンク部分が小さくアイテムごとの空白が少ないことにより下がっています。

↓の画像は過去3ヶ月のlighthouseのアクセシビリティスコアの遷移をグラフにしたものです。満点の時と5ptほどスコアを下げている時があります。

![image](https://github.com/user-attachments/assets/99aba59e-22dc-48a2-bcb5-8b99e08e1e3c)

この原因がこのPRで対策した「Touch targets do not have sufficient size or spacing.」という評価基準です。

![image](https://github.com/user-attachments/assets/0e7b7899-f5cc-49cc-956e-18d5d50b0008)

> https://dequeuniversity.com/rules/axe/4.10/target-size

lighthouseはタッチ部分のサイズが24px x 24pxより大きいか、他のタッチ部分と8pxの間が空いているかを評価基準にしています。

## やったこと

リンク同士に8pxのgapを設定しました。

## やらなかったこと
24px x 24pxのタッチサイズを確保するのはデザイン上変更が大きいかなと思ったのでリンク同士のgapで対応しました。

## 動作確認
netlifyのブランチプレビューをlighthouseにかけていただければ修正されていることがわかるかと思います。

## キャプチャ

|Before|After|
| --- | --- |
|![Pasted_Image_2024_11_19__2_46](https://github.com/user-attachments/assets/27a68a54-1706-49f5-b92f-99c593a80c39) |![Pasted_Image_2024_11_19__2_43](https://github.com/user-attachments/assets/9493f647-7268-4fb0-96ef-229438747a9f)|
