### PR TITLE
本文エリアのページネーション（次へ・前へ）を`nav`でマークアップ

### DIFF
--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -51,34 +51,36 @@ const nextSidebarItem = currentPageIndex < sidebarItemLength ? (flatArticleMetaI
         <div class="mdxStyleWrapper" id={MDX_STYLE_WRAPPER_ID}>
           <slot />
         </div>
-        <ul class="articleLinks">
-          {
-            prevSidebarItem !== null && (
-              <li class="prevArticleLinkWrapper">
-                <RoundedBoxLink
-                  path={prevSidebarItem.link}
-                  label="前へ"
-                  title={prevSidebarItem.title}
-                  align="left"
-                  caretPosition="left"
-                />
-              </li>
-            )
-          }
-          {
-            nextSidebarItem !== null && (
-              <li class="nextArticleLinkWrapper">
-                <RoundedBoxLink
-                  path={nextSidebarItem.link}
-                  label="次へ"
-                  title={nextSidebarItem.title}
-                  align="right"
-                  caretPosition="right"
-                />
-              </li>
-            )
-          }
-        </ul>
+        <nav>
+          <ul class="articleLinks">
+            {
+              prevSidebarItem !== null && (
+                <li class="prevArticleLinkWrapper">
+                  <RoundedBoxLink
+                    path={prevSidebarItem.link}
+                    label="前へ"
+                    title={prevSidebarItem.title}
+                    align="left"
+                    caretPosition="left"
+                  />
+                </li>
+              )
+            }
+            {
+              nextSidebarItem !== null && (
+                <li class="nextArticleLinkWrapper">
+                  <RoundedBoxLink
+                    path={nextSidebarItem.link}
+                    label="次へ"
+                    title={nextSidebarItem.title}
+                    align="right"
+                    caretPosition="right"
+                  />
+                </li>
+              )
+            }
+          </ul>
+        </nav>
       </Article>
     </main>
 


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

本文エリア下の「前へ」「次へ」リンク（ページネーション）がリストでマークアップされていたため、ナビゲーションにしたい

## やったこと
- 該当要素を`nav`要素でくくった

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認

- ファイルでの確認で十分だよ。
- 例：https://deploy-preview-1510--smarthr-design-system.netlify.app/products/principles/


## キャプチャ

見た目の変更はありません。

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
