### PR TITLE
revert(components): 非推奨3コンポーネントの mdx を新方式で復活

### DIFF
--- a/src/content/articles/products/components/datetime-local-picker/index.mdx
+++ b/src/content/articles/products/components/datetime-local-picker/index.mdx
@@ -1,0 +1,13 @@
+---
+title: 'DatetimeLocalPicker'
+description: "ユーザーに日付と時刻を指定させる際に使用するコンポーネントです。"
+deprecated: true
+deprecatedMessage: 'DatetimeLocalPickerは非推奨です。<a href="/products/components/input/">Input[type="datetime-local"]</a>を使ってください。'
+---
+import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
+
+ユーザーに日付と時刻を指定させる際に使用するコンポーネントです。
+
+## Props
+
+<ComponentPropsTable name="DatetimeLocalPicker" />

--- a/src/content/articles/products/components/month-picker/index.mdx
+++ b/src/content/articles/products/components/month-picker/index.mdx
@@ -9,17 +9,6 @@ import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 
 ユーザーに年と月を入力させる際に使用するコンポーネントです。
 
-## 状態
-
-### デフォルト
-[WIP]
-
-### 読み取り専用（readOnly）
-[WIP]
-
-### 無効（disabled）
-[WIP]
-
 ## Props
 
 <ComponentPropsTable name="MonthPicker" />

--- a/src/content/articles/products/components/month-picker/index.mdx
+++ b/src/content/articles/products/components/month-picker/index.mdx
@@ -1,0 +1,25 @@
+---
+title: 'MonthPicker'
+description: 'ユーザーに年と月を入力させる際に使用するコンポーネントです。'
+deprecated: true
+deprecatedMessage: 'MonthPickerは非推奨です。<a href="/products/components/input/">Input[type="month"]</a>を使ってください。'
+---
+
+import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
+
+ユーザーに年と月を入力させる際に使用するコンポーネントです。
+
+## 状態
+
+### デフォルト
+[WIP]
+
+### 読み取り専用（readOnly）
+[WIP]
+
+### 無効（disabled）
+[WIP]
+
+## Props
+
+<ComponentPropsTable name="MonthPicker" />

--- a/src/content/articles/products/components/time-picker/index.mdx
+++ b/src/content/articles/products/components/time-picker/index.mdx
@@ -9,20 +9,6 @@ import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 
 ユーザーに時刻（時と分、任意で秒）を入力させる際に使用するコンポーネントです。
 
-## 状態
-
-### デフォルト
-
-[WIP]
-
-### 読み取り専用（readOnly）
-
-[WIP]
-
-### 無効（disabled）
-
-[WIP]
-
 ## Props
 
 <ComponentPropsTable name="TimePicker" />

--- a/src/content/articles/products/components/time-picker/index.mdx
+++ b/src/content/articles/products/components/time-picker/index.mdx
@@ -1,0 +1,28 @@
+---
+title: 'TimePicker'
+description: 'ユーザーに時刻（時と分、任意で秒）を入力させる際に使用するコンポーネントです。'
+deprecated: true
+deprecatedMessage: 'TimePickerは非推奨です。<a href="/products/components/input/">Input[type="time"]</a>を使ってください。'
+---
+
+import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
+
+ユーザーに時刻（時と分、任意で秒）を入力させる際に使用するコンポーネントです。
+
+## 状態
+
+### デフォルト
+
+[WIP]
+
+### 読み取り専用（readOnly）
+
+[WIP]
+
+### 無効（disabled）
+
+[WIP]
+
+## Props
+
+<ComponentPropsTable name="TimePicker" />


### PR DESCRIPTION
## 課題・背景

[#2053](https://github.com/kufu/smarthr-design-system/pull/2053) で「smarthr-ui から削除済み」と判断して DatetimeLocalPicker / MonthPicker / TimePicker の mdx を削除しましたが、調査の結果 **smarthr-ui 93.1.2 では現在も export されており利用可能** であることが判明しました。

[Notion: 🧹 M5 コンポーネント mdx メタデータ統一](https://www.notion.so/35f37b6398eb81ab88b4db8db3471721) の進捗ログにも記録済み。

mdx ガイドラインが存在しないと:
- デザインシステムサイトから該当ページが消える → サイト内不整合
- SKILL.md は smarthr-ui 側の export を正として fallback テキストで生成され続ける → ガイドライン情報が反映されない

将来 smarthr-ui がコンポーネントを完全削除した時点で mdx も併せて削除する想定で、今回は復活させます。

## やったこと

3コンポーネントの mdx を Phase 1 の新方式(deprecated frontmatter 構造化)で復活:

- `src/content/articles/products/components/datetime-local-picker/index.mdx`
- `src/content/articles/products/components/month-picker/index.mdx`
- `src/content/articles/products/components/time-picker/index.mdx`

frontmatter 仕様:
- `deprecated: true`
- `deprecatedMessage`: `<a href="/products/components/input/">Input[type="..."]</a>` を含む案内文
- title からは「（非推奨）」表記を削除(`ArticleLayout` が自動付与)
- 本文の `<BaseColumn><ResponseMessage>...</ResponseMessage></BaseColumn>` ブロックは記載なし(`ArticleLayout` の自動描画に委ねる)

## やらなかったこと

- 本文のリッチ化(状態などは `[WIP]` のまま)
- smarthr-ui 側へのコンポーネント削除提案

## 動作確認

- [ ] `pnpm dev` で `/products/components/datetime-local-picker/`、`/month-picker/`、`/time-picker/` が表示される
- [ ] 各ページの h1 が `XXX（非推奨）`、本文冒頭に warning ResponseMessage、Input へのリンクが有効
- [ ] サイドメニュー / コンポーネント一覧でも `（非推奨）` 表示
- [ ] `pnpm generate`(scripts/generate-skills)で各 SKILL.md の description 冒頭に `【非推奨】` が付くこと、`component-selector` テーブルに `⚠️ XXX（非推奨）` マークが出ること(PR #2055 の改修要、ai-agent-skills ブランチ反映後)

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)