### PR TITLE
情報アクセシビリティ自己評価様式追加

### DIFF
--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: '機能ごとの検証結果'
+title: '検証結果'
 description: 'SmartHR 各機能のアクセシビリティ検証結果を掲載しています。'
 order: 2 
 ---
@@ -37,61 +37,61 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 - [通知用メールアドレスを登録する](./entrance-procedures/#h2-1)
 - [入社・招待時に雇用契約を行なう](./entrance-procedures/#h2-2)
 
-## [Web給与明細](./payslips/)
+### [Web給与明細](./payslips/)
 ### 試験を行なったシナリオ
 - [給与明細を確認する](./payslips/#h2-0)
 
-## [文書配布](./distribution/)
+### [文書配布](./distribution/)
 ### 試験を行なったシナリオ
 - [書類に合意する](./distribution/#h2-0)
 - [依頼された書類を確認・合意する](./distribution/#h2-1)
 - [就労条件通知に関する書類を受け取る](./distribution/#h2-2)
 - [住所情報が必要な書類へ入力する](./distribution/#h2-3)
 
-## [申請・承認](./application/)
+### [申請・承認](./application/)
 ### 試験を行なったシナリオ
 - [申請を提出する](./application/#h2-0)
 - [申請を代理提出する](./application/#h2-1)
 - [申請の提出を依頼する](./application/#h2-2)
 - [申請を承認する](./application/#h2-3)
 
-## [個人設定](./personal-settings/)
+### [個人設定](./personal-settings/)
 ### 試験を行なったシナリオ
 - [アカウントを設定する](./personal-settings/#h2-0)
 - [2要素認証の設定を行なう](./personal-settings/#h2-1)
 
-## [マイナンバー管理](./national-identity-number/)
+### [マイナンバー管理](./national-identity-number/)
 ### 試験を行なったシナリオ
 - [マイナンバーを提出する](./national-identity-number/#h2-0)
 
-## [従業員情報](./employee-info/)
+### [従業員情報](./employee-info/)
 ### 試験を行なったシナリオ
 - [従業員情報を変更する](./employee-info/#h2-0)
 
-## [手続き](./procedure/)
+### [手続き](./procedure/)
 ### 試験を行なったシナリオ
 - [扶養家族を追加する](./procedure/#h2-0)
 - [扶養家族を削除する](./procedure/#h2-1)
 - [氏名変更の手続きを行なう](./procedure/#h2-2)
 - [住所変更の手続きを行なう](./procedure/#h2-3)
 
-## [人事評価](./evaluation/)
+### [人事評価](./evaluation/)
 ### 試験を行なったシナリオ
 - [評価を提出する](./evaluation/#h2-0)
 - [評価者が複数の評価を比較して調整する](./evaluation/#h2-1)
 
-## [スキル管理](./skill/)
+### [スキル管理](./skill/)
 ### 試験を行なったシナリオ
 - [申請を提出する](./skill/#h2-0)
 - [コースを受講する](./skill/#h2-1)
 
-## [従業員サーベイ](./survey/)
+### [従業員サーベイ](./survey/)
 ### 試験を行なったシナリオ
 - [サーベイに回答する](./survey/#h2-0)
 
-## [配置シミュレーション](./simulation/)
+### [配置シミュレーション](./simulation/)
 ### 試験を行なったシナリオ
 - [人員配置をシミュレーションする](./simulation/#h2-0)
 
-更新日: <time datatime="2025-03-01">2025/03/01</time>
+更新日: <time datatime="2025-06-27">2025/06/27</time>
 

--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -6,7 +6,7 @@ order: 2
 
 import { Table, Td, Text, Th } from 'smarthr-ui'
 
-SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.co.jp/development/)で掲げる目標を達成するため、製品のアクセシビリティ向上を進めています。
+SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.co.jp/development/)で掲げる目標を達成するため、製品のアクセシビリティ検証を進めています。
 
 ## 情報アクセシビリティ自己評価様式
 ### 情報アクセシビリティ自己評価様式の開示

--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -11,22 +11,19 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 
 ## 情報アクセシビリティ自己評価様式
 ### 情報アクセシビリティ自己評価様式の開示
-総務省が、ICT機器・サービスの情報アクセシビリティ確保を促進するために作成した  「情報アクセシビリティ自己評価様式（※）」に基づき、以下の製品について評価を実施しました。
-
-（※）情報アクセシビリティ自己評価様式：  
-各企業などが自らのICT機器・サービスについて、情報アクセシビリティの確保状況を自己評価するための書式です。  
-本様式の活用を通じて、ICT機器・サービス全体のアクセシビリティ向上を目指しています。  
+総務省の情報アクセシビリティ自己評価様式を使用して、製品の評価を実施しました。
+情報アクセシビリティ自己評価様式は、企業などが製品やサービスについてアクセシビリティの自己評価を行なうための様式です。
 （参照：[総務省 情報アクセシビリティ自己評価様式の普及促進](https://www.soumu.go.jp/main_sosiki/joho_tsusin/b_free/jikohyokayoshiki.html)）
 
-なお、以下の製品が「情報アクセシビリティ好事例」として選定されました。
+以下の製品が「情報アクセシビリティ好事例」として総務省に選定されました。
 
-- 人事評価システム：情報アクセシビリティ好事例2023に選定  
-- スキル管理システム：情報アクセシビリティ好事例2024に選定
+- 人事評価：[情報アクセシビリティ好事例2023](https://www.soumu.go.jp/info-accessibility-portal/koujirei/2023/)
+- スキル管理：[情報アクセシビリティ好事例2024](https://www.soumu.go.jp/info-accessibility-portal/koujirei/2024/)
 
-### 人事評価システム
+### 人事評価
 - [2025_人事評価システム _情報アクセシビリティ自己評価様式 （書式１　自己評価結果）](https://docs.google.com/spreadsheets/d/1Dcynf7mK7i4Jd6UgKZcdG4LafMRDLeeC/edit?gid=15576948#gid=15576948)
 - [2025_人事評価システム_情報アクセシビリティ自己評価様式 （書式２ 技術基準）](https://docs.google.com/spreadsheets/d/1DM0QgJBhxOhd7wl6tdJZFYp33Ev72h3X/edit?gid=816212855#gid=816212855)
-### スキル管理システム
+### スキル管理
 - [2024_スキル管理システム _ 情報アクセシビリティ自己評価様式（書式１　自己評価結果）](https://docs.google.com/spreadsheets/d/1XEKS_ZBGzMKkGG7mi8QST9qrIUT4-Kx2/edit?gid=15576948#gid=15576948)
 - [2024_スキル管理システム_情報アクセシビリティ自己評価様式（書式２ 技術基準）](https://docs.google.com/spreadsheets/d/1KmOIVXYdPFXP3rogTekhSSNzS-5Gq7wn/edit?gid=816212855#gid=816212855)
 

--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -12,7 +12,7 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 ### 情報アクセシビリティ自己評価様式の開示
 総務省の情報アクセシビリティ自己評価様式を使用して、製品の評価を行なっています。
 情報アクセシビリティ自己評価様式は、企業などが製品やサービスについてアクセシビリティの自己評価を行なうための様式です。
-  参照：[総務省 情報アクセシビリティ自己評価様式の普及促進](https://www.soumu.go.jp/main_sosiki/joho_tsusin/b_free/jikohyokayoshiki.html)
+参考：[総務省 情報アクセシビリティ自己評価様式の普及促進](https://www.soumu.go.jp/main_sosiki/joho_tsusin/b_free/jikohyokayoshiki.html)
 
 
 以下の製品が「情報アクセシビリティ好事例」として総務省に選定されました。

--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -30,7 +30,7 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 
 ## アクセシビリティ検証結果一覧
 
-各機能のプロセスごとに、WCAG達成基準や[アクセシビリティ簡易チェックリスト](https://deploy-preview-1685--smarthr-design-system.netlify.app/accessibility/check-list/)に基づくチェック支援技術で利用可能であるかを検証しています。
+各機能のプロセスごとに、WCAG達成基準や[アクセシビリティ簡易チェックリスト](https://deploy-preview-1685--smarthr-design-system.netlify.app/accessibility/check-list/)に基づくチェック、支援技術で利用可能であるかを検証しています。
 ### [入社手続き・雇用契約](./entrance-procedures/)
 ### 試験を行なったシナリオ
 - [招待メールから入社手続きを行う](./entrance-procedures/#h2-0)

--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: '機能ごとの検証結果'
+title: '検証結果'
 description: 'SmartHR 各機能のアクセシビリティ検証結果を掲載しています。'
 order: 2 
 ---
@@ -7,40 +7,63 @@ order: 2
 import { Table, Td, Text, Th } from 'smarthr-ui'
 
 SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.co.jp/development/)で掲げる目標を達成するため、製品のアクセシビリティ向上を進めています。
-各機能のプロセスごとに、WCAG達成基準に基づく検証や、支援技術で利用可能であるかを検証しています。
+各機能ごとに、情報アクセシビリティ自己評価様式による評価や、WCAG達成基準に基づく検証、支援技術で利用可能であるかを検証しています。
+
+## 情報アクセシビリティ自己評価様式
+### 情報アクセシビリティ自己評価様式の開示
+総務省が、ICT機器・サービスの情報アクセシビリティ確保を促進するために作成した  「情報アクセシビリティ自己評価様式（※）」に基づき、以下の製品について評価を実施しました。
+
+（※）情報アクセシビリティ自己評価様式：  
+各企業などが自らのICT機器・サービスについて、情報アクセシビリティの確保状況を自己評価するための書式です。  
+本様式の活用を通じて、ICT機器・サービス全体のアクセシビリティ向上を目指しています。  
+（参照：[総務省 情報アクセシビリティ自己評価様式の普及促進](https://www.soumu.go.jp/main_sosiki/joho_tsusin/b_free/jikohyokayoshiki.html)）
+
+なお、以下の製品が「情報アクセシビリティ好事例」として選定されました。
+
+- 人事評価システム：情報アクセシビリティ好事例2023に選定  
+- スキル管理システム：情報アクセシビリティ好事例2024に選定
+
+### 人事評価システム
+- [2025_人事評価システム _情報アクセシビリティ自己評価様式 （書式１　自己評価結果）](https://docs.google.com/spreadsheets/d/1Dcynf7mK7i4Jd6UgKZcdG4LafMRDLeeC/edit?gid=15576948#gid=15576948)
+- [2025_人事評価システム_情報アクセシビリティ自己評価様式 （書式２ 技術基準）](https://docs.google.com/spreadsheets/d/1DM0QgJBhxOhd7wl6tdJZFYp33Ev72h3X/edit?gid=816212855#gid=816212855)
+### スキル管理システム
+- [2024_スキル管理システム _ 情報アクセシビリティ自己評価様式（書式１　自己評価結果）](https://docs.google.com/spreadsheets/d/1XEKS_ZBGzMKkGG7mi8QST9qrIUT4-Kx2/edit?gid=15576948#gid=15576948)
+- [2024_スキル管理システム_情報アクセシビリティ自己評価様式（書式２ 技術基準）](https://docs.google.com/spreadsheets/d/1KmOIVXYdPFXP3rogTekhSSNzS-5Gq7wn/edit?gid=816212855#gid=816212855)
+
+
 
 ## アクセシビリティ検証結果一覧
 
-## [入社手続き・雇用契約](./entrance-procedures)
+## [入社手続き・雇用契約](./entrance-procedures/)
 ### 試験を行なったシナリオ
 - [招待メールから入社手続きを行う](./entrance-procedures/#h2-0)
 - [通知用メールアドレスを登録する](./entrance-procedures/#h2-1)
 - [入社・招待時に雇用契約を行なう](./entrance-procedures/#h2-2)
 
-## [Web給与明細](./payslips)
+## [Web給与明細](./payslips/)
 ### 試験を行なったシナリオ
 - [給与明細を確認する](./payslips/#h2-0)
 
-## [文書配布](./distribution)
+## [文書配布](./distribution/)
 ### 試験を行なったシナリオ
 - [書類に合意する](./distribution/#h2-0)
 - [依頼された書類を確認・合意する](./distribution/#h2-1)
 - [就労条件通知に関する書類を受け取る](./distribution/#h2-2)
 - [住所情報が必要な書類へ入力する](./distribution/#h2-3)
 
-## [申請・承認](./application)
+## [申請・承認](./application/)
 ### 試験を行なったシナリオ
 - [申請を提出する](./application/#h2-0)
 - [申請を代理提出する](./application/#h2-1)
 - [申請の提出を依頼する](./application/#h2-2)
 - [申請を承認する](./application/#h2-3)
 
-## [個人設定](./personal-settings)
+## [個人設定](./personal-settings/)
 ### 試験を行なったシナリオ
 - [アカウントを設定する](./personal-settings/#h2-0)
 - [2要素認証の設定を行なう](./personal-settings/#h2-1)
 
-## [マイナンバー管理](./national-identity-number)
+## [マイナンバー管理](./national-identity-number/)
 ### 試験を行なったシナリオ
 - [マイナンバーを提出する](./national-identity-number/#h2-0)
 
@@ -48,28 +71,28 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 ### 試験を行なったシナリオ
 - [従業員情報を変更する](./employee-info/#h2-0)
 
-## [手続き](./procedure)
+## [手続き](./procedure/)
 ### 試験を行なったシナリオ
 - [扶養家族を追加する](./procedure/#h2-0)
 - [扶養家族を削除する](./procedure/#h2-1)
 - [氏名変更の手続きを行なう](./procedure/#h2-2)
 - [住所変更の手続きを行なう](./procedure/#h2-3)
 
-## [人事評価](./evaluation)
+## [人事評価](./evaluation/)
 ### 試験を行なったシナリオ
 - [評価を提出する](./evaluation/#h2-0)
 - [評価者が複数の評価を比較して調整する](./evaluation/#h2-1)
 
-## [スキル管理](./skill)
+## [スキル管理](./skill/)
 ### 試験を行なったシナリオ
 - [申請を提出する](./skill/#h2-0)
 - [コースを受講する](./skill/#h2-1)
 
-## [従業員サーベイ](./survey)
+## [従業員サーベイ](./survey/)
 ### 試験を行なったシナリオ
 - [サーベイに回答する](./survey/#h2-0)
 
-## [配置シミュレーション](./simulation)
+## [配置シミュレーション](./simulation/)
 ### 試験を行なったシナリオ
 - [人員配置をシミュレーションする](./simulation/#h2-0)
 

--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -31,7 +31,7 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 ## アクセシビリティ検証結果一覧
 
 各機能のプロセスごとに、WCAG達成基準に基づく検証、支援技術で利用可能であるかを検証しています。
-## [入社手続き・雇用契約](./entrance-procedures/)
+### [入社手続き・雇用契約](./entrance-procedures/)
 ### 試験を行なったシナリオ
 - [招待メールから入社手続きを行う](./entrance-procedures/#h2-0)
 - [通知用メールアドレスを登録する](./entrance-procedures/#h2-1)

--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: '検証結果'
+title: '機能ごとの検証結果'
 description: 'SmartHR 各機能のアクセシビリティ検証結果を掲載しています。'
 order: 2 
 ---
@@ -7,13 +7,13 @@ order: 2
 import { Table, Td, Text, Th } from 'smarthr-ui'
 
 SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.co.jp/development/)で掲げる目標を達成するため、製品のアクセシビリティ向上を進めています。
-各機能ごとに、情報アクセシビリティ自己評価様式による評価や、WCAG達成基準に基づく検証、支援技術で利用可能であるかを検証しています。
 
 ## 情報アクセシビリティ自己評価様式
 ### 情報アクセシビリティ自己評価様式の開示
-総務省の情報アクセシビリティ自己評価様式を使用して、製品の評価を実施しました。
+総務省の情報アクセシビリティ自己評価様式を使用して、製品の評価を行なっています。
 情報アクセシビリティ自己評価様式は、企業などが製品やサービスについてアクセシビリティの自己評価を行なうための様式です。
-（参照：[総務省 情報アクセシビリティ自己評価様式の普及促進](https://www.soumu.go.jp/main_sosiki/joho_tsusin/b_free/jikohyokayoshiki.html)）
+  参照：[総務省 情報アクセシビリティ自己評価様式の普及促進](https://www.soumu.go.jp/main_sosiki/joho_tsusin/b_free/jikohyokayoshiki.html)
+
 
 以下の製品が「情報アクセシビリティ好事例」として総務省に選定されました。
 
@@ -28,9 +28,9 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 - [2024_スキル管理システム_情報アクセシビリティ自己評価様式（書式２ 技術基準）](https://docs.google.com/spreadsheets/d/1KmOIVXYdPFXP3rogTekhSSNzS-5Gq7wn/edit?gid=816212855#gid=816212855)
 
 
-
 ## アクセシビリティ検証結果一覧
 
+各機能のプロセスごとに、WCAG達成基準に基づく検証、支援技術で利用可能であるかを検証しています。
 ## [入社手続き・雇用契約](./entrance-procedures/)
 ### 試験を行なったシナリオ
 - [招待メールから入社手続きを行う](./entrance-procedures/#h2-0)

--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -30,7 +30,7 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 
 ## アクセシビリティ検証結果一覧
 
-各機能のプロセスごとに、WCAG達成基準に基づく検証、支援技術で利用可能であるかを検証しています。
+各機能のプロセスごとに、WCAG達成基準や[アクセシビリティ簡易チェックリスト](https://deploy-preview-1685--smarthr-design-system.netlify.app/accessibility/check-list/)に基づくチェック支援技術で利用可能であるかを検証しています。
 ### [入社手続き・雇用契約](./entrance-procedures/)
 ### 試験を行なったシナリオ
 - [招待メールから入社手続きを行う](./entrance-procedures/#h2-0)


### PR DESCRIPTION
## 課題・背景

情報アクセシビリティ自己評価様式の結果を追加します。

## やったこと

- タイトルを「機能ごとの検証結果」から「検証結果」に変更しました。
- ページはじめの文を変更しました。
  -  「 各機能のプロセスごとに、WCAG達成基準に基づく検証や、支援技術で利用可能であるかを検証しています。」を「各機能ごと」に変更し、続けて「情報アクセシビリティ自己評価様式による評価や」の部分をアクセシビリティ検証結果一覧の説明文に移動しました。
  -  アクセシビリティ検証結果一覧の説明文を「WCAG達成基準に基づく検証や、支援技術で利用可能であるかを検証しています。」から「WCAG達成基準やアクセシビリティ簡易チェックリストに基づくチェック、支援技術で利用可能であるかを検証しています。」と変更しました。
  -  「製品のアクセシビリティ向上を進めています。」を「製品のアクセシビリティ検証を進めています。」に変更しました。
-   情報アクセシビリティ自己評価様式の説明と結果を追加しました。
- 人事評価システムとスキル管理システムの結果ファイルへのリンクを追加しました。
- アクセシビリティ検証結果一覧の見出しレベルを修正しました。

## やらなかったこと

- 見た目の調整


## 動作確認

- キャプチャとプレビューの確認をお願いします。



## キャプチャ
[ Before]
![変更前１](https://github.com/user-attachments/assets/f1c08dbf-2755-4679-82ff-50c043c38d69)
![変更前２](https://github.com/user-attachments/assets/4ee78276-ed2f-4ba9-aedd-7556b628d6e7)
![変更前ラスト](https://github.com/user-attachments/assets/2ad1b428-7541-41e2-9d00-d714a34dddf9)


[ After ]
![変更後１](https://github.com/user-attachments/assets/090057a6-a59e-44b1-98a9-e0d069713468)
![変更後２](https://github.com/user-attachments/assets/07f7a1c5-e894-46fd-86ed-7c682e1d351f)
![変更後３](https://github.com/user-attachments/assets/5c85eecd-5ca5-4e45-8579-128545ee3df6)
![変更後ラスト](https://github.com/user-attachments/assets/dd50dc6f-27f1-4327-a433-96ae002f315e)





