### PR TITLE
「操作を表す用語」に「同期する」を追加しました

### DIFF
--- a/src/content/articles/products/contents/idiomatic-usage/action.mdx
+++ b/src/content/articles/products/contents/idiomatic-usage/action.mdx
@@ -99,10 +99,16 @@ https://kufuinc.slack.com/archives/CJX59GJFR/p1608001964454300
 
 給与明細でCSV取り込み後のインフォメーションパネルの文言として、予約→受け付けに変更。
 
-{<span id="use-import-and-avoid-using-torikomi" />}
-## 「取り込む」と表記し、「インポート」の使用は控える
+{<span id="use-sync-not-fetch" />}
+## SmartHRにあるデータを取り込むことは「同期する」と表記し、「取得する」の使用は控える
 ### 説明
-SmartHRにデータを適用する操作は「取り込む」と表記します。
+SmartHRにあるデータを取り込んで取得元と同じ状態にすることは、データを「同期する」と表記します。
+データを「取得する」の使用は控えてください。
+
+{<span id="use-import-and-avoid-using-torikomi" />}
+## SmartHRの外部にあるデータを適用することは「取り込む」と表記し、「インポート」の使用は控える
+### 説明
+SmartHRの外部にあるデータをSmartHRに適用する操作は「取り込む」と表記します。
 
 ### 議事録
 https://smarthr-inc.docbase.io/posts/1650767

--- a/src/content/articles/products/contents/idiomatic-usage/ichiran.mdx
+++ b/src/content/articles/products/contents/idiomatic-usage/ichiran.mdx
@@ -136,7 +136,7 @@ ignoreH3Nav: true
 | 伴う | ともなう | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana) |
 | ドラッグアンドドロップ | ドラッグ＆ドロップ,　ドラッグ・ドロップ | [「ドラッグアンドドロップ」と表記し、「ドラッグ＆ドロップ」や「ドラッグ・ドロップ」の使用は控える](/products/contents/idiomatic-usage/action/#use-drag-and-drop) |
 | 取り消す | 取消 | [操作を止めるときの言葉（キャンセル・取り消し・中断の考え方）](/products/contents/idiomatic-usage/action/#words-for-stopping-an-operation) |
-| 取り込む | インポート | [SmartHRの外部にあるファイルを取り込んで操作するときの文言](/products/contents/idiomatic-usage/action/#words-for-operations-when-importing-a-file) 、 [「取り込み」と表記し、「インポート」の使用は控える](/products/contents/idiomatic-usage/action/#use-import-and-avoid-using-torikomi) |
+| 取り込む | インポート | [SmartHRの外部にあるファイルを取り込んで操作するときの文言](/products/contents/idiomatic-usage/action/#words-for-operations-when-importing-a-file) |
 | ドロップダウンリスト | プルダウン,　プルダウンメニュー,　プルダウンリスト,　ドロップダウン,　ドロップダウンメニュー | [「ドロップダウンリスト」と表記し、「プルダウンメニュー」などの使用は控える](/products/contents/idiomatic-usage/component/#use-dropdown-list-and-avoid-using-pull-down-menu) |
 
 ## な行

--- a/src/content/articles/products/contents/idiomatic-usage/ichiran.mdx
+++ b/src/content/articles/products/contents/idiomatic-usage/ichiran.mdx
@@ -127,6 +127,7 @@ ignoreH3Nav: true
 | 展開 | 解凍, 開く |  [ZIPファイルの「展開」と表記し、「解凍」または「開く」の使用は控える](/products/contents/idiomatic-usage/action/#use-extract-for-zip-files) |
 | テンプレート | フォーマット |  [「テンプレート」と「フォーマット」の使い分け](/products/contents/idiomatic-usage/other/#use-template-and-avoid-format) |
 | 問い合わせ | 問合せ | [送りがなをつけて表記する](/products/contents/idiomatic-usage/hiragana/#attach-okurigana)  |
+| 同期する | 取得する | [SmartHRにあるデータを取得することは「同期する」と表記し、「取得する」の使用は控える](/products/contents/idiomatic-usage/action/#use-synk-not-fetch)  |
 | 動作環境 | 推奨環境 | [「動作環境」と表記し、「推奨環境」の使用は控える](/products/contents/idiomatic-usage/other/#use-operating-environment-and-avoid-recommended-environment)|
 | とおり | 通り | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana) |
 | とき | 時 | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana) |
@@ -135,7 +136,7 @@ ignoreH3Nav: true
 | 伴う | ともなう | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana) |
 | ドラッグアンドドロップ | ドラッグ＆ドロップ,　ドラッグ・ドロップ | [「ドラッグアンドドロップ」と表記し、「ドラッグ＆ドロップ」や「ドラッグ・ドロップ」の使用は控える](/products/contents/idiomatic-usage/action/#use-drag-and-drop) |
 | 取り消す | 取消 | [操作を止めるときの言葉（キャンセル・取り消し・中断の考え方）](/products/contents/idiomatic-usage/action/#words-for-stopping-an-operation) |
-| 取り込む | インポート | [ファイルを取り込んで操作するときの文言](/products/contents/idiomatic-usage/action/#words-for-operations-when-importing-a-file) 、 [「取り込み」と表記し、「インポート」の使用は控える](/products/contents/idiomatic-usage/action/#use-import-and-avoid-using-torikomi) |
+| 取り込む | インポート | [SmartHRの外部にあるファイルを取り込んで操作するときの文言](/products/contents/idiomatic-usage/action/#words-for-operations-when-importing-a-file) 、 [「取り込み」と表記し、「インポート」の使用は控える](/products/contents/idiomatic-usage/action/#use-import-and-avoid-using-torikomi) |
 | ドロップダウンリスト | プルダウン,　プルダウンメニュー,　プルダウンリスト,　ドロップダウン,　ドロップダウンメニュー | [「ドロップダウンリスト」と表記し、「プルダウンメニュー」などの使用は控える](/products/contents/idiomatic-usage/component/#use-dropdown-list-and-avoid-using-pull-down-menu) |
 
 ## な行


### PR DESCRIPTION
## 課題・背景
- Jira チケット
https://smarthr.atlassian.net/browse/SD-1005?atlOrigin=eyJpIjoiZGYyYjZmZGNjYWU0NDg1Yzg5Njc2OTFhYTM0MjNkODUiLCJwIjoiaiJ9

■操作用語に「同期」を追加しました。

※注意点
これとは別に、**「取得」と表記し「インポート」は使用しない**　という用語も掲載されています。
https://smarthr.design/products/contents/idiomatic-usage/action/#h2-5

データの取り込みを表現するうえで、どちらを使うべきかばっと見わかりにくいので、用途の違いを示す下記のような文言を各々のタイトル・説明文に入れています。

同期：SmartHRにあるデータを取り込むこと
取得：SmartHRの外部にあるデータを取り込むこと

## やったこと

具体的には下記４点を対応しました。
- 操作用語に「同期する」を追加
- 操作用語にすでに掲載のある「取得する」について、外部のデータを取り込むときに使う用語であることを追記
- 索引に「同期する」を追加
- 索引にすでに掲載のある「取得する」について詳細文言を修正

## やらなかったこと
- 当初は　 https://smarthr.design/products/components/app-header/#h4-8　　この箇所にも「同期する」へのリンクを貼る予定でしたが、このページに記載してある説明文言で十分に「同期」の意味は伝わるので、わざわざリンクを貼る必要はないのではと考え省きました。違和感あればご指摘ください！

## 動作確認

- Previewでみてね。
