### PR TITLE
TextLinkコンポーネントの説明を最新化 SD-1129 

### DIFF
--- a/src/content/articles/products/components/text-link/help-link/index.mdx
+++ b/src/content/articles/products/components/text-link/help-link/index.mdx
@@ -7,18 +7,22 @@ import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import { FaExternalLinkAltIcon, FaCircleQuestionIcon} from 'smarthr-ui'
 
-ヘルプページを開くためのテキストリンクです。リンクの開き方（同ウィンドウまたは新規ウィンドウ）に応じて、アイコンの配置を自動で制御します。
+ヘルプページを開くためのテキストリンクです。
+
+<ComponentStory name="HelpLink" />
+
+## レイアウト
+HelpLinkは、リンクの開き方（同ウィンドウまたは新規ウィンドウ）に応じてアイコンの配置を自動で制御します。
 
 - リンクを同ウィンドウで開く場合は、テキストの左側に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）が配置されます。
 - リンクを新規ウィンドウで開く場合には、テキストの右側に<FaExternalLinkAltIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaExternalLinkAltIcon`）が配置されます。
-
-ヘルプページを開くリンクのテキストについては[ヘルプページへの動線](/products/contents/ui-text/help-link/)を参照してください。
 
 ```tsx editable
   <HelpLink href="/" target="_blank">ヘルプセンターを開くテキストリンク</TextLink>
 ```
 
-<ComponentStory name="HelpLink" />
+## ライティング
+ヘルプページを開くリンクのテキストについては[ヘルプページへの動線](/products/contents/ui-text/help-link/)を参照してください。
 
 ## Props
 

--- a/src/content/articles/products/components/text-link/help-link/index.mdx
+++ b/src/content/articles/products/components/text-link/help-link/index.mdx
@@ -6,7 +6,14 @@ description: 'ヘルプページを開くためのテキストリンクです。
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 
-ヘルプページを開くためのテキストリンクです。
+ヘルプページを開くためのテキストリンクです。リンクの開き方（同ウィンドウまたは新規ウィンドウ）に応じて、アイコンの配置を自動で制御します。
+
+- リンクを同ウィンドウで開く場合は、テキストの右側に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）が配置されます。
+- リンクを新規ウィンドウで開く場合には、テキストの左側に<FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）が配置されます。
+
+```tsx editable
+  <HelpLink href="/" target="_blank">ヘルプセンターを開くテキストリンク</TextLink>
+```
 
 <ComponentStory name="HelpLink" />
 

--- a/src/content/articles/products/components/text-link/help-link/index.mdx
+++ b/src/content/articles/products/components/text-link/help-link/index.mdx
@@ -5,11 +5,12 @@ description: 'ヘルプページを開くためのテキストリンクです。
 
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
+import { FaExternalLinkAltIcon, FaCircleQuestionIcon} from 'smarthr-ui'
 
 ヘルプページを開くためのテキストリンクです。リンクの開き方（同ウィンドウまたは新規ウィンドウ）に応じて、アイコンの配置を自動で制御します。
 
-- リンクを同ウィンドウで開く場合は、テキストの右側に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）が配置されます。
-- リンクを新規ウィンドウで開く場合には、テキストの左側に<FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）が配置されます。
+- リンクを同ウィンドウで開く場合は、テキストの左側に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）が配置されます。
+- リンクを新規ウィンドウで開く場合には、テキストの右側に<FaExternalLinkAltIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaExternalLinkAltIcon`）が配置されます。
 
 ヘルプページを開くリンクのテキストについては[ヘルプページへの動線](/products/contents/ui-text/help-link/)を参照してください。
 

--- a/src/content/articles/products/components/text-link/help-link/index.mdx
+++ b/src/content/articles/products/components/text-link/help-link/index.mdx
@@ -11,6 +11,8 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 - リンクを同ウィンドウで開く場合は、テキストの右側に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）が配置されます。
 - リンクを新規ウィンドウで開く場合には、テキストの左側に<FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）が配置されます。
 
+ヘルプページを開くリンクのテキストについては[ヘルプページへの動線](/products/contents/ui-text/help-link/)を参照してください。
+
 ```tsx editable
   <HelpLink href="/" target="_blank">ヘルプセンターを開くテキストリンク</TextLink>
 ```

--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -58,14 +58,14 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 
 #### ヘルプセンターを開くテキストリンク
 
-- [ヘルプセンター](https://support.smarthr.jp/ja/)を開くテキストリンクには、**テキストの左側**に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）を配置することを**推奨**します。
+[ヘルプセンター](https://support.smarthr.jp/ja/)を開くテキストリンクは[HelpLink](/products/components/text-link/help-link/)として提供しています。
+- HelpLinkは、**テキストの右側**に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）を自動で配置するため、個別に設定する必要はありません。
+  - なお、ヘルプセンターを新規ウィンドウで開く場合には、<FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）は配置しません。`target="_blank"`を指定すると<FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコンは自動的に除かれます。
   - 詳細は[ヘルプページへの動線](/products/contents/ui-text/help-link/#h3-2)を参照してください。
 - `アイコン付き（右）`（サフィックス）は指定しないでください。
 
-なお、ヘルプセンターを新規ウィンドウで開く場合には、[新規ウィンドウで開くテキストリンク](#h4-1)を優先して <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）は配置しないでください。
-
 ```tsx editable
-  <TextLink href="/" prefix={<FaCircleQuestionIcon />}>ヘルプセンターを開くテキストリンク</TextLink>
+  <HelpLink href="/" target="_blank">ヘルプセンターを開くテキストリンク</TextLink>
 ```
 
 #### 一階層上のコンテンツに戻るテキストリンク

--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -4,7 +4,7 @@ description: 'aタグの代わりに使用するコンポーネントです。�
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
-import { FaUpRightFromSquareIcon, FaCircleQuestionIcon} from 'smarthr-ui'
+import { FaUpRightFromSquareIcon} from 'smarthr-ui'
 
 `a`タグの代わりに使用するコンポーネントです。前後にアイコンを差し込めます。またリンクであることを表すために下線を強制します。
 

--- a/src/content/articles/products/components/text-link/index.mdx
+++ b/src/content/articles/products/components/text-link/index.mdx
@@ -59,14 +59,6 @@ SmartHR UIでは、`アイコン付き（左）`はプレフィックス（`pref
 #### ヘルプセンターを開くテキストリンク
 
 [ヘルプセンター](https://support.smarthr.jp/ja/)を開くテキストリンクは[HelpLink](/products/components/text-link/help-link/)として提供しています。
-- HelpLinkは、**テキストの右側**に <FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）を自動で配置するため、個別に設定する必要はありません。
-  - なお、ヘルプセンターを新規ウィンドウで開く場合には、<FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaCircleQuestionIcon`）は配置しません。`target="_blank"`を指定すると<FaCircleQuestionIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコンは自動的に除かれます。
-  - 詳細は[ヘルプページへの動線](/products/contents/ui-text/help-link/#h3-2)を参照してください。
-- `アイコン付き（右）`（サフィックス）は指定しないでください。
-
-```tsx editable
-  <HelpLink href="/" target="_blank">ヘルプセンターを開くテキストリンク</TextLink>
-```
 
 #### 一階層上のコンテンツに戻るテキストリンク
 

--- a/src/content/articles/products/contents/ui-text/help-link.mdx
+++ b/src/content/articles/products/contents/ui-text/help-link.mdx
@@ -35,10 +35,9 @@ import { FaExternalLinkAltIcon, FaQuestionCircleIcon } from 'smarthr-ui'
 - スペースの都合がある場合は、短くリライトして構いません。
 
 ### アイコン
-ヘルプセンターのリンクであることを表すために、<FaQuestionCircleIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaQuestionCircleIcon`）をテキストリンクの左側に配置できます。（推奨）  
-モードレスダイアログや新規ウィンドウなどの表示に関わらず、使用できます。
-
+- ヘルプセンターのリンクであることを表すために、<FaQuestionCircleIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaQuestionCircleIcon`）をテキストリンクの左側に配置します。（推奨）  
 - リンクを新規ウィンドウ（新規タブ）で開く場合は、[「新規ウィンドウで開くテキストリンク」の装飾](/products/components/icon/#h2-4)に準じて <FaExternalLinkAltIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaExternalLinkAltIcon`）をテキストリンクの右側に配置してください。（必須）
+    - <FaExternalLinkAltIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaExternalLinkAltIcon`）の配置を優先し、<FaQuestionCircleIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaQuestionCircleIcon`）の配置は不要です。
 
 ## アクセシビリティの観点
 - <FaQuestionCircleIcon alt="FaQuestionCircleIcon" color="TEXT_LINK" /> アイコンだけでヘルプページへのリンクを設定してもよいか。

--- a/src/content/articles/products/contents/ui-text/help-link.mdx
+++ b/src/content/articles/products/contents/ui-text/help-link.mdx
@@ -35,9 +35,8 @@ import { FaExternalLinkAltIcon, FaQuestionCircleIcon } from 'smarthr-ui'
 - スペースの都合がある場合は、短くリライトして構いません。
 
 ### アイコン
-- ヘルプセンターのリンクであることを表すために、<FaQuestionCircleIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaQuestionCircleIcon`）をテキストリンクの左側に配置します。（推奨）  
-- リンクを新規ウィンドウ（新規タブ）で開く場合は、[「新規ウィンドウで開くテキストリンク」の装飾](/products/components/icon/#h2-4)に準じて <FaExternalLinkAltIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaExternalLinkAltIcon`）をテキストリンクの右側に配置してください。（必須）
-    - <FaExternalLinkAltIcon alt="新規ウィンドウ" color="TEXT_LINK" /> アイコン（`FaExternalLinkAltIcon`）の配置を優先し、<FaQuestionCircleIcon alt="ヘルプセンター" color="TEXT_LINK" /> アイコン（`FaQuestionCircleIcon`）の配置は不要です。
+アイコンに配置については[HelpLink](/products/components/text-link/help-link/)を参照してください。
+HelpLinkを使用することで、アイコンの配置は自動で制御されます。
 
 ## アクセシビリティの観点
 - <FaQuestionCircleIcon alt="FaQuestionCircleIcon" color="TEXT_LINK" /> アイコンだけでヘルプページへのリンクを設定してもよいか。


### PR DESCRIPTION
## 課題・背景
:docbase:[プロダクトからヘルプページへの流入を取る方法](https://smarthr-inc.docbase.io/posts/3224598)では、ヘルプページへのリンクは「HelpLink」の使用が推奨されている。

しかし[TextLink | コンポーネント | SmartHR Design System](https://smarthr.design/products/components/text-link/#h4-2) の「ヘルプセンターを開くテキストリンク」の説明が古く、矛盾しているので、修正する。

チケット：https://smarthr.atlassian.net/browse/SD-1129

## やったこと
- TextLinkの説明にHelpLinkコンポーネントの使用を反映
  - https://smarthr.design/products/components/text-link/#h4-2
- 「ヘルプページへの動線」の説明が誤っていたため修正
  - https://smarthr.design/products/contents/ui-text/help-link/#h3-2
  - 新規ウィンドウでリンクを開く場合もヘルプアイコン（FaQuestionCircleIcon）が必須という説明になっていた。新規ウィンドウで開くことを示すアイコン（FaExternalLinkAltIcon） の表示を優先することが正しいため、修正した
    - 関連スレ：https://kufuinc.slack.com/archives/CJX59GJFR/p1756085175588049

## 動作確認
- Previewでみてね。