### PR TITLE
fix: テキストリンクの書き方ページのurl修正

### DIFF
--- a/src/content/articles/accessibility/link-text.mdx
+++ b/src/content/articles/accessibility/link-text.mdx
@@ -85,4 +85,4 @@ import { Table, Td, Th } from 'smarthr-ui'
 
 ## 関連・参考リンク
 * [リンクテキスト　［テキストリンク］｜実践ノウハウ｜エー イレブン ワイ［WebA11y.jp］](https://weba11y.jp/know-how/guidelines/descriptive-link-text/)
-* [テキストリンクは「こちら」ではなく、移動先を想起しやすい表現をする - UIテキスト | コンテンツ | SmartHR Design System](https://smarthr.design/products/contents/app-writing/#recQWQ2jV7NYgnzky-0)
+* [テキストリンクは「こちら」ではなく、移動先を想起しやすい表現をする - その他のUIテキスト | UIテキスト | SmartHR Design System](https://smarthr.design/products/contents/ui-text/app-writing/#h2-4)


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
- アクセシビリティコンテンツのリンクテキストページのテキストリンクの書き方ページへリンクが切れていたため、修正しました

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- デザインの調整

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->
- Previewまたはコード上でもどちらかでリンク先があっていることが確認取れたら問題です

## キャプチャ

### BEFORE
https://github.com/user-attachments/assets/1e779102-75bc-4745-b802-7c82cfeb335c

### AFTER
https://github.com/user-attachments/assets/4cfe6a7d-66d4-40fe-b185-93f3c86648d8

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
