### PR TITLE
アクセシビリティ簡易チェックリストのWCAG達成基準を一部修正

### DIFF
--- a/src/content/articles/accessibility/check-list/label.mdx
+++ b/src/content/articles/accessibility/check-list/label.mdx
@@ -21,5 +21,5 @@ order: 71
     - フォームを目で見て、各フィールドに明確なラベルがついているかを確認します。ラベルは、そのフィールドに何を入力するべきかを明確に示します。
 
 ## 関連するWCAG2.1達成基準
-- [達成基準 2.4.6 を理解する | WCAG 2.0解説書](https://waic.jp/translations/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)
-- [達成基準 3.3.2 を理解する | WCAG 2.0解説書](https://waic.jp/translations/UNDERSTANDING-WCAG20/minimize-error-cues.html)
+- [達成基準 2.4.6: 見出し及びラベルを理解する | WCAG 2.1解説書](https://waic.jp/translations/WCAG21/Understanding/headings-and-labels.html)
+- [達成基準 3.3.2: ラベル又は説明を理解する | WCAG 2.1解説書](https://waic.jp/translations/WCAG21/Understanding/labels-or-instructions.html)

--- a/src/content/articles/accessibility/check-list/link-text.mdx
+++ b/src/content/articles/accessibility/check-list/link-text.mdx
@@ -51,5 +51,5 @@ import { Table, Td, Th } from 'smarthr-ui'
     - 同じリンク先につながるリンクが複数ある場合は、それらのリンクテキストが一貫しているかを確認します。同じ内容につながるリンクは、同じか似たようなテキストを使います。
 
 ## 関連するWCAG2.1達成基準
-- [達成基準 1.1.1 を理解する | WCAG 2.0解説書](https://waic.jp/translations/UNDERSTANDING-WCAG20/text-equiv-all.html)
-- [達成基準 2.4.4 を理解する | WCAG 2.0解説書](https://waic.jp/translations/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html)
+- [達成基準 1.1.1: 非テキストコンテンツを理解する](https://waic.jp/translations/WCAG21/Understanding/non-text-content.html)
+- [達成基準 2.4.4: リンクの目的 (コンテキスト内) を理解する](https://waic.jp/translations/WCAG21/Understanding/link-purpose-in-context.html)

--- a/src/content/articles/accessibility/check-list/markup-list.mdx
+++ b/src/content/articles/accessibility/check-list/markup-list.mdx
@@ -23,7 +23,6 @@ order: 23
 ## テスト方法
 1. **コードの検証**:
     - ウェブページのソースコードを確認し、リストが適切な要素でマークアップされているかを確認します。
-   
 
 ## 関連するWCAG2.1達成基準
 - [達成基準 1.3.1: 情報及び関係性を理解する](https://waic.jp/translations/WCAG21/Understanding/info-and-relationships.html)


### PR DESCRIPTION
## 課題・背景
ウェブアクセシビリティ簡易チェックリストにおいて、「関連するWCAG2.1達成基準」のリンクを一部修正しました。また、不要な空白行を削除しました。

## やったこと
1. 以下のページの達成基準のリンクを2.0から2.1に変更
- 「入力する内容や、操作がラベルとして表示されている」
- 「リンクのテキストからリンク先が判別できる」
2. 以下のページにおいて、不要な空白行の削除
- 「リストが ul, ol, dlでマークアップされている」

## やらなかったこと
- やったこと以外のすべて

## 動作確認
Previewでみてね。


