### PR TITLE
URL修正

### DIFF
--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -30,7 +30,7 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 
 ## アクセシビリティ検証結果一覧
 
-各機能のプロセスごとに、WCAG達成基準や[アクセシビリティ簡易チェックリスト](https://deploy-preview-1685--smarthr-design-system.netlify.app/accessibility/check-list/)に基づくチェック、支援技術で利用可能であるかを検証しています。
+各機能のプロセスごとに、WCAG達成基準や[アクセシビリティ簡易チェックリスト](../check-list/)に基づくチェック、支援技術で利用可能であるかを検証しています。
 ### [入社手続き・雇用契約](./entrance-procedures/)
 ### 試験を行なったシナリオ
 - [招待メールから入社手続きを行う](./entrance-procedures/#h2-0)


### PR DESCRIPTION
## 課題・背景

簡易チェックリストへのリンクのURLがデプロイ時の絶対パスになっていたので、相対パスに修正

## やったこと
-リンクのパスの修正

## やらなかったこと
- 見た目の調整


## 動作確認

 Previewで確認お願いします。

## キャプチャ

![スクリーンショット 2025-06-30 14 15 54](https://github.com/user-attachments/assets/f52c50ba-bdd1-4cb3-9755-bdce2fcdbdd2)

![スクリーンショット 2025-06-30 14 18 49](https://github.com/user-attachments/assets/1df1bebf-66d0-4685-8309-9f5d16a72d0f)


<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
