### PR TITLE
feat: pre-commit で実行される lint-staged に、format:** 各種を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,15 @@
   "lint-staged": {
     "*.{astro,ts,tsx,md,mdx}": [
       "pnpm run lint --"
+    ],
+    "*.{astro,ts,tsx}": [
+      "pnpm run format:eslint --"
+    ],
+    "*.md{,x}": [
+      "pnpm run format:text --"
+    ],
+    "*": [
+      "pnpm run format:prettier --"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,16 +6,16 @@
   "type": "module",
   "lint-staged": {
     "*.{astro,ts,tsx,md,mdx}": [
-      "pnpm run lint --"
+      "pnpm lint"
     ],
     "*.{astro,ts,tsx}": [
-      "pnpm run format:eslint --"
+      "pnpm format:eslint"
     ],
     "*.md{,x}": [
-      "pnpm run format:text --"
+      "pnpm format:text"
     ],
     "*": [
-      "pnpm run format:prettier --"
+      "pnpm format:prettier"
     ]
   },
   "scripts": {


### PR DESCRIPTION
## 課題・背景

`pnpm run format` が用意されているが実行されるタイミングが現状なさそうなので、 pre-commit にフックさせました。

package.json では `pnpm run format` でひとつにまとまっていますが、 textlint の処理に時間がかかるので、対象ファイルそれぞれを個別に書くようにしました。ざっと使った感じそこまでgitコミット操作体験は落ちなかったです。（※落ちなくはないです）