### PR TITLE
fix(generate-skills): eslint ルール取得のサイレント失敗を直し、ルール名一覧を自動生成化

### DIFF
--- a/.github/data/eslint-rule-names.txt
+++ b/.github/data/eslint-rule-names.txt
@@ -19,8 +19,10 @@ a11y-trigger-has-button
 autofixer-smarthr-ui-migration
 best-practice-for-async-current-target
 best-practice-for-button-element
+best-practice-for-consecutive-definition-list
 best-practice-for-data-test-attribute
 best-practice-for-date
+best-practice-for-default-props
 best-practice-for-interactive-element
 best-practice-for-layouts
 best-practice-for-nested-attributes-array-index
@@ -35,8 +37,10 @@ best-practice-for-tailwind-variants
 best-practice-for-text-component
 best-practice-for-unnesessary-early-return
 component-name
+design-system-guideline-bulk-action-row-button
 design-system-guideline-prohibit-dialog-button-icon
 design-system-guideline-prohibit-double-icons
+design-system-guideline-prohibit-information-panel-in-white-bg
 format-import-path
 format-translate-component
 no-import-other-domain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,10 +64,4 @@ Layer 3: checklist.yaml（このリポジトリで管理する人手作成ルー
 - 形式: 1 行 1 ルール名
 - 全ルールを含みます（対象外判定はプロンプト側）
 
-更新方法（手動）:
-
-```sh
-gh api repos/kufu/tamatebako/contents/packages/eslint-plugin-smarthr/rules \
-  --paginate --jq '.[] | select(.type=="dir") | .name' \
-  > .github/data/eslint-rule-names.txt
-```
+更新方法: `scripts/generate-skills` の `pnpm generate` 実行時に、eslint ルール README を上流から取得する処理の副産物として自動更新されます。手動更新は不要です（GitHub API 認証付きでの実行を推奨。`GITHUB_TOKEN` 環境変数を設定してください）。

--- a/scripts/generate-skills/README.md
+++ b/scripts/generate-skills/README.md
@@ -30,7 +30,9 @@ pnpm generate
 | 2 (eslint) | `kufu/tamatebako` の `packages/eslint-plugin-smarthr/rules/*/README.md` | GitHub API 経由で取得し `.cache/eslint-rules.json` にキャッシュ |
 | 3 (checklist) | `src/content/articles/products/components/**/checklist.yaml` | 同リポジトリ内、直接読み込み |
 
-Layer 2 のキャッシュ更新は `.cache/eslint-rules.json` を削除して再実行。GitHub API のレートリミット回避のため、`GITHUB_TOKEN` 環境変数を設定すると認証付きでリクエストされます。
+Layer 2 のキャッシュ更新は `.cache/eslint-rules.json` を削除して再実行。GitHub API のレートリミット回避のため、`GITHUB_TOKEN` 環境変数を設定すると認証付きでリクエストされます（未設定時は警告を出力）。レートリミット遭遇時は `X-RateLimit-Reset` / `Retry-After` を見て自動的に待機・再試行します（最大 3 回）。
+
+`pnpm generate` 実行時、上流の全ルール名（除外前）一覧を `.github/data/eslint-rule-names.txt` に自動書き出しします。これは Claude の `checklist.yaml` 生成プロンプト (`.github/prompts/checklist-v3.md` 等) が参照する AI 向けリファレンスです。手動更新は不要です。
 
 ## 環境変数
 

--- a/scripts/generate-skills/index.ts
+++ b/scripts/generate-skills/index.ts
@@ -3,11 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { parseMetadata, loadPublicExports, type ComponentGroup } from './lib/parse-metadata.js';
-import {
-  fetchEslintRules,
-  buildComponentRuleMap,
-  type EslintRuleWithContent,
-} from './lib/fetch-eslint-rules.js';
+import { fetchEslintRules, buildComponentRuleMap, type EslintRuleWithContent } from './lib/fetch-eslint-rules.js';
 import { parseChecklist } from './lib/parse-checklist.js';
 import { parseIndexMdx, type IndexMdxInfo } from './lib/parse-index-mdx.js';
 import { collectInheritedSkills } from './lib/inherited-by.js';
@@ -19,14 +15,12 @@ import { validateCoverage, printCoverageReport } from './lib/validate-coverage.j
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../..');
 
-const DESIGN_SYSTEM_DIR =
-  process.env.DESIGN_SYSTEM_DIR ??
-  path.join(REPO_ROOT, 'src/content/articles/products/components');
-const OUTPUT_DIR =
-  process.env.OUTPUT_DIR ?? path.join(REPO_ROOT, 'plugins/smarthr-design-system/skills');
+const DESIGN_SYSTEM_DIR = process.env.DESIGN_SYSTEM_DIR ?? path.join(REPO_ROOT, 'src/content/articles/products/components');
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? path.join(REPO_ROOT, 'plugins/smarthr-design-system/skills');
 const MANUAL_MAPPING_PATH = path.join(__dirname, 'mapping/component-dir-map.json');
 const GROUP_SPLIT_PATH = path.join(__dirname, 'mapping/group-split.json');
 const ESLINT_CACHE_PATH = path.join(__dirname, '.cache/eslint-rules.json');
+const ESLINT_RULE_NAMES_PATH = path.join(REPO_ROOT, '.github/data/eslint-rule-names.txt');
 
 function applyGroupSplit(
   groups: Map<string, ComponentGroup>,
@@ -59,15 +53,13 @@ async function main() {
   console.log(`   ${publicExports.size} 個の public named exports を取得`);
   const rawGroups = parseMetadata(publicExports);
 
-  const splitConfig: Record<string, string[]> = JSON.parse(
-    fs.readFileSync(GROUP_SPLIT_PATH, 'utf-8'),
-  );
+  const splitConfig: Record<string, string[]> = JSON.parse(fs.readFileSync(GROUP_SPLIT_PATH, 'utf-8'));
   const groups = applyGroupSplit(rawGroups, splitConfig);
 
   console.log(`   ${groups.size} コンポーネントグループを検出`);
 
   console.log('🌐 eslint-plugin-smarthr ルール README を取得中…（キャッシュ優先）');
-  const rules = await fetchEslintRules(ESLINT_CACHE_PATH);
+  const rules = await fetchEslintRules(ESLINT_CACHE_PATH, ESLINT_RULE_NAMES_PATH);
   console.log(`   ${rules.length} ルールを取得`);
 
   const allDisplayNames = new Set<string>();
@@ -164,11 +156,7 @@ async function main() {
   console.log('🧭 ルータースキル component-selector を生成中…');
   const routerDir = path.join(OUTPUT_DIR, 'component-selector');
   fs.mkdirSync(routerDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(routerDir, 'SKILL.md'),
-    renderRouterSkill(routerEntries),
-    'utf-8',
-  );
+  fs.writeFileSync(path.join(routerDir, 'SKILL.md'), renderRouterSkill(routerEntries), 'utf-8');
   console.log(`   → ${path.relative(REPO_ROOT, path.join(routerDir, 'SKILL.md'))}`);
 
   console.log('🎉 完了');

--- a/scripts/generate-skills/lib/fetch-eslint-rules.ts
+++ b/scripts/generate-skills/lib/fetch-eslint-rules.ts
@@ -26,44 +26,90 @@ function isExcluded(ruleName: string): boolean {
   return EXCLUDED_RULE_PREFIXES.some((prefix) => ruleName.startsWith(prefix));
 }
 
-async function ghFetch(url: string): Promise<Response> {
+type GhFetchOptions = {
+  /** 404 を許容する場合 true。許容時は null を返す。 */
+  allow404?: boolean;
+  /** rate limit 検出時の retry 試行回数。デフォルト 3 回。 */
+  maxRetries?: number;
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function ghFetch(url: string, options: GhFetchOptions = {}): Promise<Response | null> {
+  const { allow404 = false, maxRetries = 3 } = options;
   const headers: Record<string, string> = { Accept: 'application/vnd.github+json' };
   if (process.env.GITHUB_TOKEN) {
     headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
   }
-  const res = await fetch(url, { headers });
-  if (!res.ok) {
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const res = await fetch(url, { headers });
+    if (res.ok) return res;
+    if (res.status === 404 && allow404) return null;
+
+    // rate limit: X-RateLimit-Remaining: 0 か 403/429 のときは reset まで待って再試行
+    const remaining = res.headers.get('x-ratelimit-remaining');
+    const isRateLimited = (res.status === 403 || res.status === 429) && (remaining === '0' || res.headers.get('retry-after'));
+    if (isRateLimited && attempt < maxRetries) {
+      const retryAfterSec = Number(res.headers.get('retry-after')) || 0;
+      const resetEpoch = Number(res.headers.get('x-ratelimit-reset')) || 0;
+      const nowSec = Math.floor(Date.now() / 1000);
+      const waitSec = Math.max(retryAfterSec, resetEpoch ? resetEpoch - nowSec : 0, 1);
+      console.warn(`⚠️  GitHub API rate limit に遭遇。${waitSec}s 待機して再試行 (${attempt + 1}/${maxRetries}): ${url}`);
+      await sleep(waitSec * 1000);
+      continue;
+    }
+
     throw new Error(`GitHub API ${res.status} ${res.statusText}: ${url}`);
   }
-  return res;
+
+  throw new Error(`GitHub API rate limit 再試行回数を超過: ${url}`);
 }
 
 /**
  * tamatebako の eslint-plugin-smarthr/rules/ 配下から各ルールの README.md を取得する。
  * 結果は cachePath にキャッシュし、存在すれば再利用する。
+ *
+ * `ruleNamesOutputPath` を渡した場合、上流のルールディレクトリ名一覧 (除外前の全件) を
+ * 改行区切りで書き出す。AI プロンプト (`.github/prompts/checklist-v3.md` 等) から参照される。
  */
-export async function fetchEslintRules(cachePath: string): Promise<EslintRuleRaw[]> {
+export async function fetchEslintRules(cachePath: string, ruleNamesOutputPath?: string): Promise<EslintRuleRaw[]> {
   if (fs.existsSync(cachePath)) {
     const raw = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
     if (Array.isArray(raw)) return raw as EslintRuleRaw[];
   }
 
+  if (!process.env.GITHUB_TOKEN) {
+    console.warn(
+      '⚠️  GITHUB_TOKEN が未設定です。GitHub API の unauthenticated rate limit (60 req/hour) のためルール取得が rate limit にかかる可能性があります。',
+    );
+  }
+
   const dirRes = await ghFetch(`${GH_API}/repos/${REPO}/contents/${RULES_PATH}`);
+  if (!dirRes) throw new Error(`GitHub API: rules ディレクトリ取得失敗`);
   const entries = (await dirRes.json()) as Array<{ name: string; type: string }>;
-  const ruleNames = entries.filter((e) => e.type === 'dir').map((e) => e.name);
+  const allRuleNames = entries
+    .filter((e) => e.type === 'dir')
+    .map((e) => e.name)
+    .sort();
+
+  if (ruleNamesOutputPath) {
+    fs.mkdirSync(path.dirname(ruleNamesOutputPath), { recursive: true });
+    fs.writeFileSync(ruleNamesOutputPath, allRuleNames.join('\n') + '\n');
+  }
 
   const rules: EslintRuleRaw[] = [];
-  for (const ruleName of ruleNames) {
+  for (const ruleName of allRuleNames) {
     if (isExcluded(ruleName)) continue;
     const readmeUrl = `${GH_API}/repos/${REPO}/contents/${RULES_PATH}/${ruleName}/README.md`;
-    try {
-      const r = await ghFetch(readmeUrl);
-      const json = (await r.json()) as { content: string; encoding: string };
-      const readme = Buffer.from(json.content, json.encoding as BufferEncoding).toString('utf-8');
-      rules.push({ name: ruleName, readme });
-    } catch {
-      // README が無いルールはスキップ
+    const r = await ghFetch(readmeUrl, { allow404: true });
+    if (!r) {
+      // README.md が無いルールは意図的にスキップ
+      continue;
     }
+    const json = (await r.json()) as { content: string; encoding: string };
+    const readme = Buffer.from(json.content, json.encoding as BufferEncoding).toString('utf-8');
+    rules.push({ name: ruleName, readme });
   }
 
   fs.mkdirSync(path.dirname(cachePath), { recursive: true });
@@ -112,11 +158,7 @@ function extractSection(content: string, headerPattern: RegExp): string {
   return sectionLines.join('\n');
 }
 
-function extractPrimaryComponents(
-  ruleName: string,
-  description: string,
-  componentDisplayNames: Set<string>,
-): Set<string> {
+function extractPrimaryComponents(ruleName: string, description: string, componentDisplayNames: Set<string>): Set<string> {
   const primary = new Set<string>();
   const segments = ruleName.split('-');
   const cleanedDescription = description.replace(/\[[^\]]*\]\([^)]*\)/g, '');
@@ -182,10 +224,7 @@ export function buildComponentRuleMap(
   return componentRules;
 }
 
-export function getRelevantCodeExamples(
-  rule: EslintRuleWithContent,
-  componentName: string,
-): { ng: string[]; ok: string[] } {
+export function getRelevantCodeExamples(rule: EslintRuleWithContent, componentName: string): { ng: string[]; ok: string[] } {
   const extract = (sectionContent: string): string[] => {
     const blocks: string[] = [];
     const codeBlockRegex = /```(?:\w+)?\n([\s\S]*?)```/g;


### PR DESCRIPTION
## 課題・背景

`scripts/generate-skills/lib/fetch-eslint-rules.ts` の README 取得処理 (`catch {}`) がエラーを握り潰しており、GitHub API rate limit などに遭遇したルールが**無音でスキップ**され、`pnpm generate` の実行ごとに SKILL.md に含まれる eslint ルールが変動していました。

実測: 上流 56 件 / 除外後の正規件数 41 件のところ、本リポジトリ上で実行ごとに 41 / 37 / 23 件と揺れる現象を確認。

また、`.github/data/eslint-rule-names.txt`（Claude が `checklist.yaml` 生成プロンプトから参照する AI 向けリファレンス）は **手動で `gh api` を叩いて更新する運用**でしたが、M5 Phase 4 の「mdx を単一ソースに / 手動運用は減らす」コンセプトと整合しないため、自動生成化します。

関連: 親マイルストーン [M5 Phase 4](https://www.notion.so/M5-mdx-35f37b6398eb81ab88b4db8db3471721) / base PR #2074。

## やったこと

- `ghFetch` をリトライ対応に拡張
  - `403`/`429` + `X-RateLimit-Remaining: 0` または `Retry-After` ヘッダを検出
  - `X-RateLimit-Reset` または `Retry-After` の長い方まで自動待機 → 最大 3 回まで再試行
  - `404` は `allow404` オプションで明示的に許容 (`README.md` が無いルール向け)
- `fetchEslintRules` の README 取得 `try { ... } catch {}` を廃止
  - 404 は `allow404` 経由で明示的にスキップ
  - それ以外の失敗 (5xx / rate limit 超過) はエラー終了
- `GITHUB_TOKEN` 未設定時に警告を出力 (unauthenticated は 60 req/hour で rate limit に当たりやすいため)
- 上流の全ルール名（除外前）を `.github/data/eslint-rule-names.txt` に自動書き出し
  - `fetchEslintRules(cachePath, ruleNamesOutputPath?)` の副産物として実行
  - `pnpm generate` 1 コマンドで AI リファレンスも常に最新化される
- `CLAUDE.md` / `scripts/generate-skills/README.md` の手動運用記述を「自動更新される」に置換
- `.github/data/eslint-rule-names.txt` を 52 → 56 件に追従 (上流追加 4 件を取り込み)

## やらなかったこと

- SKILL.md の本格的な再生成: 直接の差分が出るルール 4 件 (bulk-action-row / button / definition-list / information-panel) は base PR #2074 内で既に再生成済みのため、本 PR では SKILL.md 自体への変更は無し
- §8 paths 検証 (Q16-Q20) は別タスク

## 動作確認

- TypeScript 型チェック (`npx tsc --noEmit`) 通過
- `pnpm generate` をクリーンキャッシュから実行し、以下を確認:
  - 41 ルール安定取得 (実行ごとの揺れ無し)
  - `.github/data/eslint-rule-names.txt` が 56 行で自動更新
  - 整合性チェック緑
- `GITHUB_TOKEN` 未設定の状態で警告ログ出力を確認

## キャプチャ

なし（スクリプト改修と AI リファレンス自動化のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)