### PR TITLE
権限編集ダイアログ内のRadioButtonPanelの個数制限を削除

### DIFF
--- a/src/content/articles/products/design-patterns/permissions-settings.mdx
+++ b/src/content/articles/products/design-patterns/permissions-settings.mdx
@@ -138,7 +138,7 @@ ComboBoxのパネル内の説明には`{検索対象名1}、{検索対象名2}�
 - 機能管理者：すべての操作の権限を持つ
 - 業務担当者：業務に必要な操作の権限のみを持つ
 
-操作の権限が上記の2つ以内の場合は、[RadioButtonPanel](/products/components/radio-button-panel/)を使ってください。
+操作の権限の指定には、[RadioButtonPanel](/products/components/radio-button-panel/)を使用してください。
 
 **「カスタム権限」** として、操作の権限をユーザーが増やせるプロダクトもあります。この場合は[SingleComboBox](/products/components/combo-box/)や[Select](/products/components/select/)を使ってください。
 


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

[権限設定](https://smarthr.design/products/design-patterns/permissions-settings/#h4-5)のページにて、「操作の権限が2つ以内の場合はRadioButtonPanelを使ってください」という表記があるが、2つ以内に限定する必要はないため、その記載を削除したい。

cf. [2つ以内の表記が妥当かの相談スレ](https://kufuinc.slack.com/archives/CDG1XRPTP/p1734073128762699)

## やったこと
- 削除した

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 🍐 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

https://deploy-preview-1479--smarthr-design-system.netlify.app/products/design-patterns/permissions-settings/#h4-5

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
