### PR TITLE
コンポーネントを追加（PageHeading、FormDialog、WakuWakuButton）

### DIFF
--- a/src/components/article/ComponentPropsTable.astro
+++ b/src/components/article/ComponentPropsTable.astro
@@ -21,7 +21,14 @@ const fragmentId = (propsName: string) => `props-${propsName.replace(' ', '-')}`
 
 {
   !data || data?.props === null || data.props.length === 0 ? (
-    <Text as={'p'}>Propsは設定されていません。</Text>
+    <>
+      {showTitle && (
+        <FragmentTitle tag="h3" id={fragmentId(name)}>
+          {name} props
+        </FragmentTitle>
+      )}
+      <Text as={'p'}>Propsは設定されていません。</Text>
+    </>
   ) : (
     <>
       {showTitle && (

--- a/src/content/articles/products/components/dialog/action-dialog/index.mdx
+++ b/src/content/articles/products/components/dialog/action-dialog/index.mdx
@@ -54,4 +54,5 @@ SmartHR UIでは、サイズ（`size`props）で指定できます。
 
 ## Props
 
-<ComponentPropsTable name="ActionDialog" />
+<ComponentPropsTable name="ActionDialog" showTitle />
+<ComponentPropsTable name="FormDialog" showTitle />

--- a/src/content/articles/products/components/dialog/index.mdx
+++ b/src/content/articles/products/components/dialog/index.mdx
@@ -33,9 +33,10 @@ import DynamicMessageDialog from './_components/DynamicMessageDialog'
 import DynamicModelessDialog from './_components/DynamicModelessDialog'
 import DynamicStepFormDialog from './_components/DynamicStepFormDialog'
 
-### ActionDialog
+### ActionDialog、FormDialog
 
 ユーザーに入力や選択などの操作を求めるためのダイアログです。ユーザーは操作内容をシステムに送信できます。
+ダイアログコンテンツにフォームが含まれている場合は、FormDialogを使用できます。
 
 モーダルなダイアログです。ダイアログの表示中、ダイアログの裏側の領域はスクリム（幕）で隠され、操作を受け付けません。
 

--- a/src/content/articles/products/components/heading/index.mdx
+++ b/src/content/articles/products/components/heading/index.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 import { Heading, Stack, Table, Td, Th } from 'smarthr-ui'
 
-Headingコンポーネントは、直後に続くコンテンツの見出しに使います。
+Heading および PageHeadingコンポーネントは、直後に続くコンテンツの見出しに使います。
 
 <ComponentStory name="Heading" />
 
@@ -27,8 +27,8 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
 
 ```tsx editable
 <Stack>
-  <PageHeading tag="span">画面タイトル（type: screenTitle, fontSize: XL）</PageHeading>
-  <Heading tag="span">セクションタイトル（type: sectionTitle, fontSize: L）</Heading>
+  <PageHeading tag="span">画面タイトル（fontSize: XL）</PageHeading>
+  <Heading type="sectionTitle" tag="span">セクションタイトル（type: sectionTitle, fontSize: L）</Heading>
   <Heading type="blockTitle" tag="span">ブロックタイトル（type: blockTitle, fontSize: M）</Heading>
   <Heading type="subBlockTitle" tag="span">サブ・ブロックタイトル（type: subBlockTitle, fontSize: M）</Heading>
   <Heading type="subSubBlockTitle" tag="span">サブ・サブ・ブロックタイトル（type: subSubBlockTitle, fontSize: S）</Heading>
@@ -37,7 +37,8 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
 
 ### 画面タイトル
 
-画面のタイトルとして、画面ごとに1度しか使えません。
+画面のタイトルとして、画面ごとに1度しか使えません。  
+PageHeadingコンポーネントを使用してください。screenTitleタイプと`h1`要素が自動的に設定されます。
 
 <TableWrapper>
   <Table>
@@ -176,4 +177,6 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
 
 ## Props
 
-<ComponentPropsTable name="Heading" />
+<ComponentPropsTable name="Heading" showTitle />
+
+<ComponentPropsTable name="PageHeading" showTitle />

--- a/src/content/articles/products/components/table/index.mdx
+++ b/src/content/articles/products/components/table/index.mdx
@@ -35,6 +35,7 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 <ComponentPropsTable name="TdRadioButton" showTitle />
 <ComponentPropsTable name="TableReel" showTitle />
 <ComponentPropsTable name="BulkActionRow" showTitle />
+<ComponentPropsTable name="WakuWakuButton" showTitle />
 <ComponentPropsTable name="EmptyTableBody" showTitle />
 
 ## 関連リンク

--- a/src/content/articles/products/design-patterns/visual-guidance/index.mdx
+++ b/src/content/articles/products/design-patterns/visual-guidance/index.mdx
@@ -113,7 +113,7 @@ HTMLのアウトライン構造に対して順に見出しを設定すること�
 視線移動は「視覚的にグルーピングされた情報の固まり」に対して階層的に発生します。  
 例えば、「画面全体の構成を見る俯瞰的な視線の動き」をしながら、「各セクション内の要素を詳細に見る視線の動き」をする、といった動きがみられます。
 
-そのため、[見出し](/products/components/heading/)や[余白](/products/design-patterns/spacing-layout-pattern/)、グルーピングされた要素群などの「視線移動の起点や境界となる要素」を適切に配置することが重要です。具体的な配置方法は、ページレイアウトの基本パターン（WIP）や、視覚的グルーピングの基準（WIP）を参照してください。
+そのため、[見出し](/products/components/heading/)や[余白](/products/design-patterns/spacing-layout-pattern/)、グルーピングされた要素群などの「視線移動の起点や境界となる要素」を適切に配置することが重要です。具体的な配置方法は、[ページレイアウト](/products/design-patterns/page-layout/)や、[視覚的グルーピング](/products/design-patterns/visual-grouping/)を参照してください。
 
 
 ### 視線誘導のみに頼ったレイアウトをしない（アクセシビリティとの関係）


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
- 書かれていなかったコンポーネントをいくつか追加
  - PageHeading、FormDialog、WakuWakuButton
- ComponentPropsTableでpropsがないコンポーネントでも`showTitle`があればタイトルを表示できるようにした
- WIPだったリンクを適切なものに置き換え

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
- Previewでみてね。
  - https://deploy-preview-1734--smarthr-design-system.netlify.app/products/components/dialog/#h3-0
  - https://deploy-preview-1734--smarthr-design-system.netlify.app/products/components/dialog/action-dialog/#props-FormDialog
  - https://deploy-preview-1734--smarthr-design-system.netlify.app/products/components/heading/#h3-0
  - https://deploy-preview-1734--smarthr-design-system.netlify.app/products/components/table/#props-WakuWakuButton
  - https://deploy-preview-1734--smarthr-design-system.netlify.app/products/design-patterns/visual-guidance/#h3-4

<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
