### PR TITLE
掲載中のカスタム社員名簿の画面キャプチャを取り下げる

### DIFF
--- a/src/content/articles/communication/capture/capture-product.mdx
+++ b/src/content/articles/communication/capture/capture-product.mdx
@@ -130,29 +130,6 @@ import CaptureImageWithDesc from '@/components/article/CaptureImageWithDesc.astr
 
 ## SmartHRオプション機能
 
-### カスタム社員名簿機能
-
-#### 従業員一覧
-
-SmartHRが従業員データベースであることを示すシーンに適しています。
-
-<Grid autoRepeat="auto-fill" size="250px">
-
-  <CaptureImageWithDesc description="パソコンサイズ">
-
-  ![カスタム社員名簿_従業員詳細_パソコンサイズ](./images/service_capture/カスタム社員名簿_従業員詳細.png)
-
-  </CaptureImageWithDesc>
-
-  <CaptureImageWithDesc description="スマートフォンサイズ">
-
-  ![カスタム社員名簿_従業員一覧_スマートフォンサイズ](./images/service_capture/カスタム社員名簿_従業員一覧_スマートフォンサイズ.png)
-
-  </CaptureImageWithDesc>
-
-</Grid>
-
-
 ### 配置シミュレーション機能
 
 SmartHRのタレントマネジメント領域をあらわすシーンに適しています。


### PR DESCRIPTION
## 課題・背景
https://smarthr.atlassian.net/browse/SD-841

## やったこと
- [SmartHRオプション機能](https://smarthr.design/communication/capture/capture-product/#h2-1)＞カスタム社員名簿機能　のセクションを削除

## やらなかったこと
- 新たに追加する画面の検討

## 動作確認
- Previewでの確認

## キャプチャ

|Before|After|
| --- | --- |
| ![CleanShot 2024-12-20 at 18 13 41@2x](https://github.com/user-attachments/assets/1df7943c-039a-4854-bf1e-1f186ce146c5) | ![CleanShot 2024-12-20 at 18 13 48@2x](https://github.com/user-attachments/assets/eaea2132-6756-466f-aa53-ee0c59274b28) |

- 赤枠の部分を削除