### PR TITLE
fix(skills): checklist 生成 SKILL の古い参照・手順を修正

### DIFF
--- a/.claude/skills/generate-checklist/SKILL.md
+++ b/.claude/skills/generate-checklist/SKILL.md
@@ -20,7 +20,7 @@ smarthr-design-system のコンポーネントページ（index.mdx）から、A
 ## 前提条件
 
 - 抽出ルール詳細: `.github/prompts/generate-checklist.md`（severity 推測の語気手がかり、Do/Don't 変換の具体例等）
-- ディレクトリ名解決: `scripts/generate-skills/mapping/component-dir-map.json`
+- ディレクトリ名解決: `src/content/articles/products/components/` 配下を直接探索する（コンポーネント名を kebab-case 化したディレクトリ名。ネストする場合あり）
 - 参考例: `src/content/articles/products/components/button/checklist.yaml`
 
 ## 生成フロー
@@ -28,7 +28,7 @@ smarthr-design-system のコンポーネントページ（index.mdx）から、A
 ### Step 1: 対象コンポーネントの index.mdx を読む
 
 パスの解決:
-- `component-dir-map.json` でコンポーネント名 → ディレクトリ名を確認
+- `src/content/articles/products/components/` 配下を `find` / glob で探索し、コンポーネント名（kebab-case）に対応するディレクトリを特定する
 - 基本パス: `src/content/articles/products/components/<dir>/index.mdx`
 - ネストあり: `dialog/message-dialog/`, `dialog/modeless-dialog/`, `combobox/single-combobox/` 等
 

--- a/.claude/skills/generate-checklist/SKILL.md
+++ b/.claude/skills/generate-checklist/SKILL.md
@@ -129,29 +129,15 @@ ruby -ryaml -e "puts (YAML.load_file('path/to/checklist.yaml')['items'] || []).s
 
 期待範囲: 1〜20 項目。極端に多い（20 超）場合は統合の余地あり。
 
-### Step 6: SKILL ドキュメントへの反映（CI が自動実行・コミット不要）
+### Step 6: Layer 1 重複チェック
 
-`checklist.yaml` から SKILL ドキュメントへの再生成は、**マージ後に CI（`generate-skills.yml`）が自動実行**する。作業者がローカルで再生成して生成物（`plugins/smarthr-design-system/skills/` 配下）をコミットする必要はない。
+Layer 3 に入れようとしている項目が Layer 1（mdx 冒頭の説明文）と重複していないか確認する。mdx 構造から事前に予測でき（短い「冒頭説明 + props」構造のコンポーネントで重複しやすい）、重複する項目は checklist.yaml から削除する。ErrorScreen 子のように mdx 冒頭の見出しなし説明文がそのまま Layer 1 に取り込まれるケースで起きやすい。
 
-**コミット対象は `checklist.yaml` のみ**。生成物 `plugins/...` はコミットしない。
+反映結果を手元で確認したい場合のみ、リポジトリルートから `pnpm --filter ./scripts/generate-skills generate` を実行し、生成された `plugins/smarthr-design-system/skills/component-guidelines/components/<PascalCase>.md` の Layer 1 部分と突き合わせる（生成物はコミットしない）。
 
-反映結果を手元で確認したい場合のみ、リポジトリルートから次を実行する（実行しても生成物はコミットしない）。
+## 成果物とコミット
 
-```bash
-pnpm --filter ./scripts/generate-skills generate
-```
-
-### Step 7: Layer 1 重複チェック
-
-Layer 3 に入れようとしている項目が Layer 1（mdx 冒頭の説明文）と重複していないか確認する。mdx 構造から事前に予測でき（短い「冒頭説明 + props」構造のコンポーネントで重複しやすい）、Step 6 でローカル再生成した場合は生成された SKILL ドキュメントの Layer 1 部分と突き合わせて検証する。
-
-ローカル再生成した場合の確認先（生成物。コミット対象外）:
-
-```bash
-cat plugins/smarthr-design-system/skills/component-guidelines/components/<PascalCase>.md
-```
-
-mdx 本文が短く「冒頭説明 + props」構造のコンポーネント（ErrorScreen 子等）では、mdx 冒頭の見出しなし説明文がそのまま Layer 1 として取り込まれることが多い。その場合、Layer 3 で同内容を含めると重複出力されるため、checklist.yaml の該当項目を削除する。
+この SKILL の成果物は `checklist.yaml` のみ。**コミット対象は `checklist.yaml` だけ**で、コンポーネントガイド（`plugins/...`）への反映はマージ後に CI（`generate-skills.yml`）が自動実行する。ローカルで `pnpm generate` を実行して生成物をコミットする必要はない。
 
 ## checklist.yaml のフォーマット
 

--- a/.claude/skills/generate-checklist/SKILL.md
+++ b/.claude/skills/generate-checklist/SKILL.md
@@ -3,7 +3,7 @@ description: >-
   smarthr-design-system のコンポーネント mdx から checklist.yaml を生成・更新する。
   「checklist を作って」「checklist.yaml を生成して」「Layer 3 を整備して」等の
   依頼に対応する。対象コンポーネントの index.mdx を読み、使い分けガイドを
-  YAML 形式で抽出し、pnpm generate で SKILL.md に反映する。
+  YAML 形式で抽出する。
 globs:
   - "src/content/articles/products/components/**/index.mdx"
   - "src/content/articles/products/components/**/checklist.yaml"
@@ -15,7 +15,7 @@ globs:
 
 smarthr-design-system のコンポーネントページ（index.mdx）から、AI エージェント向けの使い分けガイド（checklist.yaml）を生成する手順書。
 
-生成した checklist.yaml は `pnpm generate` で SKILL.md に Layer 3 として取り込まれ、エンジニアが smarthr-ui コンポーネントを正しく使うためのガイドになる。
+生成した checklist.yaml は、マージ後に CI が再生成する SKILL ドキュメントへ Layer 3 として取り込まれ、エンジニアが smarthr-ui コンポーネントを正しく使うためのガイドになる。
 
 ## 前提条件
 
@@ -129,23 +129,29 @@ ruby -ryaml -e "puts (YAML.load_file('path/to/checklist.yaml')['items'] || []).s
 
 期待範囲: 1〜20 項目。極端に多い（20 超）場合は統合の余地あり。
 
-### Step 6: SKILL.md 再生成
+### Step 6: SKILL ドキュメントへの反映（CI が自動実行・コミット不要）
+
+`checklist.yaml` から SKILL ドキュメントへの再生成は、**マージ後に CI（`generate-skills.yml`）が自動実行**する。作業者がローカルで再生成して生成物（`plugins/smarthr-design-system/skills/` 配下）をコミットする必要はない。
+
+**コミット対象は `checklist.yaml` のみ**。生成物 `plugins/...` はコミットしない。
+
+反映結果を手元で確認したい場合のみ、リポジトリルートから次を実行する（実行しても生成物はコミットしない）。
 
 ```bash
-pnpm generate
+pnpm --filter ./scripts/generate-skills generate
 ```
-
-Layer 3 あり件数が増えていることを確認。
 
 ### Step 7: Layer 1 重複チェック
 
-生成された SKILL.md の Layer 1 部分（冒頭の説明文）を読み、checklist.yaml の各項目と同内容が含まれていないか確認する。
+Layer 3 に入れようとしている項目が Layer 1（mdx 冒頭の説明文）と重複していないか確認する。mdx 構造から事前に予測でき（短い「冒頭説明 + props」構造のコンポーネントで重複しやすい）、Step 6 でローカル再生成した場合は生成された SKILL ドキュメントの Layer 1 部分と突き合わせて検証する。
+
+ローカル再生成した場合の確認先（生成物。コミット対象外）:
 
 ```bash
-cat plugins/smarthr-design-system/skills/<component>/SKILL.md
+cat plugins/smarthr-design-system/skills/component-guidelines/components/<PascalCase>.md
 ```
 
-mdx 本文が短く「冒頭説明 + props」構造のコンポーネント（ErrorScreen 子等）では、mdx 冒頭の見出しなし説明文がそのまま Layer 1 として SKILL.md に取り込まれることが多い。その場合、Layer 3 で同内容を含めると重複出力されるため、checklist.yaml の該当項目を削除し、Step 6 を再実行する。
+mdx 本文が短く「冒頭説明 + props」構造のコンポーネント（ErrorScreen 子等）では、mdx 冒頭の見出しなし説明文がそのまま Layer 1 として取り込まれることが多い。その場合、Layer 3 で同内容を含めると重複出力されるため、checklist.yaml の該当項目を削除する。
 
 ## checklist.yaml のフォーマット
 

--- a/.claude/skills/update-checklist/SKILL.md
+++ b/.claude/skills/update-checklist/SKILL.md
@@ -25,14 +25,14 @@ globs:
 ## 前提条件
 
 - 既存 `checklist.yaml` の確認: `src/content/articles/products/components/<dir>/checklist.yaml`
-- ディレクトリ名解決: `scripts/generate-skills/mapping/component-dir-map.json`
+- ディレクトリ名解決: `src/content/articles/products/components/` 配下を直接探索する（コンポーネント名を kebab-case 化したディレクトリ名。ネストする場合あり）
 - 参考例: `src/content/articles/products/components/button/checklist.yaml`
 
 ## 更新フロー
 
 ### Step 1: 対象を特定
 
-依頼文から対象コンポーネントを抽出。複数指定可。コンポーネント名 → ディレクトリ名の解決は `scripts/generate-skills/mapping/component-dir-map.json` を参照。
+依頼文から対象コンポーネントを抽出。複数指定可。コンポーネント名 → ディレクトリ名の解決は `src/content/articles/products/components/` 配下を `find` / glob で探索する（コンポーネント名を kebab-case 化したディレクトリ名。ネストする場合あり）。
 
 ### Step 2: 入力を読み込む
 

--- a/.claude/skills/update-checklist/SKILL.md
+++ b/.claude/skills/update-checklist/SKILL.md
@@ -126,29 +126,15 @@ pnpm --filter ./scripts/generate-skills validate
 
 `error` がないことを確認。`warn` は内容に応じて対応。
 
-### Step 8: SKILL ドキュメントへの反映（CI が自動実行・コミット不要）
+### Step 8: Layer 1 重複チェック
 
-`checklist.yaml` から SKILL ドキュメントへの再生成は、**マージ後に CI（`generate-skills.yml`）が自動実行**する。作業者がローカルで再生成して生成物（`plugins/smarthr-design-system/skills/` 配下）をコミットする必要はない。
+Layer 3 に入れようとしている項目が Layer 1（mdx 冒頭の説明文）と重複していないか確認する。mdx 構造から事前に予測でき（短い「冒頭説明 + props」構造のコンポーネントで重複しやすい）、重複する項目は checklist.yaml から削除する。ErrorScreen 子のように mdx 冒頭の見出しなし説明文がそのまま Layer 1 に取り込まれるケースで起きやすい。
 
-**コミット対象は `checklist.yaml` のみ**。生成物 `plugins/...` はコミットしない。
+反映結果を手元で確認したい場合のみ、リポジトリルートから `pnpm --filter ./scripts/generate-skills generate` を実行し、生成された `plugins/smarthr-design-system/skills/component-guidelines/components/<PascalCase>.md` の Layer 1 部分と突き合わせる（生成物はコミットしない）。
 
-反映結果を手元で確認したい場合のみ、リポジトリルートから次を実行する（実行しても生成物はコミットしない）。
+## 成果物とコミット
 
-```sh
-pnpm --filter ./scripts/generate-skills generate
-```
-
-### Step 9: Layer 1 重複チェック
-
-Layer 3 に入れようとしている項目が Layer 1（mdx 冒頭の説明文）と重複していないか確認する。mdx 構造から事前に予測でき（短い「冒頭説明 + props」構造のコンポーネントで重複しやすい）、Step 8 でローカル再生成した場合は生成された SKILL ドキュメントの Layer 1 部分と突き合わせて検証する。
-
-ローカル再生成した場合の確認先（生成物。コミット対象外）:
-
-```bash
-cat plugins/smarthr-design-system/skills/component-guidelines/components/<PascalCase>.md
-```
-
-mdx 本文が短く「冒頭説明 + props」構造のコンポーネント（ErrorScreen 子等）では、mdx 冒頭の見出しなし説明文がそのまま Layer 1 として取り込まれることが多い。その場合、Layer 3 で同内容を含めると重複出力されるため、checklist.yaml の該当項目を削除する。
+この SKILL の成果物は更新後の `checklist.yaml` のみ。**コミット対象は `checklist.yaml` だけ**で、コンポーネントガイド（`plugins/...`）への反映はマージ後に CI（`generate-skills.yml`）が自動実行する。ローカルで `pnpm generate` を実行して生成物をコミットする必要はない。
 
 ## やってはいけないこと
 

--- a/.claude/skills/update-checklist/SKILL.md
+++ b/.claude/skills/update-checklist/SKILL.md
@@ -126,23 +126,29 @@ pnpm --filter ./scripts/generate-skills validate
 
 `error` がないことを確認。`warn` は内容に応じて対応。
 
-### Step 8: SKILL.md 再生成
+### Step 8: SKILL ドキュメントへの反映（CI が自動実行・コミット不要）
+
+`checklist.yaml` から SKILL ドキュメントへの再生成は、**マージ後に CI（`generate-skills.yml`）が自動実行**する。作業者がローカルで再生成して生成物（`plugins/smarthr-design-system/skills/` 配下）をコミットする必要はない。
+
+**コミット対象は `checklist.yaml` のみ**。生成物 `plugins/...` はコミットしない。
+
+反映結果を手元で確認したい場合のみ、リポジトリルートから次を実行する（実行しても生成物はコミットしない）。
 
 ```sh
 pnpm --filter ./scripts/generate-skills generate
 ```
 
-`plugins/smarthr-design-system/skills/<component>/SKILL.md` に Layer 3 が反映されることを確認。
-
 ### Step 9: Layer 1 重複チェック
 
-生成された SKILL.md の Layer 1 部分（mdx 冒頭の説明文）を読み、checklist.yaml の各項目と同内容が含まれていないか確認する。
+Layer 3 に入れようとしている項目が Layer 1（mdx 冒頭の説明文）と重複していないか確認する。mdx 構造から事前に予測でき（短い「冒頭説明 + props」構造のコンポーネントで重複しやすい）、Step 8 でローカル再生成した場合は生成された SKILL ドキュメントの Layer 1 部分と突き合わせて検証する。
+
+ローカル再生成した場合の確認先（生成物。コミット対象外）:
 
 ```bash
-cat plugins/smarthr-design-system/skills/<component>/SKILL.md
+cat plugins/smarthr-design-system/skills/component-guidelines/components/<PascalCase>.md
 ```
 
-mdx 本文が短く「冒頭説明 + props」構造のコンポーネント（ErrorScreen 子等）では、mdx 冒頭の見出しなし説明文がそのまま Layer 1 として SKILL.md に取り込まれることが多い。その場合、Layer 3 で同内容を含めると重複出力されるため、checklist.yaml の該当項目を削除し、Step 8 を再実行する。
+mdx 本文が短く「冒頭説明 + props」構造のコンポーネント（ErrorScreen 子等）では、mdx 冒頭の見出しなし説明文がそのまま Layer 1 として取り込まれることが多い。その場合、Layer 3 で同内容を含めると重複出力されるため、checklist.yaml の該当項目を削除する。
 
 ## やってはいけないこと
 


### PR DESCRIPTION
## 課題・背景

Phase 6 の利用確認フィードバックで、checklist 生成 SKILL の手順に実態と合わない記述が複数見つかった。

- `scripts/generate-skills/mapping/component-dir-map.json` への参照が残っていたが、このファイルは #2102 で削除済み。AI が存在しないパスを探して詰まった。
- 裸の `pnpm generate` をルートで実行すると失敗する（ルートに `generate` スクリプトがない）。
- SKILL ドキュメント反映ステップが作業者の手順として書かれており、「checklist.yaml と生成物のどちらをコミットするか」の混乱を招いていた。

フィードバック元 PR: #2163

## やったこと

- 削除済み `component-dir-map.json` への参照を、`src/content/articles/products/components/` 配下の自動探索に修正（generate / update 両 SKILL・計4箇所）
- 裸の `pnpm generate` を `pnpm --filter ./scripts/generate-skills generate` に統一
- SKILL ドキュメント反映の独立 Step を削除し、成果物は `checklist.yaml` のみ・反映はマージ後 CI が自動実行する旨を明記。SKILL のスコープを checklist.yaml の生成・更新までに純化
- Layer 1 重複チェックの参照パスを Phase 7 新構成（`component-guidelines/components/<PascalCase>.md`）に追随

## やらなかったこと

- CONTRIBUTING.md の同種修正（#2108 ブランチ側で対応）
- Notion 手順書の補足（別途対応）

## 動作確認

- `grep -r component-dir-map .claude .cursor .github` で残存参照がゼロであることを確認
- 変更対象は Markdown ドキュメントのみのため、generate / validate スクリプトの挙動には影響なし

## checklist.yaml の更新

- [x] index.mdx の変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)