### PR TITLE
fix(table): relatedComponents から ThSortButton を削除

### DIFF
--- a/src/content/articles/products/components/table/index.mdx
+++ b/src/content/articles/products/components/table/index.mdx
@@ -12,8 +12,6 @@ relatedComponents:
     description: 'Checkboxを内包するデータセル（Td）の派生コンポーネントです。「テーブル内の一括操作」パターンにおいて、テーブル各行を選択するときに使います。'
   - name: TdRadioButton
     description: 'RadioButtonを内包するデータセル（Td）の派生コンポーネントです。テーブル各行から1行だけ選ばせるときに使います。'
-  - name: ThSortButton
-    description: 'ソートボタンを内包する列見出しセル（Th）の派生コンポーネントです。列ヘッダーからデータセルの並べ替えを実行するときに使います。'
   - name: BulkActionRow
     description: 'テーブル内に一括操作UIを配置する行コンポーネントです。「テーブル内の一括操作」パターンにおいて、複数行を選択した状態でまとめて操作するときに使います。'
   - name: EmptyTableBody


### PR DESCRIPTION
## 課題・背景

設計システム側の `table/index.mdx` の `relatedComponents` に `ThSortButton` が宣言されているが、smarthr-ui の公開 API として export されていない内部実装コンポーネントだった。

調査結果:
- `node_modules/smarthr-ui/lib/components/Table/ThSortButton.d.ts` ファイル自体は存在
- `node_modules/smarthr-ui/lib/components/Table/index.d.ts` の export 一覧: `Table` / `Th` / `ThCheckbox` / `Td` / `TdCheckbox` / `TdRadioButton` / `BulkActionRow` / `EmptyTableBody` / `WakuWakuButton` のみ
- `node_modules/smarthr-ui/lib/index.d.ts` からも export されていない
- 結論: smarthr-ui の利用者から見ると import 不可能なコンポーネント

設計システムでドキュメント化する対象は smarthr-ui の公開 API に限るべき。

検知契機: M7 Phase 4 で新設した `coverage` ジョブの `unknownRelatedNames` チェックが `relatedComponents.name` と smarthr-ui 公開 export 集合を突合する仕組みを導入したことで顕在化。

## やったこと

- `src/content/articles/products/components/table/index.mdx` の `relatedComponents` から `ThSortButton` の 2 行を削除

## やらなかったこと

- smarthr-ui への export 追加要望: 別途必要なら smarthr-ui リポジトリで対応
- `scripts/generate-skills/coverage-baseline.json` からのエントリ削除: feat/m7-phase4-ci-pipeline PR (#2108) マージ後に別 PR で実施

## 動作確認

- `grep -i ThSortButton src/content/articles/products/components/table/index.mdx` → 0 件
- 設計システムドキュメント上の表示影響: Th / Td / ThCheckbox / TdCheckbox / TdRadioButton / BulkActionRow / EmptyTableBody は残るため、Table 関連の主要サブコンポーネントは引き続き紹介される

## キャプチャ

|Before|After|
| --- | --- |
| Table の関連コンポーネント一覧に ThSortButton が含まれる（実体はimport不可能） | ThSortButton 表示なし |

🤖 Generated with [Claude Code](https://claude.com/claude-code)