### PR TITLE
サンプルテキストのマイナンバーの項目を修正

### DIFF
--- a/src/content/articles/communication/sample/text/index.mdx
+++ b/src/content/articles/communication/sample/text/index.mdx
@@ -186,7 +186,7 @@ import TableReel from './_components/TableReel'
       </tr>
       <tr>
         <Td>マイナンバー</Td>
-        <Td><strong>・0000000000</strong></Td>
+        <Td><strong>・123456789012</strong></Td>
         <Td></Td>
       </tr>
       <tr>


### PR DESCRIPTION
## 課題・背景
- サンプルテキストで定義していたマイナンバーがSmartHRの環境ではエラーになることが判明
- 法務に問い合わせ、「123456789012」に修正

## やったこと
- マイナンバーを「123456789012」に修正

## 動作確認
- Previewでみてね

## キャプチャ

|Before|After|
| --- | --- |
| <img width="3024" height="1648" alt="CleanShot 2025-07-16 at 17 02 40@2x" src="https://github.com/user-attachments/assets/53a984c7-cffc-43da-9c30-48df7831ab62" /> | <img width="3024" height="1644" alt="CleanShot 2025-07-16 at 17 02 11@2x" src="https://github.com/user-attachments/assets/830fa39e-5a04-4497-8f0e-0210e8e9fa72" /> |

