### PR TITLE
[TextLink]新規ウィンドウで開くときとヘルプページを開くときが同時のときを対処を記載

### DIFF
--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -40,7 +40,7 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 
 テキストリンクで別の画面に移動することで、現在の画面での入力や作業が中断され作業効率が著しく落ちる場合には、新規ウィンドウ（新規タブ）でテキストリンクを開くことを検討します。
 
-新規ウィンドウで開くテキストリンクには、**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置することを**必須**とします。。リンク先がSmartHRの内部ページ、外部サイトに関わらず表示します。`アイコン付き（左）`（プレフィックス）は指定しないでください。
+新規ウィンドウで開くテキストリンクには、**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置することを**必須**とします。リンク先がSmartHRの内部ページ、外部サイトに関わらず表示します。`アイコン付き（左）`（プレフィックス）は指定しないでください。
 
 ```tsx editable
   <TextLink href="/" target="_blank">新規ウィンドウで開くテキストリンク</TextLink>
@@ -50,7 +50,7 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 
 [ヘルプセンター](https://support.smarthr.jp/ja/)を開くテキストリンクには、**テキストの左側**に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）を配置することを**推奨**します。詳細は[ヘルプページへの動線](/products/contents/ui-text/help-link/#h3-2)を参照してください。`アイコン付き（右）`（サフィックス）は指定しないでください。
 
-ヘルプセンターを新規ウィンドウで開く場合には、必須となっている新規ウィンドウで開くテキストリンクを優先して**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置してください。
+ヘルプセンターを新規ウィンドウで開く場合には、新規ウィンドウで開くテキストリンクを優先して**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置してください。
 
 ```tsx editable
   <TextLink href="/" prefix={<FaCircleQuestionIcon />}>ヘルプセンターを開くテキストリンク</TextLink>

--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -40,7 +40,7 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 
 テキストリンクで別の画面に移動することで、現在の画面での入力や作業が中断され作業効率が著しく落ちる場合には、新規ウィンドウ（新規タブ）でテキストリンクを開くことを検討します。
 
-新規ウィンドウで開くテキストリンクには、**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を必ず配置します。リンク先がSmartHRの内部ページ、外部サイトに関わらず表示します。`アイコン付き（左）`（プレフィックス）は指定しないでください。
+新規ウィンドウで開くテキストリンクには、**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置することを**必須**とします。。リンク先がSmartHRの内部ページ、外部サイトに関わらず表示します。`アイコン付き（左）`（プレフィックス）は指定しないでください。
 
 ```tsx editable
   <TextLink href="/" target="_blank">新規ウィンドウで開くテキストリンク</TextLink>

--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -40,7 +40,7 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 
 テキストリンクで別の画面に移動することで、現在の画面での入力や作業が中断され作業効率が著しく落ちる場合には、新規ウィンドウ（新規タブ）でテキストリンクを開くことを検討します。
 
-- 新規ウィンドウで開くテキストリンクには、**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置することを**必須**とします。
+- TextLinkは、**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を自動で配置するため、個別に設定する必要はありません。
     - リンク先がSmartHRの内部ページ、外部サイトに関わらず表示します。
 - `アイコン付き（左）`（プレフィックス）は指定しないでください。
 

--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -48,7 +48,9 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 
 #### ヘルプセンターを開くテキストリンク
 
-[ヘルプセンター](https://support.smarthr.jp/ja/)を開くテキストリンクには、**テキストの左側**に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）を配置することを推奨します。詳細は[ヘルプページへの動線](/products/contents/ui-text/help-link/#h3-2)を参照してください。`アイコン付き（右）`（サフィックス）は指定しないでください。
+[ヘルプセンター](https://support.smarthr.jp/ja/)を開くテキストリンクには、**テキストの左側**に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）を配置することを**推奨**します。詳細は[ヘルプページへの動線](/products/contents/ui-text/help-link/#h3-2)を参照してください。`アイコン付き（右）`（サフィックス）は指定しないでください。
+
+ヘルプセンターを新規ウィンドウで開く場合には、必須となっている新規ウィンドウで開くテキストリンクを優先して**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置してください。
 
 ```tsx editable
   <TextLink href="/" prefix={<FaCircleQuestionIcon />}>ヘルプセンターを開くテキストリンク</TextLink>

--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -50,7 +50,9 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 
 #### ヘルプセンターを開くテキストリンク
 
-[ヘルプセンター](https://support.smarthr.jp/ja/)を開くテキストリンクには、**テキストの左側**に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）を配置することを**推奨**します。詳細は[ヘルプページへの動線](/products/contents/ui-text/help-link/#h3-2)を参照してください。`アイコン付き（右）`（サフィックス）は指定しないでください。
+- [ヘルプセンター](https://support.smarthr.jp/ja/)を開くテキストリンクには、**テキストの左側**に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）を配置することを**推奨**します。
+  - 詳細は[ヘルプページへの動線](/products/contents/ui-text/help-link/#h3-2)を参照してください。
+- `アイコン付き（右）`（サフィックス）は指定しないでください。
 
 なお、ヘルプセンターを新規ウィンドウで開く場合には、[新規ウィンドウで開くテキストリンク](#h4-1)を優先して <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）は配置しないでください。
 

--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -40,7 +40,9 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 
 テキストリンクで別の画面に移動することで、現在の画面での入力や作業が中断され作業効率が著しく落ちる場合には、新規ウィンドウ（新規タブ）でテキストリンクを開くことを検討します。
 
-新規ウィンドウで開くテキストリンクには、**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置することを**必須**とします。リンク先がSmartHRの内部ページ、外部サイトに関わらず表示します。`アイコン付き（左）`（プレフィックス）は指定しないでください。
+- 新規ウィンドウで開くテキストリンクには、**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置することを**必須**とします。
+    - リンク先がSmartHRの内部ページ、外部サイトに関わらず表示します。
+- `アイコン付き（左）`（プレフィックス）は指定しないでください。
 
 ```tsx editable
   <TextLink href="/" target="_blank">新規ウィンドウで開くテキストリンク</TextLink>

--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -52,7 +52,7 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 
 [ヘルプセンター](https://support.smarthr.jp/ja/)を開くテキストリンクには、**テキストの左側**に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）を配置することを**推奨**します。詳細は[ヘルプページへの動線](/products/contents/ui-text/help-link/#h3-2)を参照してください。`アイコン付き（右）`（サフィックス）は指定しないでください。
 
-ヘルプセンターを新規ウィンドウで開く場合には、新規ウィンドウで開くテキストリンクを優先して**テキストの右側**に <FaUpRightFromSquareIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaUpRightFromSquareIcon`）を配置してください。
+なお、ヘルプセンターを新規ウィンドウで開く場合には、[新規ウィンドウで開くテキストリンク](#h4-1)を優先して <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）は配置しないでください。
 
 ```tsx editable
   <TextLink href="/" prefix={<FaCircleQuestionIcon />}>ヘルプセンターを開くテキストリンク</TextLink>


### PR DESCRIPTION
## 課題・背景

<!--
issueをリンクしてね
-->

## やったこと
- 「新規ウィンドウで開くテキストリンク」が必須であることを明記・強調
- 「ヘルプセンターを開くテキストリンク」が推奨であることを強調
- 新規ウィンドウとヘルプセンターが同時のときには新規ウィンドウを優先することを明記

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
- プレビューで確認
  - https://deploy-preview-1432--smarthr-design-system.netlify.app/products/components/text-link/#h2-1

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
