### PR TITLE
アイキャッチの使い方Figmaのリンクを削除

### DIFF
--- a/src/content/articles/communication/eye-catching-images.mdx
+++ b/src/content/articles/communication/eye-catching-images.mdx
@@ -24,8 +24,7 @@ SmartHRでは、コンテンツの魅力を最大限に伝えるため、アイ�
 #### Figmaでつくる
 - [アイキャッチテンプレート | Figma](https://www.figma.com/file/2cPeunVF3XIEWReJyKzI7l/%E3%80%90%E3%82%A2%E3%82%A4%E3%82%AD%E3%83%A3%E3%83%83%E3%83%81%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%80%91%E3%83%96%E3%83%AD%E3%82%B0?type=design&node-id=0%3A1&t=k3R14RLQF69NWl8k-1)
 
-Figmaのアカウントの発行方法などは[Figmaの利用方法](https://smarthr.design/operational-guideline/figma-operation/)を、
-Figmaでアイキャッチを自作する方法は、[Figmaアイキャッチテンプレートの使い方 | Google ドライブ](https://drive.google.com/file/d/1YyA4d9rfWxy4c3aZxzN31MUDWihZ67vt/view)を参照してください。
+Figmaのアカウントの発行方法などは[Figmaの利用方法](https://smarthr.design/operational-guideline/figma-operation/)を参照してください。
 
 #### Keynoteでつくる
 - [アイキャッチテンプレート | Google ドライブ](https://drive.google.com/drive/u/0/folders/1uVD2WIq2PJWW8oacQtbmVwkdl-t8BsFi)


### PR DESCRIPTION
## 課題・背景
- コミュニケーション＞アイキャッチページにある使い方の説明figmaへのリンクを削除する。
- https://smarthr.atlassian.net/browse/SD-989

## やったこと
- 該当ページ：[アイキャッチ＞ブログのアイキャッチ＞2. テンプレートを使って自作する＞Figmaでつくる](https://smarthr.design/communication/eye-catching-images/#h4-0)
- Figmaの使い方リンクに関わる文中を編集、該当箇所を削除
- 修正前）Figmaのアカウントの発行方法などはFigmaの利用方法を、 Figmaでアイキャッチを自作する方法は、Figmaアイキャッチテンプレートの使い方 | Google ドライブを参照してください。
- 修正後）Figmaのアカウントの発行方法などはFigmaの利用方法を参照してください。

## やらなかったこと
- 

## 動作確認
- Previewでみてね。

## キャプチャ

|Before|After|
| --- | --- |
| ![CleanShot 2025-01-30 at 13 11 02@2x](https://github.com/user-attachments/assets/67e98277-d98f-434b-85dc-9db2fd271a2e) | ![CleanShot 2025-01-30 at 13 11 30@2x](https://github.com/user-attachments/assets/35ae781a-d4c6-4e2b-b839-6148b1805019) |

