### PR TITLE
fix: 弱視・ロービジョンのユーザーに付いてページのstorybookリンク切れ修正

### DIFF
--- a/src/content/articles/accessibility/low-vision.mdx
+++ b/src/content/articles/accessibility/low-vision.mdx
@@ -137,7 +137,7 @@ import TableReel from "./_components/TableReel.astro"
           <li>
             背景色による領域の提示:
             背景色の違いによって提示された領域の区切りに気づけない。
-            例：<a href="https://story.smarthr-ui.dev/?path=/docs/data-display%EF%BC%88%E3%83%87%E3%83%BC%E3%82%BF%E8%A1%A8%E7%A4%BA%EF%BC%89-basecolumn--docs">BaseColumnコンポーネント</a>
+            例：<a href="https://story.smarthr-ui.dev/?path=/docs/data-display%EF%BC%88%E3%83%87%E3%83%BC%E3%82%BF%E8%A1%A8%E7%A4%BA%EF%BC%89-base-basecolumn--docs">BaseColumnコンポーネント</a>
           </li>
           <li>
             色の違いによるUIの状態提示： 


### PR DESCRIPTION
## 課題・背景

Storybookの整理後BaseColumn componentのdocsページのリンク先が変わったため、弱視・ロービジョンのユーザーについてのページでリンク先がエラになってる

<!--
issueをリンクしてね
-->
https://smarthr.atlassian.net/browse/SD-952

## やったこと
- アクセシビリティコンテンツの「弱視・ロービジョンのユーザーのウェブ利用時の課題と解決案」ページ内のBaseColumn componentのリンク切れを修正

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 見た目の調整

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

ファイル上でリンク先が確認取れると十分と思いますが、previewでも確認できます

Before - リンク切れ
https://smarthr.design/accessibility/low-vision/#h2-1

After - Storybook docs page
https://deploy-preview-1434--smarthr-design-system.netlify.app/accessibility/low-vision/#h2-1


