### PR TITLE
feat(generate-skills): frontmatter inheritedBy の解釈を追加

### DIFF
--- a/scripts/generate-skills/index.ts
+++ b/scripts/generate-skills/index.ts
@@ -10,6 +10,7 @@ import {
 } from './lib/fetch-eslint-rules.js';
 import { parseChecklist } from './lib/parse-checklist.js';
 import { parseIndexMdx, type IndexMdxInfo } from './lib/parse-index-mdx.js';
+import { collectInheritedSkills } from './lib/inherited-by.js';
 import { buildDirMapping, loadManualMappings, pascalToKebab } from './lib/name-mapping.js';
 import { renderSkill } from './lib/render-skill.js';
 import { renderRouterSkill, type RouterEntry } from './lib/render-router-skill.js';
@@ -85,6 +86,10 @@ async function main() {
   const dirMapping = buildDirMapping([...groups.keys()], DESIGN_SYSTEM_DIR, manualMappings);
   console.log(`   ${dirMapping.size}/${groups.size} を design-system dir に対応付け`);
 
+  console.log('🧬 inheritedBy 宣言を集約中…');
+  const inheritedSkills = collectInheritedSkills(DESIGN_SYSTEM_DIR);
+  console.log(`   ${inheritedSkills.size} 件の inheritedBy 宣言を検出`);
+
   const coverageReport = validateCoverage({
     groups,
     dirMapping,
@@ -122,6 +127,21 @@ async function main() {
       indexInfo = parseIndexMdx(path.join(compDir, 'index.mdx'));
       checklist = parseChecklist(path.join(compDir, 'checklist.yaml'));
       if (checklist !== null) withLayer3++;
+    } else if (inheritedSkills.has(dirName)) {
+      // 派生先コンポーネント: 親 mdx の本文を継承し、description のみ派生先固有に差し替える
+      const inh = inheritedSkills.get(dirName)!;
+      indexInfo = {
+        ...inh.parentInfo,
+        description: inh.description,
+        inheritedBy: [],
+      };
+      // 親コンポーネントの checklist も継承する
+      const parentDesignDirName = dirMapping.get(inh.parentName);
+      if (parentDesignDirName) {
+        const parentCompDir = path.join(DESIGN_SYSTEM_DIR, parentDesignDirName);
+        checklist = parseChecklist(path.join(parentCompDir, 'checklist.yaml'));
+        if (checklist !== null) withLayer3++;
+      }
     }
 
     const eslintRulesSet = new Map<string, EslintRuleWithContent>();

--- a/scripts/generate-skills/lib/inherited-by.ts
+++ b/scripts/generate-skills/lib/inherited-by.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { parseIndexMdx, type IndexMdxInfo } from './parse-index-mdx.js';
+
+export type InheritedSkill = {
+  /** 派生先コンポーネント名(例: ControlledActionDialog) */
+  name: string;
+  /** 派生先コンポーネント固有の description */
+  description: string;
+  /** 派生元 mdx の IndexMdxInfo(本文継承元) */
+  parentInfo: IndexMdxInfo;
+  /** 派生元コンポーネント名(例: ActionDialog) */
+  parentName: string;
+  /** 派生元 mdx の所在(設計システム相対パス、ログ用) */
+  parentDir: string;
+};
+
+/**
+ * 設計システム配下の全 mdx を走査し、frontmatter `inheritedBy` 宣言を集約する。
+ * key: 派生先コンポーネント名、value: 派生情報
+ */
+export function collectInheritedSkills(designSystemDir: string): Map<string, InheritedSkill> {
+  const result = new Map<string, InheritedSkill>();
+  walkMdx(designSystemDir, designSystemDir, result);
+  return result;
+}
+
+function walkMdx(rootDir: string, currentDir: string, acc: Map<string, InheritedSkill>): void {
+  if (!fs.existsSync(currentDir)) return;
+  for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+    const full = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name.startsWith('_')) continue;
+      walkMdx(rootDir, full, acc);
+      continue;
+    }
+    if (entry.name !== 'index.mdx') continue;
+
+    const info = parseIndexMdx(full);
+    if (!info || info.inheritedBy.length === 0) continue;
+
+    const relDir = path.relative(rootDir, path.dirname(full));
+    const parentName = inferParentName(relDir);
+
+    for (const child of info.inheritedBy) {
+      if (acc.has(child.name)) continue;
+      acc.set(child.name, {
+        name: child.name,
+        description: child.description,
+        parentInfo: info,
+        parentName,
+        parentDir: relDir,
+      });
+    }
+  }
+}
+
+/**
+ * 設計システム相対ディレクトリから親コンポーネント名(PascalCase)を推測する。
+ * 例: "dialog/action-dialog" → "ActionDialog"、 "table" → "Table"
+ */
+function inferParentName(relDir: string): string {
+  const last = relDir.split('/').filter(Boolean).pop() ?? '';
+  return last
+    .split('-')
+    .map((s) => (s.length === 0 ? '' : s[0].toUpperCase() + s.slice(1)))
+    .join('');
+}

--- a/scripts/generate-skills/lib/parse-index-mdx.ts
+++ b/scripts/generate-skills/lib/parse-index-mdx.ts
@@ -1,11 +1,17 @@
 import fs from 'node:fs';
 import matter from 'gray-matter';
 
+export type InheritedByEntry = {
+  name: string;
+  description: string;
+};
+
 export type IndexMdxInfo = {
   description: string;
   leadParagraph: string;
   deprecated: boolean;
   deprecatedMessage: string;
+  inheritedBy: InheritedByEntry[];
 };
 
 export function parseIndexMdx(indexMdxPath: string): IndexMdxInfo | null {
@@ -16,6 +22,7 @@ export function parseIndexMdx(indexMdxPath: string): IndexMdxInfo | null {
   let frontmatterDescription = '';
   let deprecated = false;
   let deprecatedMessage = '';
+  let inheritedBy: InheritedByEntry[] = [];
   let bodyContent = content;
 
   try {
@@ -23,6 +30,7 @@ export function parseIndexMdx(indexMdxPath: string): IndexMdxInfo | null {
     frontmatterDescription = (parsed.data.description as string) ?? '';
     deprecated = (parsed.data.deprecated as boolean) ?? false;
     deprecatedMessage = (parsed.data.deprecatedMessage as string) ?? '';
+    inheritedBy = normalizeInheritedBy(parsed.data.inheritedBy);
     bodyContent = parsed.content;
   } catch {
     // Fallback: no frontmatter
@@ -30,7 +38,26 @@ export function parseIndexMdx(indexMdxPath: string): IndexMdxInfo | null {
 
   const leadParagraph = extractLeadParagraph(bodyContent, frontmatterDescription);
 
-  return { description: frontmatterDescription, leadParagraph, deprecated, deprecatedMessage };
+  return {
+    description: frontmatterDescription,
+    leadParagraph,
+    deprecated,
+    deprecatedMessage,
+    inheritedBy,
+  };
+}
+
+function normalizeInheritedBy(value: unknown): InheritedByEntry[] {
+  if (!Array.isArray(value)) return [];
+  const result: InheritedByEntry[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue;
+    const name = (entry as { name?: unknown }).name;
+    const description = (entry as { description?: unknown }).description;
+    if (typeof name !== 'string' || typeof description !== 'string') continue;
+    result.push({ name, description });
+  }
+  return result;
 }
 
 function extractLeadParagraph(body: string, description: string): string {

--- a/scripts/generate-skills/mapping/component-dir-map.json
+++ b/scripts/generate-skills/mapping/component-dir-map.json
@@ -1,10 +1,4 @@
 {
-  "ActionDialog": "dialog/action-dialog",
-  "FormDialog": "dialog",
-  "MessageDialog": "dialog/message-dialog",
-  "ModelessDialog": "dialog/modeless-dialog",
-  "StepFormDialog": "dialog/step-form-dialog",
-  "Dialog": "dialog",
   "Checkbox": "checkbox",
   "SingleCombobox": "combobox/single-combobox",
   "MultiCombobox": "combobox/multi-combobox",


### PR DESCRIPTION
## 課題・背景

M5 Phase 2.5「mdx 未作成コンポーネントの方針整理」で確定した方針に基づく実装です。

派生コンポーネント(Controlled* / Table 系子コンポーネント等)について、個別 mdx を作らずに親 mdx の frontmatter 宣言だけで適切な SKILL.md を生成できる仕組みを追加します。

- [M5 Phase 2.5: mdx 未作成コンポーネントの方針整理](https://www.notion.so/35f37b6398eb81dda07af49b00dce538)

## やったこと

- frontmatter `inheritedBy` の解釈ロジックを追加
  - 設計システム配下の全 index.mdx を走査して派生宣言を集約
  - 派生先 SKILL.md は派生元 mdx 本文 + checklist を継承
  - description は派生先固有のものを使用
- `mapping/component-dir-map.json` からダイアログ系の手動マッピングを削除(子ページ化により自動解決可能)

宣言例:

```yaml
---
title: 'ActionDialog'
description: '...'
inheritedBy:
  - name: ControlledActionDialog
    description: '外部 state で開閉制御する ActionDialog。'
---
```

## やらなかったこと

- 各 mdx への `inheritedBy` 宣言の追加(別 PR で実施)
- SKILL.md の再生成コミット(mdx 側 PR (#2058) マージ後に再生成)

## 動作確認

`scripts/generate-skills` で `pnpm generate` を実行し、以下を確認しました:

- 95 コンポーネントの SKILL.md 生成完了(エラーなし)
- `inheritedBy` 宣言は現時点で 0 件検出(別 PR で宣言追加予定のため正常)
- ダイアログ系の手動マッピング削除後も対象コンポーネントの解決動作維持