### PR TITLE
chore(deps): smarthr-ui を pnpm catalog で workspace 統一管理

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-instantsearch-core": "^7.32.3",
     "react-live": "^4.1.8",
     "smarthr-normalize-css": "^1.1.0",
-    "smarthr-ui": "^95.0.0",
+    "smarthr-ui": "catalog:",
     "styled-components": "^6.4.1",
     "typescript": "^6.0.3",
     "yaml": "^2.8.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    smarthr-ui:
+      specifier: ^95.0.0
+      version: 95.0.0
+
 importers:
 
   .:
@@ -66,7 +72,7 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(styled-components@6.4.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       smarthr-ui:
-        specifier: ^95.0.0
+        specifier: 'catalog:'
         version: 95.0.0(@types/react@19.2.14)(eslint@9.39.4(jiti@1.21.7))(react-dom@19.2.6(react@19.2.6))(react-intl@10.1.6(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(styled-components@6.4.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       styled-components:
         specifier: ^6.4.1
@@ -217,7 +223,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.1
       smarthr-ui:
-        specifier: ^95.0.0
+        specifier: 'catalog:'
         version: 95.0.0(@types/react@19.2.14)(eslint@9.39.4(jiti@1.21.7))(react-dom@19.2.6(react@19.2.6))(react-intl@10.1.6(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(styled-components@6.4.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
     devDependencies:
       '@types/js-yaml':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,12 @@
 packages:
   - scripts/*
 
+# workspace 内で smarthr-ui のバージョンを統一するための catalog。
+# root と scripts/generate-skills が同じバージョンを参照する。
+# バージョン更新時はここ 1 ヶ所を変更すれば全 member に反映される。
+catalog:
+  smarthr-ui: ^95.0.0
+
 minimumReleaseAge: 10080
 
 allowBuilds:

--- a/scripts/generate-skills/package.json
+++ b/scripts/generate-skills/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",
-    "smarthr-ui": "^95.0.0"
+    "smarthr-ui": "catalog:"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## 課題・背景

root の `package.json` と `scripts/generate-skills/package.json` で `smarthr-ui` を個別に依存指定しており、本体 (root) の `pnpm upgrade smarthr-ui@latest` で `scripts/generate-skills` 側が追従しない問題があった (PR #2119 で v95 同期を一括対応したのが具体例)。

メンバーが本体の `smarthr-ui` を上げる際に **意識せず** scripts/generate-skills も同じバージョンになる仕組みとして、pnpm catalog 機能を導入し、バージョンを 1 ヶ所に集約する。

関連: PR #2119 (smarthr-ui v95 同期、本 PR の動機となった実例)

## やったこと

- `pnpm-workspace.yaml`: `catalog` セクションを追加 (`smarthr-ui: ^95.0.0`)
- `package.json` (root): `smarthr-ui` の specifier を `catalog:` 参照に変更
- `scripts/generate-skills/package.json`: `smarthr-ui` の specifier を `catalog:` 参照に変更
- `pnpm-lock.yaml`: 整合

## 運用フロー (今後)

メンバーが smarthr-ui を上げる際は `pnpm-workspace.yaml` の `catalog.smarthr-ui` のバージョンを変更するだけ。`pnpm install` で root / scripts/generate-skills の両方が同じバージョンに追従する。個別の `package.json` 更新は不要。

Renovate (v37+) は `catalog:` 参照を自動更新する PR を作成するため、自動更新でもズレない。

## 動作確認

- `pnpm install` → root / scripts/generate-skills の両方が `smarthr-ui@95.0.0` を resolve することを node の `createRequire` で確認
- `pnpm generate` → `✅ すべて整合` / 101 SKILL / Layer 3 あり 69