### PR TITLE
chore: ComponentPropsTableの表示を等幅フォントに変更

### DIFF
--- a/src/components/article/ComponentPropsTable.astro
+++ b/src/components/article/ComponentPropsTable.astro
@@ -80,6 +80,7 @@ const fragmentId = (propsName: string) => `props-${propsName.replace(' ', '-')}`
   .propName {
     display: flex;
     align-items: center;
+    font-family: monospace;
     font-weight: bold;
 
     > span {
@@ -90,6 +91,7 @@ const fragmentId = (propsName: string) => `props-${propsName.replace(' ', '-')}`
   .propTypes {
     display: flex;
     flex-wrap: wrap;
+    font-family: monospace;
     gap: 8px;
   }
 


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
- propsのコンテンツが長い時に見づらいので等幅フォントに変更した

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## キャプチャ

|Before|After|
| --- | --- |
| <img width="793" height="578" alt="image" src="https://github.com/user-attachments/assets/50dad7d8-4410-4dc8-bd78-e27a203d1545" /> | <img width="729" height="612" alt="image" src="https://github.com/user-attachments/assets/626306df-bbc2-46e9-8957-04dc6680ddd8" /> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
