### PR TITLE
feat(generate-skills): parseMetadata で src/intl/ 配下のコンポーネントを取り込む

### DIFF
--- a/plugins/smarthr-design-system/skills/component-selector/SKILL.md
+++ b/plugins/smarthr-design-system/skills/component-selector/SKILL.md
@@ -42,6 +42,7 @@ metadata:
 | ControlledMessageDialog | MessageDialogの開閉状態を外部stateで制御する派生コンポーネントです。開閉状態をアプリケーション側で管理するときに使います。 | `smarthr-design-system:smarthr-ui-controlled-message-dialog` |
 | ControlledStepFormDialog | StepFormDialogの開閉状態を外部stateで制御する派生コンポーネントです。開閉状態をアプリケーション側で管理するときに使います。 | `smarthr-design-system:smarthr-ui-controlled-step-form-dialog` |
 | CurrencyInput | 金額を入力させるためのコンポーネントです。給与・税額など金額値を入力させるときに使います。 | `smarthr-design-system:smarthr-ui-currency-input` |
+| DateFormatter | 日付データを任意の形式にフォーマットして表示するコンポーネントです。日付をユーザーの言語や地域設定に適した形式で表示するときに使います。 | `smarthr-design-system:smarthr-ui-date-formatter` |
 | ⚠️ DatePicker（非推奨） | 【非推奨】ユーザーに日付を指定させる際に使用するコンポーネントです。フォーカスするとCalendarが開き、視覚的に日付を選択できます。 | `smarthr-design-system:smarthr-ui-date-picker` |
 | ⚠️ DatetimeLocalPicker（非推奨） | 【非推奨】ユーザーに日付と時刻を指定させる際に使用するコンポーネントです。 | `smarthr-design-system:smarthr-ui-datetime-local-picker` |
 | DefinitionList | 見出しと説明をペアで並べる定義リストコンポーネントです。フォーム入力内容の確認画面や編集不要のデータ表示など、ラベルと値のペアを参照用に並べるときに使います。 | `smarthr-design-system:smarthr-ui-definition-list` |
@@ -111,8 +112,10 @@ metadata:
 | TextLink | a要素の代わりに使用する汎用テキストリンクコンポーネントです。本文中にリンクを置くとき、HelpLinkやUpwardLinkで表現できないテキストリンクを提供するときに使います。 | `smarthr-design-system:smarthr-ui-text-link` |
 | Th | th要素の代替としてテーブルの列見出しセルを表すコンポーネントです。 | `smarthr-design-system:smarthr-ui-th` |
 | ThCheckbox | Checkboxを内包する列見出しセル（Th）の派生コンポーネントです。「テーブル内の一括操作」パターンにおいて、テーブル全行の一括選択UIを列見出しに配置するときに使います。 | `smarthr-design-system:smarthr-ui-th-checkbox` |
+| TimeFormatter | 時刻データを任意の形式にフォーマットして表示するコンポーネントです。時刻をユーザーの言語や地域設定に適した形式で表示するときに使います。 | `smarthr-design-system:smarthr-ui-time-formatter` |
 | Timeline | 情報を時間の流れに沿って整理・表示するためのコンポーネントです。操作履歴や更新履歴を時系列で見せるときに使います。 | `smarthr-design-system:smarthr-ui-timeline` |
 | ⚠️ TimePicker（非推奨） | 【非推奨】ユーザーに時刻（時と分、任意で秒）を入力させる際に使用するコンポーネントです。 | `smarthr-design-system:smarthr-ui-time-picker` |
+| TimestampFormatter | 日付と時刻データを任意の形式にフォーマットして表示するコンポーネントです。日付と時刻をユーザーの言語や地域設定に適した形式で表示するときに使います。 | `smarthr-design-system:smarthr-ui-timestamp-formatter` |
 | Tooltip | 補足説明テキストをホバーやフォーカスで一時的に表示するためのツールチップコンポーネントです。アイコンのみボタンへのラベル付け、LineClampで省略したテキストの全文表示など、限られたスペースで補足情報を添えるときに使います。 | `smarthr-design-system:smarthr-ui-tooltip` |
 | UnauthorizedErrorScreen | セッション切れなど認証が必要な状態を伝える全画面コンポーネントです。401相当のエラーで再ログインが必要なときに使います。 | `smarthr-design-system:smarthr-ui-unauthorized-error-screen` |
 | UnexpectedErrorScreen | 予期しないエラーが発生したことを表示する全画面コンポーネントです。500相当のサーバーエラーを伝えるときに使います。 | `smarthr-design-system:smarthr-ui-unexpected-error-screen` |

--- a/plugins/smarthr-design-system/skills/smarthr-ui-date-formatter/SKILL.md
+++ b/plugins/smarthr-design-system/skills/smarthr-ui-date-formatter/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: smarthr-ui-date-formatter
+description: "DateFormatterは、日付データを任意の形式にフォーマットして表示するコンポーネントです。日付をユーザーの言語や地域設定に適した形式で表示するときに使います。"
+metadata:
+  version: "1.0.0"
+  source: smarthr-design-system
+  generated-from: layer1+layer3
+---
+
+日付データを任意の形式にフォーマットして表示するコンポーネントです。日付をユーザーの言語や地域設定に適した形式で表示するときに使います。
+
+日付データを任意の形式にフォーマットして表示するコンポーネントです。日付を[ユーザーの言語や地域設定に適した形式](/products/contents/idiomatic-usage/count/#h4-0)で表示するときに使います。
+
+## import
+
+```ts
+import { DateFormatter } from 'smarthr-ui'
+```
+
+## Props
+
+| Props 名 | 型 | デフォルト値 | 必須 | 説明 |
+|---|---|---|---|---|
+| parts | readonly [DatePart, ...DatePart[]] | - | - | 表示する日付のパーツ。指定しない場合は全て表示 |
+| options | DateTimeFormatOptions & { disableSlashInJa?: boolean; capitalizeFirstLetter?: boolean; } | - | - | フォーマットオプション |
+| date | string \| Date | - | ✓ | - |
+
+## 実装ルール
+
+DateFormatter に直接関連する eslint-plugin-smarthr のルールは現時点ではありません。
+
+## 使い方チェックリスト
+
+### 使用上の注意 > 日付をフォーマットする機能だけ必要な場合
+- [must] フォーマットされた日付の文字列だけが必要な場合は `useIntl` の `formatDate` を使う

--- a/plugins/smarthr-design-system/skills/smarthr-ui-time-formatter/SKILL.md
+++ b/plugins/smarthr-design-system/skills/smarthr-ui-time-formatter/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: smarthr-ui-time-formatter
+description: "TimeFormatterは、時刻データを任意の形式にフォーマットして表示するコンポーネントです。時刻をユーザーの言語や地域設定に適した形式で表示するときに使います。"
+metadata:
+  version: "1.0.0"
+  source: smarthr-design-system
+  generated-from: layer1
+---
+
+時刻データを任意の形式にフォーマットして表示するコンポーネントです。時刻をユーザーの言語や地域設定に適した形式で表示するときに使います。
+
+時刻データを任意の形式にフォーマットして表示するコンポーネントです。時刻を[ユーザーの言語や地域設定に適した形式](/products/contents/idiomatic-usage/count/#h4-0)で表示するときに使います。
+
+## import
+
+```ts
+import { TimeFormatter } from 'smarthr-ui'
+```
+
+## Props
+
+| Props 名 | 型 | デフォルト値 | 必須 | 説明 |
+|---|---|---|---|---|
+| parts | readonly [TimePart, ...TimePart[]] | - | - | 表示する時刻のパーツ。指定しない場合は ['hour', 'minute'] がデフォルト |
+| options | DateTimeFormatOptions | - | - | フォーマットオプション |
+| date | string \| Date | - | ✓ | - |
+
+## 実装ルール
+
+TimeFormatter に直接関連する eslint-plugin-smarthr のルールは現時点ではありません。
+
+## 使い方チェックリスト
+
+使い方チェックリスト（Layer 3）は設定されていません。

--- a/plugins/smarthr-design-system/skills/smarthr-ui-timestamp-formatter/SKILL.md
+++ b/plugins/smarthr-design-system/skills/smarthr-ui-timestamp-formatter/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: smarthr-ui-timestamp-formatter
+description: "TimestampFormatterは、日付と時刻データを任意の形式にフォーマットして表示するコンポーネントです。日付と時刻をユーザーの言語や地域設定に適した形式で表示するときに使います。"
+metadata:
+  version: "1.0.0"
+  source: smarthr-design-system
+  generated-from: layer1
+---
+
+日付と時刻データを任意の形式にフォーマットして表示するコンポーネントです。日付と時刻をユーザーの言語や地域設定に適した形式で表示するときに使います。
+
+日付と時刻データを任意の形式にフォーマットして表示するコンポーネントです。日付と時刻を[ユーザーの言語や地域設定に適した形式](/products/contents/idiomatic-usage/count/#h4-0)で表示するときに使います。
+
+## import
+
+```ts
+import { TimestampFormatter } from 'smarthr-ui'
+```
+
+## Props
+
+| Props 名 | 型 | デフォルト値 | 必須 | 説明 |
+|---|---|---|---|---|
+| timeParts | readonly [TimePart, ...TimePart[]] | - | - | 表示する時刻のパーツ。指定しない場合は ['hour', 'minute'] がデフォルト |
+| date | string \| Date | - | ✓ | - |
+
+## 実装ルール
+
+TimestampFormatter に直接関連する eslint-plugin-smarthr のルールは現時点ではありません。
+
+## 使い方チェックリスト
+
+使い方チェックリスト（Layer 3）は設定されていません。

--- a/scripts/generate-skills/lib/parse-metadata.ts
+++ b/scripts/generate-skills/lib/parse-metadata.ts
@@ -55,7 +55,13 @@ export function loadPublicExports(): Set<string> {
 
 /**
  * smarthr-ui の metadata.json をコンポーネントグループに整形して返す。
- * グルーピングキーは filePath の直上ディレクトリ名（例: `src/components/Button/Button.tsx` → `Button`）。
+ *
+ * 対応する filePath:
+ * - `src/components/<Component>/<Component>.tsx` (通常パターン)
+ *   グルーピングキーは直上ディレクトリ名 (例: `Button`)。
+ * - `src/intl/<Component>.tsx` (フラット構成。`DateFormatter` / `TimeFormatter` / `TimestampFormatter` 等)
+ *   グルーピングキーは displayName そのまま (1 file = 1 component)。
+ *
  * publicExports を渡すと、そこに含まれない displayName を除外する。
  */
 export function parseMetadata(publicExports?: Set<string>): Map<string, ComponentGroup> {
@@ -63,18 +69,33 @@ export function parseMetadata(publicExports?: Set<string>): Map<string, Componen
   const groups = new Map<string, ComponentGroup>();
 
   for (const component of data) {
-    if (!component.filePath.startsWith('src/components/')) continue;
-    // 内部実装パターン (例: src/components/AppHeader/components/desktop/AppLauncher.tsx) を除外。
-    // 同一 displayName が別所で公開エクスポートされる場合はそちらの定義のみ採用。
-    const rest = component.filePath.slice('src/components/'.length);
-    if (rest.includes('/components/')) continue;
+    const isComponentsDir = component.filePath.startsWith('src/components/');
+    const isIntlDir = component.filePath.startsWith('src/intl/');
+    if (!isComponentsDir && !isIntlDir) continue;
+
+    if (isComponentsDir) {
+      // 内部実装パターン (例: src/components/AppHeader/components/desktop/AppLauncher.tsx) を除外。
+      // 同一 displayName が別所で公開エクスポートされる場合はそちらの定義のみ採用。
+      const rest = component.filePath.slice('src/components/'.length);
+      if (rest.includes('/components/')) continue;
+    }
     if (/^Fa.+Icon$/.test(component.displayName)) continue;
+    // Context Provider 系 (IntlProvider / StepFormDialogProvider 等) は UI コンポーネントではなく
+    // 設計システムのドキュメント対象外。`src/components/` 配下では従来から SKILL 化されておらず、
+    // src/intl/ から取り込んだ際に意図せず対象化されるのを防ぐため除外する。
+    if (/Provider$/.test(component.displayName)) continue;
     if (publicExports && !publicExports.has(component.displayName)) continue;
 
-    const parts = component.filePath.split('/');
-    if (parts.length < 3) continue;
-
-    const dirName = parts[parts.length - 2];
+    let dirName: string;
+    if (isIntlDir) {
+      // src/intl/ 配下はフラット構成。displayName を dirName とする
+      // (design-system 側のディレクトリ名 kebab-case と pascalToKebab 経由で対応付け可能)。
+      dirName = component.displayName;
+    } else {
+      const parts = component.filePath.split('/');
+      if (parts.length < 3) continue;
+      dirName = parts[parts.length - 2];
+    }
 
     if (!groups.has(dirName)) {
       groups.set(dirName, { dirName, displayNames: [], components: [] });


### PR DESCRIPTION
## 課題・背景

smarthr-ui の `DateFormatter` / `TimeFormatter` / `TimestampFormatter` は `src/intl/` 配下にフラットに配置されている (`src/intl/DateFormatter.tsx` 等)。一方 `scripts/generate-skills/lib/parse-metadata.ts` は `src/components/` 配下のみを対象にしていたため、これらの metadata.json エントリは `groups` に入らず、設計システム側に index.mdx / checklist.yaml が存在しても SKILL.md として生成されない状態だった (M6 一斉生成の盲点)。

`feature/ai-agent-skills` 取り込み済みの `formatter/date-formatter` / `time-formatter` / `timestamp-formatter` を SKILL 配布対象に乗せる。

## やったこと

### `scripts/generate-skills/lib/parse-metadata.ts`

- filePath フィルタを `src/components/` と `src/intl/` の両方を許容するよう拡張
- `src/intl/` 配下はフラット構成 (1 file = 1 component) のため、`displayName` をそのまま `dirName` として採用。設計システム側ディレクトリへは `pascalToKebab(displayName)` 経由で対応付け (例: `DateFormatter` → `date-formatter` → 既存の自動探索で `formatter/date-formatter` にマッピング)
- Context Provider 系 (`IntlProvider` / `StepFormDialogProvider` 等) は UI コンポーネントではなく設計システムのドキュメント対象外のため、`/Provider$/` パターンで除外

### `plugins/smarthr-design-system/skills/`

- `smarthr-ui-date-formatter/SKILL.md` 新規追加 (Layer 1+2+3 完全版)
- `smarthr-ui-time-formatter/SKILL.md` 新規追加 (Layer 1+2、Layer 3 は別 PR で yaml 整備予定)
- `smarthr-ui-timestamp-formatter/SKILL.md` 新規追加 (同上)
- `component-selector/SKILL.md` に 3 件分のエントリ追記

## やらなかったこと

- `TimeFormatter` / `TimestampFormatter` の `checklist.yaml` 整備 (デモ素材として活用したいため、別 PR で `generate-checklist` SKILL を使って整備する)
- `IntlProvider` / `StepFormDialogProvider` の設計システム側ドキュメント整備 (Provider 系は性質が異なるため別途検討)

## 動作確認

```sh
pnpm --filter ./scripts/generate-skills generate
```

結果:

- 生成 SKILL 数: 101 → 104 (+3: date-formatter / time-formatter / timestamp-formatter)
- Layer 3 あり: 69 → 70 (+1: DateFormatter の既存 checklist.yaml が反映)
- 整合性チェック: `✅ すべて整合`
- 古い `smarthr-ui-intl-provider/` (取り込み初期に一時的に生成されたもの) は自動削除

ローカル `src/content/articles/products/components/date-formatter/_check/` (gitignore 対象、過去の rename 前の生成物) が残っていると buildDirMapping が誤って top-level `date-formatter` を優先してしまうケースがあるが、CI/クリーン環境では存在しないため問題なし。

## キャプチャ

|Before|After|
| --- | --- |
| `DateFormatter` / `TimeFormatter` / `TimestampFormatter` の SKILL.md が生成されず、AI エージェントに使い方が伝わらない | 3 件分の SKILL.md が生成され、`component-selector` にも掲載される |

🤖 Generated with [Claude Code](https://claude.com/claude-code)