### PR TITLE
astroのconfigにsiteプロパティを追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,7 @@ import remarkIndexIdHeader from './src/remark/remark-index-id-header';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://smarthr.design/',
   prefetch: {
     prefetchAll: true,
     defaultStrategy: 'viewport',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,7 @@ import remarkIndexIdHeader from './src/remark/remark-index-id-header';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://smarthr.design/',
+  site: 'https://smarthr.design',
   prefetch: {
     prefetchAll: true,
     defaultStrategy: 'viewport',


### PR DESCRIPTION
## 課題・背景

公式サイトのメタプロパティ`og:url`の値が`http://localhost:4321/`になっている。

## やったこと
- `astro.config.mjs`のconfigに`site`プロパティを追加した

## 動作確認
https://deploy-preview-1989--smarthr-design-system.netlify.app/

## キャプチャ

|Before|After|
| --- | --- |
| <img width="384" height="90" alt="スクリーンショット 2026-04-16 19 28 42" src="https://github.com/user-attachments/assets/0234bb3a-b242-41f0-9225-d7b1a23211cb" /> | <img width="425" height="86" alt="スクリーンショット 2026-04-16 19 29 08" src="https://github.com/user-attachments/assets/c5f81345-99b7-4aa9-aac6-4832c68f461d" /> |
