### PR TITLE
marketplace.jsonのバージョンを0.5.1に更新

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "smarthr-design-system",
       "source": "./plugins/smarthr-design-system",
       "description": "SmartHR Design System の使い方ガイド。AI コーディングエージェントが smarthr-ui のコンポーネントを正しく選択し、props を間違えず、デザインシステムのレイアウト・パターンに沿った実装をするための知識集。",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "design-system",
       "keywords": ["smarthr", "smarthr-ui", "design-system", "react", "component-library"]
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "smarthr-design-system",
       "source": "./plugins/smarthr-design-system",
       "description": "SmartHR Design System の使い方ガイド。AI コーディングエージェントが smarthr-ui のコンポーネントを正しく選択し、props を間違えず、デザインシステムのレイアウト・パターンに沿った実装をするための知識集。",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "design-system",
       "keywords": ["smarthr", "smarthr-ui", "design-system", "react", "component-library"]
     }


### PR DESCRIPTION
## 課題・背景

PR #2179 でplugin.jsonのバージョンを0.5.0→0.5.1に更新した際、marketplace.jsonの更新が漏れていた。

## やったこと
- `.claude-plugin/marketplace.json`のバージョンを0.5.1に更新
- `.cursor-plugin/marketplace.json`のバージョンを0.5.1に更新

## やらなかったこと
- なし

## 動作確認
- リポジトリ内のバージョン文字列を検索し、0.5.0の残りがないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)