### PR TITLE
♿️: CustomLink の外部リンクに代替テキストがなかったので TextLink に差し替え

### DIFF
--- a/src/components/article/CustomLink/index.module.scss
+++ b/src/components/article/CustomLink/index.module.scss
@@ -1,5 +1,0 @@
-.link {
-  svg {
-    margin-inline: 0.25em;
-  }
-}

--- a/src/components/article/CustomLink/index.tsx
+++ b/src/components/article/CustomLink/index.tsx
@@ -1,12 +1,10 @@
-import { FaUpRightFromSquareIcon } from 'smarthr-ui';
-
-import styles from './index.module.scss';
+import { TextLink } from 'smarthr-ui';
 
 import type { ComponentPropsWithoutRef } from 'react';
 
 type Props = {
   href: string;
-} & ComponentPropsWithoutRef<'a'>;
+} & ComponentPropsWithoutRef<typeof TextLink>;
 
 // NOTE:
 // Astro コンポーネントだと改行による空白文字が削除されず <slot /> (children) の前後に空白文字が入るため、
@@ -15,19 +13,12 @@ type Props = {
 // Slots render additional character spaces · Issue #6893 · withastro/astro
 // https://github.com/withastro/astro/issues/6893
 
-export default function CustomLink({ children, href, ...props }: Props) {
+export default function CustomLink({ children, href, ...rest }: Props) {
   const isExternal = href.match(/^https?:\/\/(?!smarthr\.design).*?$/) !== null;
 
   return (
-    <a
-      {...props}
-      className={styles.link}
-      href={href}
-      target={isExternal ? '_blank' : undefined}
-      rel={isExternal ? 'noreferrer' : undefined}
-    >
+    <TextLink {...rest} href={href} target={isExternal ? '_blank' : undefined} rel={isExternal ? 'noreferrer' : undefined}>
       {children}
-      {isExternal && <FaUpRightFromSquareIcon />}
-    </a>
+    </TextLink>
   );
 }


### PR DESCRIPTION
## 課題・背景

maiha さんが代替テキスト入ってなかったことを発見。

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
-

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
