### PR TITLE
fix: ErrorScreenページの `レイアウト` セクションで実装部分の高さが無限に増えてしまうバグを修正する

### DIFF
--- a/src/content/articles/products/components/error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/index.mdx
@@ -35,7 +35,7 @@ import { Button, Center, Cluster, ErrorScreen, Stack, Text, TextLink } from 'sma
 
 ErrorScreenコンポーネントではロゴ、タイトル、メッセージ、リンクを表示できます。
 
-```tsx editable
+```tsx editable noIframe
 <div style={{ width: '100%' }}>
   <ErrorScreen
     title="タイトル"


### PR DESCRIPTION
表題の通りです。

[確認URL](https://deploy-preview-2147--smarthr-design-system.netlify.app/products/components/error-screen/#h2-1)