### PR TITLE
チャート（グラフ）の色にHEX表記も表示する

### DIFF
--- a/src/content/articles/products/design-tokens/color.mdx
+++ b/src/content/articles/products/design-tokens/color.mdx
@@ -81,27 +81,27 @@ import ColorPalettesWrapper from '@/components/article/ColorPaletteWrapper.astro
 #### 多色チャート
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="rgb(0, 196, 204)" colorName="CHART_COLOR_1" description="多色チャート色1" />
-  <ColorPalette colorValue="rgb(255, 205, 0)" colorName="CHART_COLOR_2" description="多色チャート色2" />
-  <ColorPalette colorValue="rgb(255, 145, 0)" colorName="CHART_COLOR_3" description="多色チャート色3" />
-  <ColorPalette colorValue="rgb(230, 85, 55)" colorName="CHART_COLOR_4" description="多色チャート色4" />
-  <ColorPalette colorValue="rgb(45, 75, 155)" colorName="CHART_COLOR_5" description="多色チャート色5" />
-  <ColorPalette colorValue="rgb(45, 125, 240)" colorName="CHART_COLOR_6" description="多色チャート色6" />
-  <ColorPalette colorValue="rgb(105, 215, 255)" colorName="CHART_COLOR_7" description="多色チャート色7" />
-  <ColorPalette colorValue="rgb(75, 180, 125)" colorName="CHART_COLOR_8" description="多色チャート色8" />
-  <ColorPalette colorValue="rgb(5, 135, 140)" colorName="CHART_COLOR_9" description="多色チャート色9" />
-  <ColorPalette colorValue="rgb(0, 90, 100)" colorName="CHART_COLOR_10" description="多色チャート色10" />
+  <ColorPalette colorValue="#00c4cc" colorName="CHART_COLOR_1" description="多色チャート色1" />
+  <ColorPalette colorValue="#ffcd00" colorName="CHART_COLOR_2" description="多色チャート色2" />
+  <ColorPalette colorValue="#ff9100" colorName="CHART_COLOR_3" description="多色チャート色3" />
+  <ColorPalette colorValue="#e65537" colorName="CHART_COLOR_4" description="多色チャート色4" />
+  <ColorPalette colorValue="#2d4b9b" colorName="CHART_COLOR_5" description="多色チャート色5" />
+  <ColorPalette colorValue="#2d7df0" colorName="CHART_COLOR_6" description="多色チャート色6" />
+  <ColorPalette colorValue="#69d7ff" colorName="CHART_COLOR_7" description="多色チャート色7" />
+  <ColorPalette colorValue="#4bb47d" colorName="CHART_COLOR_8" description="多色チャート色8" />
+  <ColorPalette colorValue="#05878c" colorName="CHART_COLOR_9" description="多色チャート色9" />
+  <ColorPalette colorValue="#005a64" colorName="CHART_COLOR_10" description="多色チャート色10" />
 </ColorPalettesWrapper>
 
 #### 単色チャート
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="rgb(161, 227, 230)" colorName="SINGLE_CHART_COLOR_1" description="単色チャート色1" />
-  <ColorPalette colorValue="rgb(0, 196, 204)" colorName="SINGLE_CHART_COLOR_2" description="単色チャート色2" />
-  <ColorPalette colorValue="rgb(0, 172, 179)" colorName="SINGLE_CHART_COLOR_3" description="単色チャート色3" />
-  <ColorPalette colorValue="rgb(5, 134, 139)" colorName="SINGLE_CHART_COLOR_4" description="単色チャート色4" />
-  <ColorPalette colorValue="rgb(5, 86, 89)" colorName="SINGLE_CHART_COLOR_5" description="単色チャート色5" />
-  <ColorPalette colorValue="rgb(3, 48, 51)" colorName="SINGLE_CHART_COLOR_6" description="単色チャート色6" />
+  <ColorPalette colorValue="#a1e3e6" colorName="SINGLE_CHART_COLOR_1" description="単色チャート色1" />
+  <ColorPalette colorValue="#00c4cc" colorName="SINGLE_CHART_COLOR_2" description="単色チャート色2" />
+  <ColorPalette colorValue="#00acb3" colorName="SINGLE_CHART_COLOR_3" description="単色チャート色3" />
+  <ColorPalette colorValue="#05868b" colorName="SINGLE_CHART_COLOR_4" description="単色チャート色4" />
+  <ColorPalette colorValue="#055659" colorName="SINGLE_CHART_COLOR_5" description="単色チャート色5" />
+  <ColorPalette colorValue="#033033" colorName="SINGLE_CHART_COLOR_6" description="単色チャート色6" />
 </ColorPalettesWrapper>
 
 #### その他のチャート色
@@ -109,7 +109,7 @@ import ColorPalettesWrapper from '@/components/article/ColorPaletteWrapper.astro
 その他のチャート色は、チャート内の「その他」を示す項目に使います。
 
 <ColorPalettesWrapper>
-  <ColorPalette colorValue="rgb(235, 235, 235)" colorName="OTHER_CHART_COLOR" description="「その他」項目に使う色" />
+  <ColorPalette colorValue="#ebebeb" colorName="OTHER_CHART_COLOR" description="「その他」項目に使う色" />
 </ColorPalettesWrapper>
 
 


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
- チャート（グラフ）の色のcolorValueをRGB表記からHEX表記に変更した。これによりHEX表記とRGB表記が並んで表示されるようになります。

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <img width="396" alt="image" src="https://github.com/user-attachments/assets/c4a24ab4-eb06-4ce3-99cc-3daadcc94243" /> | <img width="361" alt="image" src="https://github.com/user-attachments/assets/9c3bab0c-9024-496c-8148-dd639e4235bf" /> |


|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
