### PR TITLE
docs(calendar): 内部部品の説明で DatePicker に非推奨を明示（M8層2対応 + CI動作確認）

### DIFF
--- a/src/content/articles/products/components/calendar/checklist.yaml
+++ b/src/content/articles/products/components/calendar/checklist.yaml
@@ -1,3 +1,5 @@
 items:
   # 動作確認
-  - text: 動作確認用のダミー項目です。severity と source_section を欠落させて validate を失敗させます
+  - severity: avoid
+    text: Calendarは単独で利用せず、DatePickerやWarekiPickerの内部部品としてのみ利用する
+    source_section: 動作確認

--- a/src/content/articles/products/components/calendar/checklist.yaml
+++ b/src/content/articles/products/components/calendar/checklist.yaml
@@ -1,0 +1,3 @@
+items:
+  # 動作確認
+  - text: 動作確認用のダミー項目です。severity と source_section を欠落させて validate を失敗させます

--- a/src/content/articles/products/components/calendar/checklist.yaml
+++ b/src/content/articles/products/components/calendar/checklist.yaml
@@ -1,5 +1,0 @@
-items:
-  # 動作確認
-  - severity: avoid
-    text: Calendarは単独で利用せず、DatePickerやWarekiPickerの内部部品としてのみ利用する
-    source_section: 動作確認

--- a/src/content/articles/products/components/calendar/index.mdx
+++ b/src/content/articles/products/components/calendar/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Calendar'
-description: 'カレンダーを表示し日付を選択するためのコンポーネントです。基本的にDatePickerやWarekiPickerの内部部品として使われるため、単独では使用しません。'
+description: 'カレンダーを表示し日付を選択するためのコンポーネントです。基本的にWarekiPickerやDatePicker（非推奨）の内部部品として使われるため、単独では使用しません。'
 ---
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 
-カレンダーを表示し日付を選択するためのコンポーネントです。基本的に[DatePicker](/products/components/date-picker/)や[WarekiPicker](/products/components/wareki-picker/)の内部部品として使われるため、単独では使用しません。
+カレンダーを表示し日付を選択するためのコンポーネントです。基本的に[WarekiPicker](/products/components/wareki-picker/)や[DatePicker](/products/components/date-picker/)（非推奨）の内部部品として使われるため、単独では使用しません。
 
 <ComponentStory name="Calendar" />
 


### PR DESCRIPTION
## 課題・背景

M8 層2 静的監査で、Calendar の説明文が非推奨コンポーネント `DatePicker` に言及している点を検出しました。読者に非推奨であることが伝わらないため修正します。

あわせて、M7 Phase 4 でマージした CI（validate-skills / generate-skills）の実挙動を、本 PR で初めて通しで確認します（後述「動作確認」）。

## やったこと

- `calendar/index.mdx` の説明文（frontmatter `description` + 本文 lead）で `DatePicker` に「（非推奨）」を明記し、推奨される `WarekiPicker` を先に記載するよう順序を調整（事実関係は維持）

## やらなかったこと

- `DatePicker` 自体の扱い変更（非推奨化は別途対応済み）
- 他コンポーネントの同種言及の洗い出し（必要なら別 PR）
- checklist.yaml の更新（Calendar は対象外。下記参照）

## 動作確認

- ローカルで diff を確認
- 説明文の変更が SKILL ドキュメント（`plugins/.../skills/Calendar.md`）に再生成反映されることを想定
- CI 動作確認（本 PR の主目的の一つ）:
  - validate / coverage / checklist-sync が PR 上で起動するか
  - checklist-sync は **fail 見込み**（Calendar に checklist.yaml が無いため）→ `skip-checklist-update` ラベルで pass に変わるか
  - マージ後に generate-skills が発火し、再生成物を **skill-bot App が App トークンで main へ直接 push** できるか（Ruleset bypass_mode: always）
  - その自動再生成コミットの committer が **skill-bot[bot] 名義**になっているか

## checklist.yaml の更新

- [x] generate-checklist SKILL の判定でスキップ対象だった（理由: Calendar は内部部品で単独使用しないため Layer 3 使い分けチェックリスト対象外）→ `skip-checklist-update` ラベルを付与

## キャプチャ

|Before|After|
| --- | --- |
| 基本的にDatePickerやWarekiPickerの内部部品として使われるため、単独では使用しません。 | 基本的にWarekiPickerやDatePicker（非推奨）の内部部品として使われるため、単独では使用しません。 |
