### PR TITLE
chore(deps): upgrade:smarthr-ui を recursive 実行に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "update:smarthr-ui.css": "tsx scripts/update-smarthr-ui-css.ts",
     "generate:thumbnails": "cd ./scripts/component-thumbnails && pnpm install && cd ../.. && tsx ./scripts/component-thumbnails/componentThumbnails.ts",
     "copy:smarthr-ui-css": "cp node_modules/smarthr-ui/smarthr-ui.css public/",
-    "upgrade:smarthr-ui": "pnpm upgrade smarthr-ui@latest",
+    "upgrade:smarthr-ui": "pnpm -r upgrade smarthr-ui@latest",
     "postupgrade:smarthr-ui": "run-s copy:smarthr-ui-css generate:thumbnails",
     "prepare": "husky"
   },


### PR DESCRIPTION
## 課題・背景

`pnpm upgrade smarthr-ui@latest` は root の `package.json` のみ対象とし、workspace member の `scripts/generate-skills/package.json` は追従しない。本体 (root) の smarthr-ui を上げる際に scripts/generate-skills のバージョンがズレ、`createRequire` 経由で古いバージョンを resolve する事象が発生していた (PR #2119 で v95 同期を一括対応したのが具体例)。

メンバーが SmartHR UI 更新手順 (Notion) に従って `pnpm run upgrade:smarthr-ui` を実行するだけで、root + workspace member の両方が同じバージョンに揃うようにする。

関連:
- PR #2119 (smarthr-ui v95 同期、本 PR の動機)
- PR #2120 (catalog 化アプローチ、本 PR で代替するため撤回予定)

## やったこと

- `package.json`: `upgrade:smarthr-ui` を `pnpm upgrade smarthr-ui@latest` → `pnpm -r upgrade smarthr-ui@latest` に変更

## 運用フロー (今後)

メンバーが `pnpm run upgrade:smarthr-ui` を実行するだけで、root の `package.json` と `scripts/generate-skills/package.json` の両方で `smarthr-ui` が最新版に更新される。SmartHR UI 更新手順 (Notion) の修正は不要。

## やらなかったこと

別アプローチとして検討した pnpm catalog 機能 (PR #2120) は撤回予定。`pnpm upgrade` が `catalog:` 参照を強制解除する挙動があり、catalog 化と既存の `upgrade:smarthr-ui` script が両立しないため。本変更 (1 行修正) で要件を満たせる。

## 動作確認

`pnpm-workspace.yaml` の `packages: scripts/*` 配下で `smarthr-ui` に依存しているのは `scripts/generate-skills` のみ (`scripts/content-checker`, `scripts/component-thumbnails` は非依存)。`pnpm -r upgrade smarthr-ui@latest` は root + scripts/generate-skills の 2 つを対象に更新する。