### PR TITLE
refactor: From Vite 6, the modern Sass API is used by default

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -41,10 +41,6 @@ export default defineConfig({
     css: {
       preprocessorOptions: {
         scss: {
-          // Deprecation [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
-          // を出ないようにするために sass-embedded を指定
-          // 参考: https://retrorocket.biz/archives/fix-scss-deprecate-with-astro-v4
-          api: 'modern-compiler',
           loadPaths: ['src'],
           // media query での出し分けのための mixin をグローバルで使えるように
           additionalData: `@use "styles/mixin.scss" as *;`,


### PR DESCRIPTION
完全な外部の人からのPRがNGでしたらcloseしてください。コミットメッセージとブランチ名は開発ルールがわからなかったので適当です。

## 課題・背景

- Vite 6以降、[デフォルトでSass modern APIを使用するため](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/#bundlers)、Astro 6であれば  `css.preprocessorOptions.scss.api` の指定は不要です。
  - `SassPreprocessorOptions` にないプロパティなので、指定するとTypeScriptのプロパティチェックでエラーが出ます。

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと

- 不要な設定とコメントを削除しました。

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと

新人研修用かと思いましたので、以下は手元で直すだけにとどめています。

- `package.json` に足りていないパッケージがあり、`pnpm install`しただけだとbuildが通らない。
- ドキュメントと実装が食い違っている箇所がある。
- lintでエラーが出ている箇所がある。

<!--
e.g.
- 見た目の調整
-->

## 動作確認

- `pnpm dev`の目視と、`pnpm build` して `dist/_astro` のdiffを取って差分がないことを確認しました。

## checklist.yaml の更新

<!--
コンポーネントの index.mdx を変更/追加した場合のみチェックしてください。
詳細は CONTRIBUTING.md「smarthr-ui コンポーネント向け AI スキルの整備」を参照。
-->

- [ ] checklist.yaml を新規作成 or 更新した
- [ ] generate-checklist SKILL の判定でスキップ対象だった（理由: ）→ `skip-checklist-update` ラベルを付与
- [ ] index.mdx の変更が軽微（typo / description のみ等）→ `skip-checklist-update` ラベルを付与
- [ ] index.mdx の変更なし

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
