### PR TITLE
情報アクセシビリティ好事例選定製品に勤怠管理機能を追加

### DIFF
--- a/src/content/articles/accessibility/status/index.mdx
+++ b/src/content/articles/accessibility/status/index.mdx
@@ -19,6 +19,7 @@ SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.c
 
 - 人事評価：[情報アクセシビリティ好事例2023](https://www.soumu.go.jp/info-accessibility-portal/koujirei/2023/)
 - スキル管理：[情報アクセシビリティ好事例2024](https://www.soumu.go.jp/info-accessibility-portal/koujirei/2024/)
+- 勤怠管理機能：[情報アクセシビリティ好事例2025](https://www.soumu.go.jp/menu_news/s-news/01ryutsu05_02000185.html)
 
 ### 人事評価
 - [2025_人事評価システム _情報アクセシビリティ自己評価様式 （書式１　自己評価結果）](https://docs.google.com/spreadsheets/d/1Dcynf7mK7i4Jd6UgKZcdG4LafMRDLeeC/edit?gid=15576948#gid=15576948)


### PR DESCRIPTION
## 課題・背景
情報アクセシビリティ好事例2025の選定結果公表をうけて、アクセシビリティコンテンツの検証結果のページに「勤怠管理機能」を追加しました。

## やったこと
- 「情報アクセシビリティ自己評価様式の開示」のセクションに「勤怠管理機能」および総務省の公表ページへのリンクを追加
  - 昨年までと違い、[情報アクセシビリティ好事例2025｜企業等の情報アクセシビリティの取組事例｜情報アクセシビリティポータルサイト｜総務省](https://www.soumu.go.jp/info-accessibility-portal/koujirei/2025/) には選定結果が反映されていないようです。代わりに総務省の公表ページ（https://www.soumu.go.jp/menu_news/s-news/01ryutsu05_02000185.html） へのリンクを貼っています。
## やらなかったこと
- それ以外

## 動作確認
プレビュー画面[検証結果](https://deploy-preview-1994--smarthr-design-system.netlify.app/accessibility/status/)を確認してください。

## キャプチャ
<img width="400"  alt="情報アクセシビリティ自己評価様式の開示のセクションに勤怠管理機能の文字と情報アクセシビリティ好事例2025というリンクが追加されている" src="https://github.com/user-attachments/assets/c6b8aed6-b85a-40c7-8449-e2b57843ddd6" />
