### PR TITLE
Airtableの埋め込み→表記載に変更: ヘルプページへの動線編

### DIFF
--- a/src/content/articles/products/contents/ui-text/help-link.mdx
+++ b/src/content/articles/products/contents/ui-text/help-link.mdx
@@ -51,10 +51,10 @@ import { FaExternalLinkAltIcon, FaQuestionCircleIcon } from 'smarthr-ui'
 
 ## ライティングパターン
 
-|   | 例 |
+| ライティングパターン | 例 |
 | ---- | ---- |
-| 1 | `詳しくは、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" /> を参照してください。` |
-| 2 | `{hoge}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。` |
-| 3 | `{hoge}の詳しい操作方法は、{ヘルプページタイトル}<FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。` |
-| 4 | `{hoge}や{fuga}、{piyo}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。` |
-| 5 | `<FaQuestionCircleIcon visuallyHiddenText="ヘルプセンター" /> {ヘルプページタイトル}` |
+| `詳しくは、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" /> を参照してください。` | 詳しくは、<u>SmartHR基本機能の通知設定を確認・変更する</u>を参照してください。 |
+| `{hoge}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。` | 「旧経路（廃止予定）」については、<u>旧経路（廃止予定）はどんな経路ですか？</u>を参照してください。 |
+| `{hoge}の詳しい操作方法は、{ヘルプページタイトル}<FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。` | それぞれの詳しい操作方法は、<u>昨年分の保険や住宅借入金控除の申告情報を引き継ぐ</u>を参照してください。 |
+| `{hoge}や{fuga}、{piyo}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。` | 通知のタイミングや通知先については、<u>【一覧】申請機能の通知メール</u>を参照してください。 |
+| `<FaQuestionCircleIcon visuallyHiddenText="ヘルプセンター" /> {ヘルプページタイトル}` | <u>年末調整機能の事前準備の流れ</u> |

--- a/src/content/articles/products/contents/ui-text/help-link.mdx
+++ b/src/content/articles/products/contents/ui-text/help-link.mdx
@@ -53,8 +53,8 @@ import { FaExternalLinkAltIcon, FaQuestionCircleIcon } from 'smarthr-ui'
 
 |   | 例 |
 | ---- | ---- |
-| 1 | 詳しくは、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" /> を参照してください。 |
-| 2 | {hoge}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。 |
-| 3 | {hoge}の詳しい操作方法は、{ヘルプページタイトル}<FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。 |
-| 4 | {hoge}や{fuga}、{piyo}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。 |
-| 5 | <FaQuestionCircleIcon visuallyHiddenText="ヘルプセンター" /> {ヘルプページタイトル} |
+| 1 | `詳しくは、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" /> を参照してください。` |
+| 2 | `{hoge}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。` |
+| 3 | `{hoge}の詳しい操作方法は、{ヘルプページタイトル}<FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。` |
+| 4 | `{hoge}や{fuga}、{piyo}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。` |
+| 5 | `<FaQuestionCircleIcon visuallyHiddenText="ヘルプセンター" /> {ヘルプページタイトル}` |

--- a/src/content/articles/products/contents/ui-text/help-link.mdx
+++ b/src/content/articles/products/contents/ui-text/help-link.mdx
@@ -45,9 +45,9 @@ import { FaExternalLinkAltIcon, FaQuestionCircleIcon } from 'smarthr-ui'
 
     - 構いません。`alt`を記述したうえで、前後の文脈から関連したヘルプページに移動することが推測できれば良いです。
 - リンクテキストとリンク先ページタイトルが違っても問題ないか。
-    - リンクの目的が判断できれば構いません。リンクテキストとリンク先のページタイトルは完全一致でなくても構いません。(※1.)
+    - リンクの目的が判断できれば構いません。リンクテキストとリンク先のページタイトルは完全一致でなくても構いません。(※)
 
-※1. [Web Content Accessibility Guidelines - 2.4.4 リンクの目的（コンテキスト内）を理解する](https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html)
+※ [Web Content Accessibility Guidelines - 2.4.4 リンクの目的（コンテキスト内）を理解する](https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html)
 
 ## ライティングパターン
 

--- a/src/content/articles/products/contents/ui-text/help-link.mdx
+++ b/src/content/articles/products/contents/ui-text/help-link.mdx
@@ -47,10 +47,14 @@ import { FaExternalLinkAltIcon, FaQuestionCircleIcon } from 'smarthr-ui'
 - リンクテキストとリンク先ページタイトルが違っても問題ないか。
     - リンクの目的が判断できれば構いません。リンクテキストとリンク先のページタイトルは完全一致でなくても構いません。(※1.)
 
-## ライティングパターン
-<iframe class="airtable-embed" src="https://airtable.com/embed/shr0uo6clqu2YkINO?backgroundColor=teal&viewControls=on" frameborder="0" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
-
-
-
-## 参考文献
 ※1. [Web Content Accessibility Guidelines - 2.4.4 リンクの目的（コンテキスト内）を理解する](https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html)
+
+## ライティングパターン
+
+|   | 例 |
+| ---- | ---- |
+| 1 | 詳しくは、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" /> を参照してください。 |
+| 2 | {hoge}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。 |
+| 3 | {hoge}の詳しい操作方法は、{ヘルプページタイトル}<FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。 |
+| 4 | {hoge}や{fuga}、{piyo}については、{ヘルプページタイトル} <FaExternalLinkAltIcon visuallyHiddenText="新規ウィンドウ" />を参照してください。 |
+| 5 | <FaQuestionCircleIcon visuallyHiddenText="ヘルプセンター" /> {ヘルプページタイトル} |


### PR DESCRIPTION
## 課題・背景

ソリスケの観点から、Airtableからスプシに置き換えたい。
https://smarthr.atlassian.net/browse/SD-1012

## やったこと

- ↓記事にある Airtableの埋込部分を、Markdown形式の表に変更（記載量が軽めなので、スプシ埋め込みするほどではないと判断）
  - :design_system:[ヘルプページへの動線 | UIテキスト](https://smarthr.design/products/contents/ui-text/help-link/)

- 注釈と注釈の詳細の位置が遠いので近づける

## やらなかったこと
- 他にあるAirtableの埋込部分は別PRで対応予定

## 動作確認
- Previewでみてね。

## キャプチャ

|Before|After|
| --- | --- |
| ![screenshot](https://github.com/user-attachments/assets/5ce8afc5-431d-4028-8776-c7ffeeb1d0fb) |  ![screenshot 3](https://github.com/user-attachments/assets/882b9b97-6e7f-450e-ba69-e302199cd9e9) |

