### PR TITLE
fix(Icon): Iconコンポーネントページの参考文献のurl修正

### DIFF
--- a/src/content/articles/products/components/icon/index.mdx
+++ b/src/content/articles/products/components/icon/index.mdx
@@ -103,7 +103,7 @@ Font Awesomeから必要なものを取り込んでいます。
 ## 参考文献
 
 * https://www.lightningdesignsystem.com/icons/
-* https://www.carbondesignsystem.com/guidelines/icons/usage/
+* https://www.carbondesignsystem.com/elements/icons/usage/
 
 
 ## Props


### PR DESCRIPTION
## 課題・背景

Carbon design systemがv11でページ構造が変わって、もとのiconページが404なってましたので修正しました

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
- Carbon design systemのiconのusageページのurlの修正

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- n/a

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->
Iconページの参考文献にあるCarbon DSのリンクが404になってないこと
https://deploy-preview-2135--smarthr-design-system.netlify.app/products/components/icon/#h2-5

## キャプチャ

|Before|After|
| --- | --- |
| https://www.carbondesignsystem.com/guidelines/icons/usage/ | https://carbondesignsystem.com/elements/icons/usage/ |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
