### PR TITLE
[Proposal] 記事ページの中央カラムの幅を広げたい

### DIFF
--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -104,7 +104,7 @@ const nextSidebarItem = currentPageIndex < sidebarItemLength ? (flatArticleMetaI
   .main {
     flex: 1 1 auto;
     display: grid;
-    grid-template: 'sidebar article index' auto / 1fr minmax(auto, 712px) 1fr;
+    grid-template: 'sidebar article index' auto / 1fr minmax(auto, 2fr) 1fr;
 
     @include breakpointPC1 {
       grid-template: 'sidebar article .' auto / 1fr minmax(auto, 712px) minmax(40px, 1fr);


### PR DESCRIPTION
## 課題・背景

記事ページの中央カラムの幅が `minmax(auto, 712px)` で狭いので広くしたい。

#1206 と同じ内容ですが、あちらはAstro化する前のPRで古いので新しく立て直しました。

## やったこと
- `.main` の article カラムの幅を 712px から 2fr に広げた

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <img width="1800" alt="スクリーンショット 2024-11-26 14 46 27" src="https://github.com/user-attachments/assets/766f1ef6-3a28-4a35-8918-b82795ebfd16"> | <img width="1800" alt="スクリーンショット 2024-11-26 14 46 33" src="https://github.com/user-attachments/assets/30bbc492-6e44-4655-a7fe-dd8b31e2cb17"> |
| <img width="1800" alt="スクリーンショット 2024-11-26 14 56 14" src="https://github.com/user-attachments/assets/66c9b71e-8d47-40c3-9a2b-88662337dcf2"> | <img width="1801" alt="スクリーンショット 2024-11-26 14 56 37" src="https://github.com/user-attachments/assets/c971ad71-1839-4fe3-b3c5-4eb1ee71d713"> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
