### PR TITLE
用字用語から「何卒」を削除

### DIFF
--- a/src/content/articles/products/contents/idiomatic-usage/ichiran.mdx
+++ b/src/content/articles/products/contents/idiomatic-usage/ichiran.mdx
@@ -145,7 +145,6 @@ ignoreH3Nav: true
 | ない | 無い | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana) |
 | 〜なかで | 〜中で | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana) |
 | など | 等 | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana) |
-| 何卒 | 何とぞ | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana) |
 | 並び順, 横並び, 縦並び | ならび順, 横ならび, 縦ならび | 例外： [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana)  |
 | ならびに | 並びに | [平仮名にしたほうが読みやすい漢字は平仮名にする](/products/contents/idiomatic-usage/hiragana/#use-hiragana-for-kanji-that-is-easier-to-read-as-hiragana) |
 | 並べ替え | 並び替え | [「並べ替え」と表記する](/products/contents/idiomatic-usage/action/#use-narabekae) |


### PR DESCRIPTION
## 課題・背景
以下の理由により、用字用語から「何卒」を削除する。
- ガイドラインはプロダクト（UIやサポートコンテンツ）の言葉を対象としている
- プロダクトで「何卒」を使うケースは少ない
  - 現時点で5件のみ
  - 積極的に統一するほどではない
- プロダクトとしては、そもそも[敬語を使いすぎない](https://smarthr.design/products/contents/writing-style/#h2-5)ことを推奨している
  - 「なにとぞ」の使用自体が推奨されない

チケット：https://www.notion.so/36e37b6398eb80b3b3faf606748f8272
スレ：https://kufuinc.slack.com/archives/CJX59GJFR/p1778476231056379

## やったこと
用字用語から「何卒」を削除する。
