### PR TITLE
グループ会社情報の更新

### DIFF
--- a/src/content/articles/introduction/user/group.mdx
+++ b/src/content/articles/introduction/user/group.mdx
@@ -14,11 +14,9 @@ import ImgWithDesc from '@/components/article/ImgWithDesc.astro'
 
 以下、全SmartHRグループ会社従業員を対象としています。
 
-- 株式会社Looper
 - 株式会社Smart相談室
-- 株式会社BYARD
-- Nstock株式会社
 - 株式会社AIRVISA
+- 株式会社CloudBrains
 
 ## 利用できるコンテンツ
 


### PR DESCRIPTION
## 課題・背景
- SmartHRグループ会社をコーポレートサイトに合わせる

## やったこと
はじめに＞利用者のかたへ＞SmartHR グループ会社従業員＞[対象者](http://localhost:4321/introduction/user/group#h2-0)を以下に変更。
- Smart相談室株式会社
- AIRVISA株式会社
- 株式会社CloudBrains

## やらなかったこと
- なし

## 動作確認
- Previewでみてね。

## キャプチャ

|Before|After|
| --- | --- |
| <img width="2744" height="1602" alt="CleanShot 2025-07-11 at 12 52 22@2x" src="https://github.com/user-attachments/assets/07b56aa7-0e9e-47ba-9e51-39087a882889" /> | <img width="2744" height="1602" alt="CleanShot 2025-07-11 at 12 51 29@2x" src="https://github.com/user-attachments/assets/36741484-2dd6-4cb2-8f84-76d122fea1bd" /> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
