### PR TITLE
fix: lint-staged のコマンドが意図通りになっていなかったのを修正する

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "pnpm format:text",
       "pnpm format:prettier"
     ],
-    "!(src/**/*.{astro,ts,tsx.md,mdx})": [
+    "!(src/**/*.{astro,ts,tsx,md,mdx})": [
       "pnpm format:prettier"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -5,16 +5,22 @@
   "license": "MIT",
   "type": "module",
   "lint-staged": {
-    "*.{astro,ts,tsx,md,mdx}": [
-      "pnpm lint"
+    "src/**/*.{astro,ts,tsx}": [
+      "pnpm prelint",
+      "pnpm lint:ts:content",
+      "pnpm lint:ts:codeblock",
+      "pnpm lint:check",
+      "pnpm format:eslint",
+      "pnpm format:prettier"
     ],
-    "*.{astro,ts,tsx}": [
-      "pnpm format:eslint"
+    "src/**/*.md{,x}": [
+      "pnpm prelint",
+      "pnpm lint:check",
+      "pnpm lint:text",
+      "pnpm format:text",
+      "pnpm format:prettier"
     ],
-    "*.md{,x}": [
-      "pnpm format:text"
-    ],
-    "*": [
+    "!(src/**/*.{astro,ts,tsx.md,mdx})": [
       "pnpm format:prettier"
     ]
   },

--- a/scripts/component-thumbnails/componentThumbnails.ts
+++ b/scripts/component-thumbnails/componentThumbnails.ts
@@ -25,7 +25,7 @@ const loadPreviousStories = async () => {
 
 // ストーリー情報を保存
 const saveStoryCache = async (storyData) => {
-  await fs.writeFile(cacheFilePath, JSON.stringify(storyData, null, 2), 'utf8');
+  await fs.writeFile(cacheFilePath, `${JSON.stringify(storyData, null, 2)}\n`, 'utf8');
 };
 
 // ストーリーが変更されたかチェック


### PR DESCRIPTION
## 課題

AsIs では astro, ts, tsx ファイルに対して `pnpm lint` `pnpm format:eslint` `pnpm format:prettier` が同時に実行され、タスクが競合を起こしてエラーになってしまっていました。

ファイルの場所と拡張子によって実行すべき lint と format を整理し、それぞれ指定するように修正しています。