### PR TITLE
fix: TableReelのスタイルを上書きしている箇所でのスタイル崩れを修正

### DIFF
--- a/src/content/articles/accessibility/_components/TableReel.astro
+++ b/src/content/articles/accessibility/_components/TableReel.astro
@@ -23,7 +23,6 @@ import { TableReel as OriginalTableReel } from 'smarthr-ui';
     :global(th),
     :global(td) {
       min-width: initial;
-      border: none;
       box-sizing: content-box;
       font-size: var(--font-size-14);
     }

--- a/src/content/articles/communication/sample/text/_components/TableReel/index.module.scss
+++ b/src/content/articles/communication/sample/text/_components/TableReel/index.module.scss
@@ -13,7 +13,6 @@
   :global(th),
   :global(td) {
     min-width: initial;
-    border: none;
     box-sizing: content-box;
 
     :global(p) {

--- a/src/content/articles/products/usability/_components/TableReel/index.module.scss
+++ b/src/content/articles/products/usability/_components/TableReel/index.module.scss
@@ -15,7 +15,6 @@
   :global(th),
   :global(td) {
     min-width: initial;
-    border: none;
     box-sizing: content-box;
     font-size: var(--font-size-14) !important;
   }


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

https://kufuinc.slack.com/archives/C018J0A6DCH/p1749552171109319

## やったこと
- スタイル修正

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- なし

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

以下で確認

before:

- https://smarthr.design/communication/sample/text/#h3-1
- https://smarthr.design/accessibility/low-vision/#h2-1
- https://smarthr.design/products/usability/usability-checklist/#h2-2

after:

- https://deploy-preview-1660--smarthr-design-system.netlify.app/communication/sample/text/#h3-1
- https://deploy-preview-1660--smarthr-design-system.netlify.app/accessibility/low-vision/#h2-1
- https://deploy-preview-1660--smarthr-design-system.netlify.app/products/usability/usability-checklist/#h2-2

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
