### PR TITLE
docs: プラグインREADMEを実態に合わせて更新

### DIFF
--- a/plugins/smarthr-design-system/README.md
+++ b/plugins/smarthr-design-system/README.md
@@ -1,38 +1,70 @@
 # smarthr-design-system プラグイン
 
-SmartHR Design System の使い方ガイドを AI コーディングエージェント（Claude Code / Cursor）に提供するプラグイン。
+SmartHR Design SystemのコンポーネントガイドラインをAIコーディングエージェント（Claude Code / Cursor / Codex）に提供するプラグイン。
 
-- 対象: SmartHR 社内エンジニア、`smarthr-ui` を使う社外開発者
-- 提供する知識: コンポーネントの選定基準・Props 仕様・eslint ルール・チェックリスト
-- ベースリポジトリ: <https://github.com/kufu/smarthr-design-system>
+smarthr-uiのコンポーネントを正しく選択・使用するための知識（Props仕様・eslintルール・使い方チェックリスト）をスキルとして配布する。
 
-## 構成
+## 導入方法
 
-```
-plugins/smarthr-design-system/
-├── .claude-plugin/plugin.json
-├── .cursor-plugin/plugin.json
-├── README.md
-├── LICENSE
-└── skills/
-    └── component-guidelines/              唯一のスキル
-        ├── SKILL.md                       エントリポイント（手動管理）
-        ├── component-selector.md          コンポーネント選定ガイド（自動生成）
-        └── components/                    各コンポーネントガイド（自動生成）
-            ├── Button.md
-            ├── Table.md
-            └── ...
+プラグインはマーケットプレイス経由でインストールする。詳細な手順はNotionの「SmartHR Design SystemのAIコーディングエージェント向けスキルプラグイン」を参照。
+
+### Claude Code
+
+```sh
+/plugin marketplace add kufu/smarthr-design-system
+/plugin install smarthr-design-system@smarthr-design-system
 ```
 
-`components/*.md` と `component-selector.md` は `scripts/generate-skills/` のスクリプトで生成された自動生成物です。直接編集せず、入力ソース（`metadata.json`、`eslint-plugin-smarthr` のルール README、`src/content/articles/products/components/**/checklist.yaml`）を更新して再生成してください。`SKILL.md` はエントリポイントとして手動管理しています。
+### Cursor
 
-## ローカル動作確認（Claude Code）
+Settings > Plugins > Browse Marketplaceから「SmartHR Design System」を検索してインストール。
+
+## スキル構成
+
+プラグインは**1つのスキル（`component-guidelines`）**を提供する。[Progressive Disclosureパターン](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#progressive-disclosure-patterns)を採用しており、AIが必要に応じて段階的にドキュメントを読み込む。
+
+```
+skills/component-guidelines/
+├── SKILL.md                       エントリポイント（手動管理）
+├── component-selector.md          コンポーネント選定ガイド（自動生成）
+└── components/                    各コンポーネントガイド（自動生成）
+    ├── Button.md
+    ├── ActionDialog.md
+    └── ...（104件）
+```
+
+各コンポーネントガイドは3層で構成される:
+
+| 層 | 内容 | ソース |
+|-|-|-|
+| Layer 1 | Props・型情報 | `smarthr-ui/metadata.json` |
+| Layer 2 | 実装ルール（Do/Don't） | `eslint-plugin-smarthr`のルールREADME |
+| Layer 3 | 使い方チェックリスト | `checklist.yaml`（人手レビュー済み） |
+
+## 開発者向け情報
+
+`components/*.md`と`component-selector.md`は`scripts/generate-skills/`で自動生成される。直接編集せず、入力ソースを更新して再生成すること。`SKILL.md`のみ手動管理。
+
+### ローカル動作確認
 
 ```sh
 claude --plugin-dir ./plugins/smarthr-design-system
 ```
 
-## 詳細
+### 再生成
 
-- ロードマップ: 親リポジトリ Notion 「smarthr-ui × AIエージェント プラグイン検討」を参照
+```sh
+pnpm --filter ./scripts/generate-skills generate
+```
+
+### バリデーション
+
+```sh
+pnpm --filter ./scripts/generate-skills validate
+```
+
+### 関連ドキュメント
+
 - 生成スクリプト仕様: `scripts/generate-skills/README.md`
+- checklist.yamlの運用: `CONTRIBUTING.md`の「smarthr-uiコンポーネント向けAIスキルの整備」
+- プロジェクト詳細: Notion「SmartHR Design SystemのAIコーディングエージェント向けスキルプラグイン」


### PR DESCRIPTION
## 課題・背景

プラグインの`README.md`が初期のまま更新されておらず、導入方法やスキル構成の説明が実態とズレていた。Notionの「SmartHR Design SystemのAIコーディングエージェント向けスキルプラグイン」の内容を踏まえ、簡潔に整理し直した。

## やったこと
- 導入方法（Claude Code / Cursor）のマーケットプレイス経由の手順を追加
- スキルの3層構成（Props・eslintルール・チェックリスト）を表形式で明記
- Progressive Disclosureパターンへの言及を追加
- 開発者向け情報（ローカル確認・再生成・バリデーション）を整理
- 古くなった「ロードマップ」表記を削除し、関連ドキュメントへのリンクを更新

## やらなかったこと
- `scripts/generate-skills/README.md`の更新（別ブランチで対応予定）

## 動作確認
- 画面変更なし（ドキュメントのみの変更）

## キャプチャ

画面変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)