### PR TITLE
improvement: カラートークンのページのレイアウトを調整

### DIFF
--- a/src/content/articles/products/design-tokens/color.mdx
+++ b/src/content/articles/products/design-tokens/color.mdx
@@ -6,6 +6,8 @@ order: 1
 
 import ColorPalette from '@/components/article/ColorPalette.astro'
 import ColorPalettesWrapper from '@/components/article/ColorPaletteWrapper.astro'
+import { Table, Td, Th } from 'smarthr-ui'
+import TableWrapper from '@/components/article/TableWrapper.astro'
 
 プロダクトを構成するために必要な最低限の色を定義しています。
 
@@ -15,102 +17,471 @@ import ColorPalettesWrapper from '@/components/article/ColorPaletteWrapper.astro
 
 ## セマンティックトークン
 
-### メイン
-
-プライマリーカラーである`MAIN`と、コンポーネントのベースカラーとなる`WHITE`を定めています。
-
-プライマリーカラーは、プロダクトの印象を司る箇所に使います。具体的な使用箇所は、各コンポーネントを参照してください。
-
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
-  <ColorPalette colorValue="#fff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
-</ColorPalettesWrapper>
-
-
-### アクセント
-コンテキストに応じた色を定めています。
-
-`MAIN`と合わせて、ユーザーのメインアクションや、アクションに対する結果、ヘルプの表示、オブジェクトの状態を表します。
-
-具体的な使用箇所は、各コンポーネントを参照してください。
-
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#e01e5a" colorName="DANGER" description="エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）" />
-  <ColorPalette colorValue="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う" />
-</ColorPalettesWrapper>
-
-
-### 文字
-
-テキストの状態に応じた文字の色を定めています。
-
-強調などの文字スタイルは、[タイポグラフィ](/products/design-tokens/typography/)を参照してください。
-
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#23221e" colorName="TEXT_BLACK" description="基本的な文字の色" />
-  <ColorPalette colorValue="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
-  <ColorPalette colorValue="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
-  <ColorPalette colorValue="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
-  <ColorPalette colorValue="#fff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
-</ColorPalettesWrapper>
-
-
-### コンポーネント
-
-コンポーネントを構成する要素に必要な色を定めています。
-
-具体的な使用箇所は、各コンポーネントを参照してください。
-
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#d6d3d0" colorName="BORDER" description="枠線・罫線の色" />
-  <ColorPalette colorValue="#d6d3d0" colorName="ACTION_BACKGROUND" description="TableBulkActionAreaの背景色" />
-  <ColorPalette colorValue="#edebe8" colorName="HEAD" description="テーブルヘッダーの背景色" />
-  <ColorPalette colorValue="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette colorValue="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette colorValue="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
-  <ColorPalette colorValue="rgba(3,3,2,0.15)" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
-  <ColorPalette colorValue="rgba(3,3,2,0.5)" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
-  <ColorPalette colorValue="rgba(255,255,255,0)" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
-</ColorPalettesWrapper>
-
-
-### チャート（グラフ）
-
-チャートで使用する色を定めています。チャートには指定された順序で色を使用します。
-
-#### 多色チャート
-
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#00c4cc" colorName="CHART_COLOR_1" description="多色チャート色1" />
-  <ColorPalette colorValue="#ffcd00" colorName="CHART_COLOR_2" description="多色チャート色2" />
-  <ColorPalette colorValue="#ff9100" colorName="CHART_COLOR_3" description="多色チャート色3" />
-  <ColorPalette colorValue="#e65537" colorName="CHART_COLOR_4" description="多色チャート色4" />
-  <ColorPalette colorValue="#2d4b9b" colorName="CHART_COLOR_5" description="多色チャート色5" />
-  <ColorPalette colorValue="#2d7df0" colorName="CHART_COLOR_6" description="多色チャート色6" />
-  <ColorPalette colorValue="#69d7ff" colorName="CHART_COLOR_7" description="多色チャート色7" />
-  <ColorPalette colorValue="#4bb47d" colorName="CHART_COLOR_8" description="多色チャート色8" />
-  <ColorPalette colorValue="#05878c" colorName="CHART_COLOR_9" description="多色チャート色9" />
-  <ColorPalette colorValue="#005a64" colorName="CHART_COLOR_10" description="多色チャート色10" />
-</ColorPalettesWrapper>
-
-#### 単色チャート
-
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#a1e3e6" colorName="SINGLE_CHART_COLOR_1" description="単色チャート色1" />
-  <ColorPalette colorValue="#00c4cc" colorName="SINGLE_CHART_COLOR_2" description="単色チャート色2" />
-  <ColorPalette colorValue="#00acb3" colorName="SINGLE_CHART_COLOR_3" description="単色チャート色3" />
-  <ColorPalette colorValue="#05868b" colorName="SINGLE_CHART_COLOR_4" description="単色チャート色4" />
-  <ColorPalette colorValue="#055659" colorName="SINGLE_CHART_COLOR_5" description="単色チャート色5" />
-  <ColorPalette colorValue="#033033" colorName="SINGLE_CHART_COLOR_6" description="単色チャート色6" />
-</ColorPalettesWrapper>
-
-#### その他のチャート色
-
-その他のチャート色は、チャート内の「その他」を示す項目に使います。
-
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#ebebeb" colorName="OTHER_CHART_COLOR" description="「その他」項目に使う色" />
-</ColorPalettesWrapper>
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>トークン名</Th>
+        <Th>色</Th>
+        <Th>説明</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td><code>MAIN</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#0077c7', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#0077c7</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,119,199)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>プライマリーカラー（プロダクトの印象を司る箇所に使う）</Td>
+      </tr>
+      <tr>
+        <Td><code>WHITE</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#fff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#fff</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,255,255)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>コンポーネントの背景色（Baseコンポーネントなど）</Td>
+      </tr>
+      <tr>
+        <Td><code>DANGER</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#e01e5a', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#e01e5a</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(224,30,90)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）</Td>
+      </tr>
+      <tr>
+        <Td><code>WARNING_YELLOW</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#ffcc17', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#ffcc17</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,204,23)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う</Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_BLACK</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#23221e', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#23221e</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(35,34,30)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>基本的な文字の色</Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_GREY</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#706d65', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#706d65</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(112,109,101)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>TEXT_BLACKからジャンプ率を確保するときに使う文字の色</Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_LINK</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#0071c1', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#0071c1</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,113,193)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>リンクを表す文字の色</Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_DISABLED</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#c1bdb7', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#c1bdb7</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(193,189,183)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>disabled状態を表す文字の色</Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_WHITE</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#fff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#fff</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,255,255)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>暗い地色やMAINに対して使う文字の色</Td>
+      </tr>
+      <tr>
+        <Td><code>BORDER</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#d6d3d0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#d6d3d0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(214,211,208)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>枠線・罫線の色</Td>
+      </tr>
+      <tr>
+        <Td><code>ACTION_BACKGROUND</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#d6d3d0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#d6d3d0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(214,211,208)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>TableBulkActionAreaの背景色</Td>
+      </tr>
+      <tr>
+        <Td><code>HEAD</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#edebe8', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#edebe8</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(237,235,232)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>テーブルヘッダーの背景色</Td>
+      </tr>
+      <tr>
+        <Td><code>OVER_BACKGROUND</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#f2f1f0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#f2f1f0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(242,241,240)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）</Td>
+      </tr>
+      <tr>
+        <Td><code>COLUMN</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#f8f7f6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#f8f7f6</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(248,247,246)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>WHITEの上で使う囲み色（要素をグルーピングするときに使う色）</Td>
+      </tr>
+      <tr>
+        <Td><code>BACKGROUND</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#f8f7f6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#f8f7f6</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(248,247,246)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>画面の背景色</Td>
+      </tr>
+      <tr>
+        <Td><code>OVERLAY</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: 'rgba(3,3,2,0.15)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>rgba(3,3,2,0.15)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>ボタンなどhover時に重ねる色</Td>
+      </tr>
+      <tr>
+        <Td><code>SCRIM</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: 'rgba(3,3,2,0.5)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>rgba(3,3,2,0.5)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色</Td>
+      </tr>
+      <tr>
+        <Td><code>TRANSPARENT</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: 'rgba(255,255,255,0)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>rgba(255,255,255,0)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_1</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#00c4cc', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#00c4cc</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,196,204)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色1</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_2</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#ffcd00', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#ffcd00</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,205,0)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色2</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_3</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#ff9100', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#ff9100</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,145,0)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色3</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_4</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#e65537', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#e65537</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(230,85,55)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色4</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_5</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#2d4b9b', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#2d4b9b</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(45,75,155)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色5</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_6</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#2d7df0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#2d7df0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(45,125,240)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色6</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_7</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#69d7ff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#69d7ff</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(105,215,255)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色7</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_8</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#4bb47d', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#4bb47d</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(75,180,125)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色8</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_9</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#05878c', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#05878c</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(5,135,140)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色9</Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_10</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#005a64', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#005a64</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,90,100)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>多色チャート色10</Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_1</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#a1e3e6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#a1e3e6</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(161,227,230)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>単色チャート色1</Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_2</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#00c4cc', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#00c4cc</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,196,204)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>単色チャート色2</Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_3</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#00acb3', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#00acb3</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,172,179)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>単色チャート色3</Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_4</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#05868b', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#05868b</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(5,134,139)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>単色チャート色4</Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_5</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#055659', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#055659</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(5,86,89)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>単色チャート色5</Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_6</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#033033', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#033033</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(3,48,51)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>単色チャート色6</Td>
+      </tr>
+      <tr>
+        <Td><code>OTHER_CHART_COLOR</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#ebebeb', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#ebebeb</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(235,235,235)</div>
+            </div>
+          </div>
+        </Td>
+        <Td>「その他」項目に使う色</Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
 
 ## プリミティブトークン

--- a/src/content/articles/products/design-tokens/color.mdx
+++ b/src/content/articles/products/design-tokens/color.mdx
@@ -38,7 +38,25 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>プライマリーカラー（プロダクトの印象を司る箇所に使う）</Td>
+        <Td>
+        **使用用途**
+        - プライマリーカラーとして使うアイコン、背景色、枠線
+        - プライマリーカラーとして使うコンポーネントの背景色、枠線
+        - フォーカスリングの枠線
+        - `Selected`になっているコンポーネントの背景色、枠線
+          - NotificationBar
+          - RadioButton等
+        - `Current`になっているコンポーネントの背景色、枠線
+          - SideMenu
+          - SideNav等
+        - `Checked`になっているコンポーネントの背景色
+          - Checkbox
+          - Switch等
+          
+        **他のトークンとの使い分け**
+        - `TEXT_LINK`
+          - テキストの場合は使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>WHITE</code></Td>
@@ -51,7 +69,17 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>コンポーネントの背景色（Baseコンポーネントなど）</Td>
+        <Td>
+        **利用用途**
+        - コンポーネントの背景色
+          - Base
+            - Dialog
+            - Dropdown等
+
+        **他のトークンとの使い分け**
+        - `TEXT_WHITE`
+          - テキストの場合は使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>DANGER</code></Td>
@@ -64,7 +92,15 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）</Td>
+        <Td>
+        **利用用途**
+        - エラー時のコンポーネントの文字色、背景色、線
+        - 削除など破壊的な変更を行なうアイコン、ボタン、文字色、背景色、枠線
+
+        **他のトークンとの使い分け**
+        - `WARNING_YELLOW`
+          - 警告時には使わない（削除前などのアクション前）
+        </Td>
       </tr>
       <tr>
         <Td><code>WARNING_YELLOW</code></Td>
@@ -77,7 +113,20 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う</Td>
+        <Td>
+        **利用用途**
+        - 警告時のコンポーネントの背景色、WarningIconなどのアイコン
+        - 削除やUndoなどの破壊的アクションをする前の注意に使う
+
+        **他のトークンとの使い分け**
+        - `DANGER`
+          - 削除の実行アクションには使わない
+
+        **注意事項**
+        - 必ず`TEXT_BLACK`と組み合わせて使う
+        - 基本的には文字色には使わない
+
+        </Td>
       </tr>
       <tr>
         <Td><code>TEXT_BLACK</code></Td>
@@ -90,7 +139,15 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>基本的な文字の色</Td>
+        <Td>
+        **利用用途**
+        - 基本的な文字の色、アイコンの色
+        - Buttonなどのコンポーネントの通常時の文字の色
+
+        **他のトークンとの使い分け**
+        - `TEXT_GREY`
+          - ジャンプ率がある場合は使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>TEXT_GREY</code></Td>
@@ -103,7 +160,15 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>TEXT_BLACKからジャンプ率を確保するときに使う文字の色</Td>
+        <Td>
+        **利用用途**
+        - `TEXT_BLACK`からジャンプ率を確保するときに使う文字の色、アイコンの色
+        - Definition List、Heddingなどのジャンプ率を確保した見出しコンポーネントの文字の色
+
+        **他のトークンとの使い分け**
+        - `TEXT_BLACK`
+          - 通常の文字の色には使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>TEXT_LINK</code></Td>
@@ -116,7 +181,15 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>リンクを表す文字の色</Td>
+        <Td>
+        **利用用途**
+        - リンクを表す文字の色、下線、アイコン
+        - Buttonの`tertiary`の文字の色
+
+        **他のトークンとの使い分け**
+        - `MAIN`
+          - リンクの場合は使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>TEXT_DISABLED</code></Td>
@@ -129,7 +202,17 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>disabled状態を表す文字の色</Td>
+        <Td>
+        **利用用途**
+        - `disabled`状態を表す文字の色
+        - Button、SegmentedControl、Select、Input等
+
+        **他のトークンとの使い分け**
+        - `TEXT_GREY`
+          - 単なるグレーテキストの場合は使わない
+        - `BORDER_DISABLED`
+          - 線の色には使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>TEXT_WHITE</code></Td>
@@ -142,7 +225,15 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>暗い地色やMAINに対して使う文字の色</Td>
+        <Td>
+        **利用用途**
+          - `DANGER`、`MAIN`に対して使う文字、アイコンの色
+            - Button、AppHeader等
+
+        **他のトークンとの使い分け**
+        - `WHITE`
+          - 背景色では使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>BORDER</code></Td>
@@ -155,7 +246,11 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>枠線・罫線の色</Td>
+        <Td>
+        **利用用途**
+        - 基本的な枠線・罫線の色
+        - Buttonなどの通常時のコンポーネントの枠線
+        </Td>
       </tr>
       <tr>
         <Td><code>ACTION_BACKGROUND</code></Td>
@@ -168,7 +263,17 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>TableBulkActionAreaの背景色</Td>
+        <Td>
+        **利用用途**
+        - TableBulkActionAreaの背景色
+
+        **他のトークンとの使い分け**
+        - `HEAD`
+          - テーブルヘッダーの背景色では使わない
+
+        **注意事項**
+        - `OVER_BACKGROUND`の上に置く色として使われることもある
+        </Td>
       </tr>
       <tr>
         <Td><code>HEAD</code></Td>
@@ -181,7 +286,15 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>テーブルヘッダーの背景色</Td>
+        <Td>
+        **利用用途**
+        - テーブルヘッダーの背景色
+        - 視覚的グルーピングの`COLUMN`以上のネストが必要なときに使用
+
+        **他のトークンとの使い分け**
+        - `ACTION_BACKGROUND`
+          - TableBulkActionAreaでは使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>OVER_BACKGROUND</code></Td>
@@ -194,7 +307,17 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）</Td>
+        <Td>
+        **利用用途**
+        - `BACKGROUND`の上で使う囲み色（要素をグルーピングするときに使う色）
+        - hover時に`COLUMN`を使っている場合の背景色
+
+        **他のトークンとの使い分け**
+        - `BACKGROUND`
+          - 画面の背景色では使わない
+        - `COLUMN`
+          - `WHITE`の上では使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>COLUMN</code></Td>
@@ -207,7 +330,18 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>WHITEの上で使う囲み色（要素をグルーピングするときに使う色）</Td>
+        <Td>
+        **利用用途**
+        - `WHITE`の上で使う囲み色（要素をグルーピングするときに使う色）
+        - 各コンポーネントの背景色
+          - DropZone、SideNav
+
+        **他のトークンとの使い分け**
+        - `BACKGROUND`
+          - 画面の背景色では使わない
+        - `OVER_BACKGROUND`
+          - `BACKGROUND`の上では使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>BACKGROUND</code></Td>
@@ -220,7 +354,16 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>画面の背景色</Td>
+        <Td>
+        **利用用途**
+        - 画面の背景色
+        - 広い背景のある各コンポーネントの背景色
+          - InputFile
+
+        **他のトークンとの使い分け**
+        - `COLUMN`
+          - `WHITE`の上では使わない
+        </Td>
       </tr>
       <tr>
         <Td><code>OVERLAY</code></Td>
@@ -244,7 +387,10 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色</Td>
+        <Td>
+        **利用用途**
+          - モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色
+        </Td>
       </tr>
       <tr>
         <Td><code>TRANSPARENT</code></Td>
@@ -256,7 +402,10 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
             </div>
           </div>
         </Td>
-        <Td>デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用</Td>
+        <Td>
+        **利用用途**
+        - コンポーネントの枠線などを消すときのAppearanceに使用
+        </Td>
       </tr>
       <tr>
         <Td><code>CHART_COLOR_1</code></Td>


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
- Clusterでカラーチップが並べられていたのを、テーブルにしておくことで説明を書きやすくしました。
- 必要のないセクション分けを削除しました。

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

https://deploy-preview-2137--smarthr-design-system.netlify.app/products/design-tokens/color/

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
