### PR TITLE
feat(components): 派生コンポーネントを inheritedBy で宣言

### DIFF
--- a/scripts/generate-skills/index.ts
+++ b/scripts/generate-skills/index.ts
@@ -95,6 +95,7 @@ async function main() {
     dirMapping,
     skillTriggers,
     designSystemDir: DESIGN_SYSTEM_DIR,
+    inheritedNames: new Set(inheritedSkills.keys()),
   });
   printCoverageReport(coverageReport);
 

--- a/scripts/generate-skills/lib/validate-coverage.ts
+++ b/scripts/generate-skills/lib/validate-coverage.ts
@@ -35,22 +35,24 @@ export function validateCoverage(args: {
   dirMapping: Map<string, string>;
   skillTriggers: Record<string, string>;
   designSystemDir: string;
+  inheritedNames?: Set<string>;
 }): CoverageReport {
-  const { groups, dirMapping, skillTriggers, designSystemDir } = args;
+  const { groups, dirMapping, skillTriggers, designSystemDir, inheritedNames } = args;
 
   const allDisplayNames = new Set<string>();
   for (const g of groups.values()) {
     for (const n of g.displayNames) allDisplayNames.add(n);
   }
 
-  // newComponents: dir mapping なし かつ skill-triggers にも未登録
+  // newComponents: dir mapping なし、skill-triggers にも未登録、inheritedBy 派生先でもない
   const newComponents: string[] = [];
   const unmappedGroups: string[] = [];
   for (const [dir, g] of groups) {
     if (!dirMapping.has(dir)) {
       unmappedGroups.push(dir);
       const hasTrigger = g.displayNames.some((n) => skillTriggers[n]);
-      if (!hasTrigger) newComponents.push(dir);
+      const isInherited = inheritedNames?.has(dir) ?? false;
+      if (!hasTrigger && !isInherited) newComponents.push(dir);
     }
   }
 

--- a/scripts/generate-skills/mapping/group-split.json
+++ b/scripts/generate-skills/mapping/group-split.json
@@ -18,5 +18,16 @@
     "NotFoundErrorScreen",
     "UnauthorizedErrorScreen",
     "UnexpectedErrorScreen"
+  ],
+  "Table": [
+    "Table",
+    "Th",
+    "Td",
+    "ThCheckbox",
+    "TdCheckbox",
+    "TdRadioButton",
+    "ThSortButton",
+    "BulkActionRow",
+    "EmptyTableBody"
   ]
 }

--- a/src/content/articles/products/components/dialog/action-dialog/index.mdx
+++ b/src/content/articles/products/components/dialog/action-dialog/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: 'ActionDialog'
 description: 'ユーザーに入力や選択などの操作を求めるためのダイアログです。ユーザーは操作内容をシステムに送信できます。'
+inheritedBy:
+  - name: ControlledActionDialog
+    description: '外部 state で開閉を制御する ActionDialog です。'
 ---
 
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'

--- a/src/content/articles/products/components/dialog/action-dialog/index.mdx
+++ b/src/content/articles/products/components/dialog/action-dialog/index.mdx
@@ -3,7 +3,7 @@ title: 'ActionDialog'
 description: 'ユーザーに入力や選択などの操作を求めるためのダイアログです。ユーザーは操作内容をシステムに送信できます。'
 inheritedBy:
   - name: ControlledActionDialog
-    description: '外部 state で開閉を制御する ActionDialog です。'
+    description: '外部stateで開閉を制御するActionDialogです。'
 ---
 
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'

--- a/src/content/articles/products/components/dialog/message-dialog/index.mdx
+++ b/src/content/articles/products/components/dialog/message-dialog/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: 'MessageDialog'
 description: 'ユーザーに情報を提示するためのダイアログです。'
+inheritedBy:
+  - name: ControlledMessageDialog
+    description: '外部 state で開閉を制御する MessageDialog です。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'

--- a/src/content/articles/products/components/dialog/message-dialog/index.mdx
+++ b/src/content/articles/products/components/dialog/message-dialog/index.mdx
@@ -3,7 +3,7 @@ title: 'MessageDialog'
 description: 'ユーザーに情報を提示するためのダイアログです。'
 inheritedBy:
   - name: ControlledMessageDialog
-    description: '外部 state で開閉を制御する MessageDialog です。'
+    description: '外部stateで開閉を制御するMessageDialogです。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'

--- a/src/content/articles/products/components/dialog/step-form-dialog/index.mdx
+++ b/src/content/articles/products/components/dialog/step-form-dialog/index.mdx
@@ -3,7 +3,7 @@ title: 'StepFormDialog'
 description: 'ステップを複数に分けたダイアログです。タスクの完了に複数の操作が必要な場合に使います。'
 inheritedBy:
   - name: ControlledStepFormDialog
-    description: '外部 state で開閉を制御する StepFormDialog です。'
+    description: '外部stateで開閉を制御するStepFormDialogです。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'

--- a/src/content/articles/products/components/dialog/step-form-dialog/index.mdx
+++ b/src/content/articles/products/components/dialog/step-form-dialog/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: 'StepFormDialog'
 description: 'ステップを複数に分けたダイアログです。タスクの完了に複数の操作が必要な場合に使います。'
+inheritedBy:
+  - name: ControlledStepFormDialog
+    description: '外部 state で開閉を制御する StepFormDialog です。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'

--- a/src/content/articles/products/components/table/index.mdx
+++ b/src/content/articles/products/components/table/index.mdx
@@ -1,6 +1,23 @@
 ---
 title: 'Table'
 description: '表形式でデータを表示するためのコンポーネントです。'
+inheritedBy:
+  - name: Th
+    description: 'テーブルの列見出しセルです。'
+  - name: Td
+    description: 'テーブルのデータセルです。'
+  - name: ThCheckbox
+    description: 'チェックボックスを内包する Th です。'
+  - name: TdCheckbox
+    description: 'チェックボックスを内包する Td です。aria-labelledby 属性が必須です。'
+  - name: TdRadioButton
+    description: 'ラジオボタンを内包する Td です。aria-labelledby 属性が必須です。'
+  - name: ThSortButton
+    description: 'ソート機能付きの Th です。'
+  - name: BulkActionRow
+    description: 'テーブル内の一括操作行です。'
+  - name: EmptyTableBody
+    description: 'テーブルが空の場合の表示用 tbody です。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'

--- a/src/content/articles/products/components/table/index.mdx
+++ b/src/content/articles/products/components/table/index.mdx
@@ -7,17 +7,17 @@ inheritedBy:
   - name: Td
     description: 'テーブルのデータセルです。'
   - name: ThCheckbox
-    description: 'チェックボックスを内包する Th です。'
+    description: 'チェックボックスを内包するThです。'
   - name: TdCheckbox
-    description: 'チェックボックスを内包する Td です。aria-labelledby 属性が必須です。'
+    description: 'チェックボックスを内包するTdです。aria-labelledby属性が必須です。'
   - name: TdRadioButton
-    description: 'ラジオボタンを内包する Td です。aria-labelledby 属性が必須です。'
+    description: 'ラジオボタンを内包するTdです。aria-labelledby属性が必須です。'
   - name: ThSortButton
-    description: 'ソート機能付きの Th です。'
+    description: 'ソート機能付きのThです。'
   - name: BulkActionRow
     description: 'テーブル内の一括操作行です。'
   - name: EmptyTableBody
-    description: 'テーブルが空の場合の表示用 tbody です。'
+    description: 'テーブルが空の場合の表示用tbodyです。'
 ---
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'


### PR DESCRIPTION
## 課題・背景

M5 Phase 2.5「mdx未作成コンポーネントの方針整理」で確定した方針の最終ステップです。

#2059で追加した`inheritedBy`の解釈ロジックを用いて、各派生コンポーネントを親mdxのfrontmatterで宣言します。これにより、Controlled\*系・Table系子コンポーネントなど、個別mdxを作るほどではない派生コンポーネントのSKILL.mdが、親mdxの本文とchecklistを継承する形で適切に生成されるようになります。

- [M5 Phase 2.5: mdx未作成コンポーネントの方針整理](https://www.notion.so/35f37b6398eb81dda07af49b00dce538)

## やったこと

- 親mdxのfrontmatterに`inheritedBy`宣言を追加
  - ActionDialog→ControlledActionDialog
  - MessageDialog→ControlledMessageDialog
  - StepFormDialog→ControlledStepFormDialog
  - Table→Th/Td/TdCheckbox/ThCheckbox/TdRadioButton/ThSortButton/BulkActionRow/EmptyTableBody
- generate-skillsの設定追加
  - `mapping/group-split.json`にTableを分割エントリ追加(子コンポーネントを独立group化)
  - `validate-coverage`にinheritedBy派生先を新規未対応警告から除外する処理を追加

## やらなかったこと

- FormDialog→ControlledFormDialogの宣言(FormDialogのmdxが別PR (#2058) で追加されるため、そちらのマージ後に対応)
- SKILL.mdの再生成コミット(mdx側変更を含む別タイミングで実施)

## 動作確認

`scripts/generate-skills`で`pnpm generate`を実行:

- [x] 11件のinheritedBy宣言を検出
- [x] 102個のSKILL.md生成(Table子コンポーネント8件/Controlled\*3件の派生先Skillが独立生成)
- [x] Layer 3取得: 9→17件に増加(派生先で親checklistを継承)
- [x] 新規未対応コンポーネント警告なし

## ローカルで試す手順

```sh
cd scripts/generate-skills
pnpm install
pnpm generate
```

確認ポイント:

- ログに `11 件の inheritedBy 宣言を検出` と表示されること
- `plugins/smarthr-design-system/skills/` 配下に `controlled-action-dialog/`, `th/`, `td/`, `bulk-action-row/` 等の派生先ディレクトリが生成されていること
- 派生先 SKILL.md の frontmatter `description` が親mdxの本文ではなく、`inheritedBy`で宣言した派生先固有のものになっていること

## キャプチャ

UI変更なし(スクリプトとmdxのfrontmatter変更のみ)。

## 関連PR

- 依存: #2059 (inheritedBy解釈ロジック追加、マージ済み)
- 関連: #2058 (mdx未作成コンポーネントのページ追加、レビュー中)