### PR TITLE
カスタム社員名簿機能の画面キャプチャを取り下げる

### DIFF
--- a/src/content/articles/communication/capture/capture-product.mdx
+++ b/src/content/articles/communication/capture/capture-product.mdx
@@ -130,29 +130,6 @@ import CaptureImageWithDesc from '@/components/article/CaptureImageWithDesc.astr
 
 ## SmartHRオプション機能
 
-### カスタム社員名簿機能
-
-#### 従業員一覧
-
-SmartHRが従業員データベースであることを示すシーンに適しています。
-
-<Grid autoRepeat="auto-fill" size="250px">
-
-  <CaptureImageWithDesc description="パソコンサイズ">
-
-  ![カスタム社員名簿_従業員詳細_パソコンサイズ](./images/service_capture/カスタム社員名簿_従業員詳細.png)
-
-  </CaptureImageWithDesc>
-
-  <CaptureImageWithDesc description="スマートフォンサイズ">
-
-  ![カスタム社員名簿_従業員一覧_スマートフォンサイズ](./images/service_capture/カスタム社員名簿_従業員一覧_スマートフォンサイズ.png)
-
-  </CaptureImageWithDesc>
-
-</Grid>
-
-
 ### 配置シミュレーション機能
 
 SmartHRのタレントマネジメント領域をあらわすシーンに適しています。


### PR DESCRIPTION
## 課題・背景
https://smarthr.atlassian.net/browse/SD-841

## やったこと
- [SmartHRオプション機能](https://smarthr.design/communication/capture/capture-product/#h2-1)の[カスタム社員名簿機能](https://smarthr.design/communication/capture/capture-product/#h3-2)をセクションごと削除

## やらなかったこと
- 新たに追加する画面の検討

## 動作確認
- Previewでみてね。

## キャプチャ

|Before|After|
| --- | --- |
| ![CleanShot 2024-12-20 at 18 13 41@2x](https://github.com/user-attachments/assets/1b0a44a0-0608-4b2c-b778-5fdb72aca8ca) | ![CleanShot 2024-12-20 at 18 13 48@2x](https://github.com/user-attachments/assets/68886ec7-4209-4f38-8a0a-a1ad9e9a2543) |
- 赤枠の部分を変更