### PR TITLE
feat: 各エラースクリーンコンポーネントのガイドラインを追加する

### DIFF
--- a/src/content/articles/products/components/error-screen/auth-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/auth-error-screen/index.mdx
@@ -1,0 +1,17 @@
+---
+title: 'AuthErrorScreen'
+description: ''
+---
+import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
+import ComponentStory from '@/components/article/ComponentStory.astro'
+
+
+
+<ComponentStory name="ErrorScreen" />
+
+## 使用上の注意
+
+## props
+
+<ComponentPropsTable name="ErrorScreen" />
+

--- a/src/content/articles/products/components/error-screen/auth-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/auth-error-screen/index.mdx
@@ -7,11 +7,11 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 
 
 
-<ComponentStory name="ErrorScreen" />
+<ComponentStory name="AuthErrorScreen" />
 
 ## 使用上の注意
 
 ## props
 
-<ComponentPropsTable name="ErrorScreen" />
+<ComponentPropsTable name="AuthErrorScreen" />
 

--- a/src/content/articles/products/components/error-screen/auth-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/auth-error-screen/index.mdx
@@ -1,15 +1,17 @@
 ---
 title: 'AuthErrorScreen'
-description: ''
+description: '認証エラーが発生した場合に表示するコンポーネントです。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 
+認証エラーが発生した場合に表示するコンポーネントです。
 
+ユーザーがログインしていない状態で認証が必要なページにアクセスした場合や、ログインに問題が発生した場合に表示します。
+
+「SmartHRに戻る」のリンク先はアプリケーションのホームではなく、SmartHRのホームにしてください。
 
 <ComponentStory name="AuthErrorScreen" />
-
-## 使用上の注意
 
 ## props
 

--- a/src/content/articles/products/components/error-screen/forbidden-roor-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/forbidden-roor-screen/index.mdx
@@ -1,0 +1,17 @@
+---
+title: 'ForbiddenErrorScreen'
+description: ''
+---
+import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
+import ComponentStory from '@/components/article/ComponentStory.astro'
+
+
+
+<ComponentStory name="ErrorScreen" />
+
+## 使用上の注意
+
+## props
+
+<ComponentPropsTable name="ErrorScreen" />
+

--- a/src/content/articles/products/components/error-screen/forbidden-roor-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/forbidden-roor-screen/index.mdx
@@ -7,11 +7,11 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 
 
 
-<ComponentStory name="ErrorScreen" />
+<ComponentStory name="ForbiddenErrorScreen" />
 
 ## 使用上の注意
 
 ## props
 
-<ComponentPropsTable name="ErrorScreen" />
+<ComponentPropsTable name="ForbiddenErrorScreen" />
 

--- a/src/content/articles/products/components/error-screen/forbidden-roor-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/forbidden-roor-screen/index.mdx
@@ -1,15 +1,15 @@
 ---
 title: 'ForbiddenErrorScreen'
-description: ''
+description: 'ページにアクセスする権限がない場合に表示するコンポーネントです。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 
+ページにアクセスする権限がない場合に表示するコンポーネントです。
 
+ユーザーがページにアクセスする権限をもっていない場合、所属企業の担当者（管理者）へ問い合わせるという対応策と、アプリケーションのホームへ戻るリンクを表示します。
 
 <ComponentStory name="ForbiddenErrorScreen" />
-
-## 使用上の注意
 
 ## props
 

--- a/src/content/articles/products/components/error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/index.mdx
@@ -4,11 +4,16 @@ description: 'エラーを全画面で表示をするためのコンポーネン
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
+import PageIndex from '@/components/article/PageIndex.astro'
 import { Button, Center, Cluster, ErrorScreen, Stack, Text, TextLink } from 'smarthr-ui'
 
 ErrorScreenコンポーネントはエラーを全画面で表示するためのコンポーネントです。
 
 <ComponentStory name="ErrorScreen" />
+
+## ErrorScreenを使用したコンポーネント
+
+<PageIndex basePath="/products/components/error-screen/" heading="h3" />
 
 ## 使用上の注意
 

--- a/src/content/articles/products/components/error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/index.mdx
@@ -9,54 +9,51 @@ import { Button, Center, Cluster, ErrorScreen, Stack, Text, TextLink } from 'sma
 
 ErrorScreenコンポーネントはエラーを全画面で表示するためのコンポーネントです。
 
+なんらかのエラーによってユーザーが操作できなくなった場合や、ユーザーに操作をさせたくない場合に使用してください。
+
 <ComponentStory name="ErrorScreen" />
-
-## ErrorScreenを使用したコンポーネント
-
-<PageIndex basePath="/products/components/error-screen/" heading="h3" />
 
 ## 使用上の注意
 
-以下のように、エラーによってユーザーが操作できない状況や、ユーザーに操作させたくない状況で使用してください。
+全画面でエラーを表示する必要がないエラーには使用しないでください。
 
-- 存在しないページにアクセスした場合
-- ページにアクセスする権限がない場合
-- サービスがメンテナンス中の場合
-- 一定時間操作がなかった場合
-- 予期しないエラーが発生した場合
+フォームのバリデーションエラーや連携APIの疎通エラーのような一時的なエラーの場合は以下のコンポーネントの使用を検討します。
 
-具体例は<a href="#h2-2">エラー別の表示内容</a>に記述しています。
+- [NotificationBar](/products/components/notification-bar/)
+- [ResponseMessage](/products/components/response-message/)
+- [InformationPanel](/products/components/information-panel/)
 
-フォームのバリデーションエラーや連携APIの疎通エラーのような一時的なエラーの場合、[NotificationBar](/products/components/notification-bar/)や[ResponseMessage](/products/components/response-message/)、[InformationPanel](/products/components/information-panel/)などを使用を検討します。詳細は[フィードバック](/products/design-patterns/feedback/)の基準を参照してください。
+詳細は[フィードバック](/products/design-patterns/feedback/)の基準を参照してください。
 
 ## レイアウト
 
-ロゴ、タイトル、メッセージ、リンクを表示できます。
+ErrorScreenコンポーネントではロゴ、タイトル、メッセージ、リンクを表示できます。
 
 ```tsx editable
-<ErrorScreen
-  className="shr-w-full"
-  title="タイトル"
-  links={[
-    {
-      label: 'リンク1',
-      url: '/',
-    },
-    {
-      label: 'リンク2',
-      url: '/',
-    },
-    {
-      label: 'リンク3',
-      url: '/',
-      target: '_blank',
-    },
-  ]}
->
-  <p>
-    メッセージ
-  </p>
-</ErrorScreen>
+<div style={{ width: '100%' }}>
+  <ErrorScreen
+    title="タイトル"
+    links={[
+      {
+        label: 'リンク1',
+        url: '/',
+      },
+      {
+        label: 'リンク2',
+        url: '/',
+      },
+      {
+        label: 'リンク3',
+        url: '/',
+        target: '_blank',
+      },
+    ]}
+  >
+    <p>
+      メッセージ
+    </p>
+  </ErrorScreen>
+</div>
 ```
 
 ### ロゴ
@@ -65,7 +62,7 @@ ErrorScreenコンポーネントはエラーを全画面で表示するための
 
 ### タイトル
 
-なぜエラーが発生したのかがわかる文言を設定します。
+どのようなエラーが発生したのかがわかる文言を設定します。
 
 ### メッセージ
 
@@ -77,126 +74,11 @@ ErrorScreenコンポーネントはエラーを全画面で表示するための
 
 必要に応じて別タブで開くオプションも設定します。
 
-## エラー別の表示内容
+## ErrorScreenを使用したコンポーネント
 
-### 存在しないページにアクセスした場合（404 Not Foundエラー）
+頻繁に利用するErrorScreenのパターンを、エラーの種類に応じたコンポーネントとして用意しています。
 
-存在しないページにアクセスした原因として、ページ自体が移動・削除された可能性やユーザーがURLを間違えている可能性を提示しましょう。SmartHRのホームへ戻るリンクも表示してください。
-
-```tsx editable
-<ErrorScreen
-  className="shr-w-full"
-  title="指定のページは見つかりませんでした"
-  links={[
-    {
-      label: 'ホームへ戻る',
-      url: '（適切なURLを設定してください）',
-    },
-  ]}
->
-  <p>
-    指定のページはアクセスできない状況にあるか、削除された可能性があります。
-    <br />
-    URLに間違いがないか、確認してください。
-  </p>
-</ErrorScreen>
-```
-
-### ページにアクセスする権限がない場合（403 Forbiddenエラー）
-
-ユーザーがページにアクセスする権限をもっていない場合、SmartHRのホームへ戻るリンクを表示します。必要に応じて、所属企業の担当者（管理者）へ問い合わせるという対応策を提示してください。
-
-```tsx editable
-<ErrorScreen
-  className="shr-w-full"
-  title="このページを表示する権限がありません"
-  links={[
-    {
-      label: 'ホームへ戻る',
-      url: '（適切なURLを設定してください）',
-    },
-  ]}
->
-  <p>
-    詳しくは、所属企業の担当者にお問い合わせください。
-  </p>
-</ErrorScreen>
-```
-
-### サービスがメンテナンス中の場合（503 Service Unavailableエラー）
-
-サービスがメンテナンス中の場合、SmartHRのメンテナンス・障害のお知らせへのリンクを表示してください。お知らせは、別タブで開くように設定してください。
-
-```tsx editable
-<ErrorScreen
-  className="shr-w-full"
-  title="SmartHRは現在メンテナンス中です"
-  links={[
-    {
-      label: 'お知らせ',
-      url: 'https://support.smarthr.jp/ja/info/status/page/1/',
-      target: '_blank',
-    },
-  ]}
->
-  <p>
-    いつもSmartHRをご利用いただき、ありがとうございます。
-    <br />
-    ただいまメンテナンスのため、一時的にサービスを停止しています。
-    <br />
-    ご迷惑をおかけしますが、ご理解のほどよろしくお願いいたします。
-  </p>
-</ErrorScreen>
-```
-
-### 一定時間操作がなかった場合（401 Unauthorizedエラー）
-
-一定の時間、ユーザーが操作しなかった場合、自動でログアウトしたことがわかるメッセージとログインボタンを表示します。ログインボタンを押せば、再ログインできるようにしてください。
-
-「セッションがタイムアウトしました。」は一般的なユーザーには伝わりにくい表現なので「自動でログアウトしました」を推奨します。
-
-```tsx editable
-<ErrorScreen
-  className="shr-w-full"
-  title="一定の時間、操作がなかったためログアウトしました"
->
-  <Stack gap={1.5}>
-    <p>
-      一定の時間、操作がなかったため、自動でログアウトしました。
-      <br />
-      指定のページを表示するには、再度ログインしてください。
-    </p>
-    <Center>
-      <Button>ログイン</Button>
-    </Center>
-  </Stack>
-</ErrorScreen>
-```
-
-### 予期しないエラーが発生した場合（500 Internal Server Errorエラーなど）
-
-データの閲覧・作成・更新が安全に実行できない状況の場合、予期しないエラーが発生したメッセージを表示してください。
-
-また、このページに記載されていないその他のエラーをまとめて扱う場合にも、以下の表示内容を使用できます。
-
-必要があれば、SmartHRのホームへ戻るリンクを表示してください。
-
-```tsx editable
-<ErrorScreen
-  className="shr-w-full"
-  title="予期しないエラーが発生しました"
-  links={[
-    {
-      label: 'ホームへ戻る',
-      url: '（適切なURLを設定してください）',
-    },
-  ]}
->
-  <p>
-    時間をおいて、やり直してください。
-  </p>
-</ErrorScreen>
-```
+<PageIndex basePath="/products/components/error-screen/" heading="h3" />
 
 ## props
 

--- a/src/content/articles/products/components/error-screen/not-found-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/not-found-error-screen/index.mdx
@@ -1,0 +1,17 @@
+---
+title: 'NotFoundErrorScreen'
+description: ''
+---
+import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
+import ComponentStory from '@/components/article/ComponentStory.astro'
+
+
+
+<ComponentStory name="ErrorScreen" />
+
+## 使用上の注意
+
+## props
+
+<ComponentPropsTable name="ErrorScreen" />
+

--- a/src/content/articles/products/components/error-screen/not-found-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/not-found-error-screen/index.mdx
@@ -7,11 +7,11 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 
 
 
-<ComponentStory name="ErrorScreen" />
+<ComponentStory name="NotFoundErrorScreen" />
 
 ## 使用上の注意
 
 ## props
 
-<ComponentPropsTable name="ErrorScreen" />
+<ComponentPropsTable name="NotFoundErrorScreen" />
 

--- a/src/content/articles/products/components/error-screen/not-found-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/not-found-error-screen/index.mdx
@@ -1,15 +1,15 @@
 ---
 title: 'NotFoundErrorScreen'
-description: ''
+description: '存在しないページにアクセスした場合に表示するコンポーネントです。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 
+存在しないページにアクセスした場合に表示するコンポーネントです。
 
+ユーザーが存在しないページにアクセスした場合、ページ自体が移動・削除された可能性の提示と、アプリケーションのホームへ戻るリンクを表示します。
 
 <ComponentStory name="NotFoundErrorScreen" />
-
-## 使用上の注意
 
 ## props
 

--- a/src/content/articles/products/components/error-screen/unauthorized-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/unauthorized-error-screen/index.mdx
@@ -1,0 +1,17 @@
+---
+title: 'UnauthorizedErrorScreen'
+description: ''
+---
+import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
+import ComponentStory from '@/components/article/ComponentStory.astro'
+
+
+
+<ComponentStory name="ErrorScreen" />
+
+## 使用上の注意
+
+## props
+
+<ComponentPropsTable name="ErrorScreen" />
+

--- a/src/content/articles/products/components/error-screen/unauthorized-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/unauthorized-error-screen/index.mdx
@@ -1,15 +1,17 @@
 ---
 title: 'UnauthorizedErrorScreen'
-description: ''
+description: '一定時間操作がなかったためにセッションが切れたときなど、認証が必要な状態でアクセスした場合に表示するコンポーネントです。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 
+一定時間操作がなかったためにセッションが切れたときなど、認証が必要な状態でアクセスした場合に表示するコンポーネントです。
 
+ユーザーが一定時間操作しなかった場合、自動でログアウトしたことがわかるメッセージとログインボタンを表示します。ログインボタンを押せば、再ログインできるようにしてください。
+
+「セッションがタイムアウトしました。」は一般的なユーザーには伝わりにくい表現なので「自動でログアウトしました」としています。
 
 <ComponentStory name="UnauthorizedErrorScreen" />
-
-## 使用上の注意
 
 ## props
 

--- a/src/content/articles/products/components/error-screen/unauthorized-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/unauthorized-error-screen/index.mdx
@@ -7,11 +7,11 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 
 
 
-<ComponentStory name="ErrorScreen" />
+<ComponentStory name="UnauthorizedErrorScreen" />
 
 ## 使用上の注意
 
 ## props
 
-<ComponentPropsTable name="ErrorScreen" />
+<ComponentPropsTable name="UnauthorizedErrorScreen" />
 

--- a/src/content/articles/products/components/error-screen/unexpected-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/unexpected-error-screen/index.mdx
@@ -1,0 +1,17 @@
+---
+title: 'UnexpectedErrorScreen'
+description: ''
+---
+import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
+import ComponentStory from '@/components/article/ComponentStory.astro'
+
+
+
+<ComponentStory name="ErrorScreen" />
+
+## 使用上の注意
+
+## props
+
+<ComponentPropsTable name="ErrorScreen" />
+

--- a/src/content/articles/products/components/error-screen/unexpected-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/unexpected-error-screen/index.mdx
@@ -1,15 +1,17 @@
 ---
 title: 'UnexpectedErrorScreen'
-description: ''
+description: '予期しないエラーが発生した場合に表示するコンポーネントです。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 
+予期しないエラーが発生した場合に表示するコンポーネントです。
 
+メンテナンスやシステム障害などでデータの閲覧・作成・更新が安全に実行できない状況の場合、予期しないエラーが発生したメッセージを表示します。
+
+予期しないエラーの場合、対応方法やヘルプセンターへのリンクを丁寧に提示することが重要です。アプリケーションのホームへ戻るリンクも表示してください。
 
 <ComponentStory name="UnexpectedErrorScreen" />
-
-## 使用上の注意
 
 ## props
 

--- a/src/content/articles/products/components/error-screen/unexpected-error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/unexpected-error-screen/index.mdx
@@ -7,11 +7,11 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 
 
 
-<ComponentStory name="ErrorScreen" />
+<ComponentStory name="UnexpectedErrorScreen" />
 
 ## 使用上の注意
 
 ## props
 
-<ComponentPropsTable name="ErrorScreen" />
+<ComponentPropsTable name="UnexpectedErrorScreen" />
 


### PR DESCRIPTION
## 課題・背景

SmartHR UI v93.1.0 で以下のエラー専用のコンポーネントが追加されたので、それぞれ個別のページに切り出してガイドラインを追加しました。

- UnauthorizedErrorScreen (401)
- ForbiddenErrorScreen (403)
- NotFoundErrorScreen (404)
- UnexpectedErrorScreen (500)
- AuthErrorScreen (認証エラー)

ref: https://github.com/kufu/smarthr-ui/pull/6274

## やったこと

- 上記５エラー画面のページを追加し、内容を移植した
- ErrorScreenトップページの内容を整えた
  - 以前はエラーごとにセクションを設けてガイドラインを記載していましたが、各エラー画面ごとのページに移動しました

## 移植によるBefore/After

### Not Foundエラー

https://deploy-preview-2027--smarthr-design-system.netlify.app/products/components/error-screen/not-found-error-screen

| BEFORE | AFTER |
|:---:|:---:|
| <img width="893" height="690" alt="スクリーンショット 2026-05-01 18 38 59" src="https://github.com/user-attachments/assets/60a7276c-2f45-49b9-939d-0e0ed33cd325" /> | <img width="898" height="736" alt="スクリーンショット 2026-05-01 18 39 11" src="https://github.com/user-attachments/assets/1d19c4d7-00b4-432b-956b-9d83da056b6b" /> |

### Forbiddenエラー

https://deploy-preview-2027--smarthr-design-system.netlify.app/products/components/error-screen/forbidden-error-screen

| BEFORE | AFTER |
|:---:|:---:|
| <img width="909" height="678" alt="スクリーンショット 2026-05-01 18 39 18" src="https://github.com/user-attachments/assets/b4117297-a7e3-48f3-b16b-6d3f4865dedc" /> | <img width="899" height="752" alt="スクリーンショット 2026-05-01 18 39 33" src="https://github.com/user-attachments/assets/2359837d-e7d6-4bc8-b5d9-45054f57745d" /> |

### Unavailableエラー

新規URLなし。

メンテナンス中のエラー画面については、現在はCloud Functionでメンテナンス画面を表示しているので、コンポーネントもガイドラインも不要と判断してトルツメしています。

### Unauthorizedエラー

https://deploy-preview-2027--smarthr-design-system.netlify.app/products/components/error-screen/unauthorized-error-screen

| BEFORE | AFTER |
|:---:|:---:|
| <img width="895" height="758" alt="スクリーンショット 2026-05-01 18 39 47" src="https://github.com/user-attachments/assets/90ceb645-a338-49e8-851b-758d5cb75776" /> | <img width="898" height="878" alt="スクリーンショット 2026-05-01 18 40 00" src="https://github.com/user-attachments/assets/f86f3733-87c7-470a-865c-61022e763676" /> |

### Unexpectedエラー

https://deploy-preview-2027--smarthr-design-system.netlify.app/products/components/error-screen/unexpected-error-screen

| BEFORE | AFTER |
|:---:|:---:|
| <img width="893" height="807" alt="スクリーンショット 2026-05-01 18 40 12" src="https://github.com/user-attachments/assets/10ef316d-7252-4b64-aeba-ac52a1710e4f" /> | <img width="903" height="1235" alt="スクリーンショット 2026-05-01 18 40 34" src="https://github.com/user-attachments/assets/debe6008-f85f-46c6-897a-a7554585a388" /> |

### Authエラー

https://deploy-preview-2027--smarthr-design-system.netlify.app/products/components/error-screen/auth-error-screen

| BEFORE | AFTER |
|:---:|:---:|
| なし | <img width="901" height="809" alt="スクリーンショット 2026-05-01 18 40 43" src="https://github.com/user-attachments/assets/b732b22f-a3a9-4b2b-9577-f860fede61a8" /> |

## やらなかったこと

エラーコードの記載は移植せずトルツメしました。

## 動作確認

https://deploy-preview-2027--smarthr-design-system.netlify.app/products/components/error-screen/
