### PR TITLE
chore(plugin): マーケットプレイス登録情報を整備 (v0.5.0、design-system カテゴリ、email 削除)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,6 @@
   },
   "owner": {
     "name": "SmartHR Design System",
-    "email": "design-system@smarthr.co.jp",
     "url": "https://smarthr.design/"
   },
   "plugins": [
@@ -13,8 +12,8 @@
       "name": "smarthr-design-system",
       "source": "./plugins/smarthr-design-system",
       "description": "SmartHR Design System の使い方ガイド。AI コーディングエージェントが smarthr-ui のコンポーネントを正しく選択し、props を間違えず、デザインシステムのレイアウト・パターンに沿った実装をするための知識集。",
-      "version": "0.1.0",
-      "category": "ui-frameworks",
+      "version": "0.5.0",
+      "category": "design-system",
       "keywords": ["smarthr", "smarthr-ui", "design-system", "react", "component-library"]
     }
   ]

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,6 @@
   },
   "owner": {
     "name": "SmartHR Design System",
-    "email": "design-system@smarthr.co.jp",
     "url": "https://smarthr.design/"
   },
   "plugins": [
@@ -13,8 +12,8 @@
       "name": "smarthr-design-system",
       "source": "./plugins/smarthr-design-system",
       "description": "SmartHR Design System の使い方ガイド。AI コーディングエージェントが smarthr-ui のコンポーネントを正しく選択し、props を間違えず、デザインシステムのレイアウト・パターンに沿った実装をするための知識集。",
-      "version": "0.1.0",
-      "category": "ui-frameworks",
+      "version": "0.5.0",
+      "category": "design-system",
       "keywords": ["smarthr", "smarthr-ui", "design-system", "react", "component-library"]
     }
   ]

--- a/plugins/smarthr-design-system/.claude-plugin/plugin.json
+++ b/plugins/smarthr-design-system/.claude-plugin/plugin.json
@@ -1,10 +1,9 @@
 {
   "name": "smarthr-design-system",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "SmartHR Design System の使い方ガイド。AI コーディングエージェントが smarthr-ui のコンポーネントを正しく選択し、props を間違えず、デザインシステムのレイアウト・パターンに沿った実装をするための知識集。",
   "author": {
-    "name": "SmartHR Design System",
-    "email": "design-system@smarthr.co.jp"
+    "name": "SmartHR Design System"
   },
   "homepage": "https://smarthr.design/",
   "repository": "https://github.com/kufu/smarthr-design-system",

--- a/plugins/smarthr-design-system/.cursor-plugin/plugin.json
+++ b/plugins/smarthr-design-system/.cursor-plugin/plugin.json
@@ -1,15 +1,14 @@
 {
   "name": "smarthr-design-system",
   "displayName": "SmartHR Design System",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "SmartHR Design System の使い方ガイド。AI コーディングエージェントが smarthr-ui のコンポーネントを正しく選択し、props を間違えず、デザインシステムのレイアウト・パターンに沿った実装をするための知識集。",
   "author": {
-    "name": "SmartHR Design System",
-    "email": "design-system@smarthr.co.jp"
+    "name": "SmartHR Design System"
   },
   "homepage": "https://smarthr.design/",
   "repository": "https://github.com/kufu/smarthr-design-system",
   "license": "MIT",
   "keywords": ["smarthr", "smarthr-ui", "design-system", "react", "component-library"],
-  "category": "ui-frameworks"
+  "category": "design-system"
 }


### PR DESCRIPTION
## 課題・背景

`feature/ai-agent-skills` の main マージ後にプラグイン検証を実施するにあたり、マーケットプレイス登録情報を実態に合わせて整備する。

## やったこと

### version: 0.1.0 → 0.5.0

M8 前のマイルストーンに合わせて引き上げ。

### category: ui-frameworks → design-system

Claude Code プラグイン規格 (https://code.claude.com/docs/en/plugin-marketplaces) 上、`category` は **自由文字列** (enum ではない)。`design-system` の方が本プラグインの性格を明示的に表現できる。

### owner.email / author.email 削除

- ダミーテキストだったので削除

### 対象 4 ファイル

- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`
- `plugins/smarthr-design-system/.claude-plugin/plugin.json`
- `plugins/smarthr-design-system/.cursor-plugin/plugin.json`

## やらなかったこと

- `description` は維持 (内容明確、ターゲットと価値が網羅されているため)

## 動作確認

JSON 形式のみの変更のため、ファイル単位での schema valid 確認のみ実施。