### PR TITLE
[TEST #1] phase4: mdx + yaml 両方変更 (正常パス)

### DIFF
--- a/src/content/articles/products/components/button/checklist.yaml
+++ b/src/content/articles/products/components/button/checklist.yaml
@@ -1,3 +1,4 @@
+# test/phase4-1: 同期チェック通常パス検証用の無害コメント
 items:
   # 使用上の注意 > type="button" について
   - severity: must

--- a/src/content/articles/products/components/button/index.mdx
+++ b/src/content/articles/products/components/button/index.mdx
@@ -11,6 +11,7 @@ import { OpenInNewTabIconInAnchorButton } from './_components/OpenInNewTabIcon'
 import DoAndDont from '@/components/article/DoAndDont.astro'
 import Caption from './_components/Caption.astro'
 
+{/* test/phase4-1: 同期チェック通常パス検証用の無害コメント */}
 `button`要素の代替として操作や処理を実行するコンポーネントです。ユーザーに操作を促すとき、フォームを送信するとき、アクションを選択するときに使います。
 
 <ComponentStory name="Button" />


### PR DESCRIPTION
Phase 4 CI 検証用テスト PR #1。マージ不要。

## 検証内容
Button の index.mdx と checklist.yaml の両方に無害コメントを追加し、両方が同 PR で変更されている状態を作る。

## 期待結果
- validate-skills / validate: ✅
- validate-skills / checklist-sync: ✅ (`button` ディレクトリで mdx + yaml 両方更新検知)

検証後ブランチ削除。