### PR TITLE
リンクの指定ミスを修正

### DIFF
--- a/src/content/articles/products/components/base/base-column.mdx
+++ b/src/content/articles/products/components/base/base-column.mdx
@@ -8,7 +8,7 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 
 [矩形](/products/design-patterns/visual-grouping/#h3-3)で視覚的に要素をグルーピングするコンポーネントです。
 
-主に[Base](/products/components/base/)や各種[Dialog](/products/components/information-panel/)の上で[視覚的グルーピングにおけるブロック](/products/design-patterns/visual-grouping/#h3-6)の表現に使います。
+主に[Base](/products/components/base/)や各種[Dialog](/products/components/dialog/)の上で[視覚的グルーピングにおけるブロック](/products/design-patterns/visual-grouping/#h3-6)の表現に使います。
 
 <ComponentStory name="BaseColumn" />
 


### PR DESCRIPTION
## 課題・背景

<!--
issueをリンクしてね
-->

## やったこと
- [BaseColumn](https://smarthr.design/products/components/base/base-column/) における `Dialog` へのリンクが `InformationPanel` へのリンクになっていたので修正しました

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 🍐 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

- ファイルでの確認で十分だよ。
  - 念のため動作確認用のリンクはこちら
    - https://deploy-preview-1465--smarthr-design-system.netlify.app/products/components/base/base-column/

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
