### PR TITLE
[TEST #8] phase4: validate error (severity 欠落)

### DIFF
--- a/src/content/articles/products/components/button/checklist.yaml
+++ b/src/content/articles/products/components/button/checklist.yaml
@@ -1,7 +1,7 @@
 items:
   # 使用上の注意 > type="button" について
-  - severity: must
-    text: 'form submit を使う場合は `type="submit"` を明記する'
+  # test/phase4-8: severity 欠落で validate error を再現
+  - text: 'form submit を使う場合は `type="submit"` を明記する'
     source_section: '使用上の注意 > type="button" について'
 
   # 種類 > Primary


### PR DESCRIPTION
Phase 4 CI 検証用テスト PR #8。マージ不要。

## 検証内容
Button の checklist.yaml の1項目から severity を削除し、validate が error を返すかを確認。

## 期待結果
- validate-skills / validate: ❌ (`MISSING_SEVERITY` で error 1 件)
- validate-skills / checklist-sync: ✅ (yaml 変更ありなのでパス)

検証後ブランチ削除。