### PR TITLE
fix: ページの言語のチェックリストページのwcagの関連リンクを修正

### DIFF
--- a/src/content/articles/accessibility/check-list/lang.mdx
+++ b/src/content/articles/accessibility/check-list/lang.mdx
@@ -22,4 +22,5 @@ order: 61
     - ソースコードを確認し、`<html>` 要素に`lang`属性が存在し、適切な言語コードが設定されているかを確認します。
 
 ## 関連するWCAG2.1達成基準
-- [達成基準 1.3.3: 感覚的な特徴を理解する](https://waic.jp/translations/WCAG21/Understanding/sensory-characteristics.html)
+- [達成基準 3.1.1: ページの言語を理解する](https://waic.jp/translations/WCAG21/Understanding/language-of-page.html)
+- [達成基準 3.1.2: 一部分の言語を理解する](https://waic.jp/translations/WCAG21/Understanding/language-of-parts.html)


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
-　ページの言語のチェックリストページのwcagの関連リンクが「達成基準 1.3.3: 感覚的な特徴を理解する」になっていましたので、リンクを修正しました

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- デザイン・レイアウトの変更

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->
- 修正した内容のリンクテキストとリンク先が確認できれば問題ない
- previewでもみれます

## キャプチャ

|Before|After|
| --- | --- |
https://smarthr.design/accessibility/check-list/lang/#h2-4 | https://deploy-preview-1511--smarthr-design-system.netlify.app/accessibility/check-list/lang/#h2-4
| <img width="531" alt="wcagの関連リンクが「達成基準 1.3.3: 感覚的な特徴を理解する」" src="https://github.com/user-attachments/assets/98fdcd07-c615-442f-8559-9683a06b2e05" /> | <img width="617" alt="wcagの関連リンクが「ページの言語と一部分の言語を理解する」" src="https://github.com/user-attachments/assets/aa5a0356-2ba9-4905-b324-3878eb3542f7" /> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
