### PR TITLE
chore(generate-skills): ハードコード削減 (component-dir-map.json 削除)

### DIFF
--- a/scripts/generate-skills/mapping/component-dir-map.json
+++ b/scripts/generate-skills/mapping/component-dir-map.json
@@ -1,7 +1,0 @@
-{
-  "Checkbox": "checkbox",
-  "SingleCombobox": "combobox/single-combobox",
-  "MultiCombobox": "combobox/multi-combobox",
-  "SmartHRLogo": "smarthr-logo",
-  "SmartHRAILogo": "smarthr-ai-logo"
-}


### PR DESCRIPTION
## 課題・背景

`scripts/generate-skills/mapping/` 配下の手動マッピングファイル 2 件について、ハードコード運用削減方針に従って必要性を検証する。

## やったこと

### component-dir-map.json: 削除

PascalCase コンポーネント名 → design-system ディレクトリ相対パスの手動マッピング。現エントリ 5 件はすべて `name-mapping.ts` の自動探索で解決可能と判明したため削除。

- `Checkbox` → `checkbox`: `pascalToKebab` で自動解決
- `SmartHRLogo` → `smarthr-logo`: `pascalToKebab` 内の SmartHR 特殊処理
- `SmartHRAILogo` → `smarthr-ai-logo`: 同上
- `SingleCombobox` → `combobox/single-combobox`: `buildDirMapping` の 1 階層下再帰探索
- `MultiCombobox` → `combobox/multi-combobox`: 同上

検証: ファイル削除前後で `pnpm generate` の出力が完全一致（102 SKILL / Layer 3 あり 69 / dirMapping 90/102）。

`loadManualMappings` はファイル不在を `{}` として扱う実装のため、将来同名衝突等で手動オーバーライドが必要になった場合は同じパスに JSON を再配置するだけで再有効化できる。`validate-coverage.ts` の警告メッセージは参照先として残置。

## やらなかったこと

### group-split.json: 維持

検証の結果、smarthr-ui のディレクトリ単位グループ (Dialog/ErrorScreen/Picker/Table 配下) を個別 SKILL に分離する必須設定であることを確認。空にすると 102→84 SKILL に減少し、ActionDialog/FormDialog/AuthErrorScreen/TimePicker/Th/Td 等の個別 SKILL が統合されて消失する。`inheritedBy` (描画統合用) とは別レイヤーのため代替不可。

## 動作確認

- `pnpm generate` 成功
- 出力 102 SKILL / Layer 3 あり 69 / dirMapping 90/102 がベースラインと完全一致

## キャプチャ

なし（内部実装のみ、画面変更なし）