### PR TITLE
サンプルテキストの誤字（コピペミス）の修正

### DIFF
--- a/src/content/articles/communication/sample/text/index.mdx
+++ b/src/content/articles/communication/sample/text/index.mdx
@@ -93,7 +93,7 @@ import TableReel from './_components/TableReel'
       </tr>
       <tr>
         <Td>法人番号</Td>
-        <Td><strong>・011001093311</strong></Td>
+        <Td><strong>・2011001093311</strong></Td>
         <Td>
           <ul>
             <li>自社のものを使用する</li>


### PR DESCRIPTION
## 課題・背景
- サンプルテキストページの「法人番号」に誤字（コピペミス）があったので修正しました

## やったこと
- 法人番号を正しいものに修正

## 動作確認
- Previewでみてね
- 最初の数字「2」の有無

## キャプチャ
|Before|After|
| --- | --- |
| ![CleanShot 2025-07-03 at 16 18 06@2x](https://github.com/user-attachments/assets/5eaa3a1b-fa4b-4f47-9546-9289fa1d7f85) | ![CleanShot 2025-07-03 at 16 18 58@2x](https://github.com/user-attachments/assets/8c9f2d8f-b4ea-4300-9df9-a5df1f8cf13b) |
