### PR TITLE
fix: LiveEditorでfocus trapされないように修正

### DIFF
--- a/src/components/CodeBlock/LiveContainer.tsx
+++ b/src/components/CodeBlock/LiveContainer.tsx
@@ -155,7 +155,7 @@ export default function LiveContainer({ code, language, scope, noIframe, withSty
                 <div className={sharedStyles.preContainer}>
                   <CopyButton text={code || ''} />
                   {/* @ts-expect-error -- LiveEditorの型定義が正しくないようなので、エラーを無視。 https://github.com/FormidableLabs/react-live/pull/234 */}
-                  <LiveEditor padding={0} />
+                  <LiveEditor padding={0} tabMode="focus" />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 課題・背景

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

MDX の Live Editor でフォーカストラップが発生しており、キーボードユーザーがページ内の他のコンテンツへ移動できない状態になっていました

## やったこと
ページ内の Live Editor にフォーカスが移動した後も、キーボード操作でページ内の他の要素へ移動できるように修正しました。

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- n/a

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->
live editorがあるページでキーボードでフォカストラップされないことが確認できます

## checklist.yaml の更新

<!--
コンポーネントの index.mdx を変更/追加した場合のみチェックしてください。
詳細は CONTRIBUTING.md「smarthr-ui コンポーネント向け AI スキルの整備」を参照。
-->

- [ ] checklist.yaml を新規作成 or 更新した
- [ ] generate-checklist SKILL の判定でスキップ対象だった（理由: ）→ `skip-checklist-update` ラベルを付与
- [ ] index.mdx の変更が軽微（typo / description のみ等）→ `skip-checklist-update` ラベルを付与
- [x] index.mdx の変更なし

## キャプチャ

### BEFORE

タブキーではインデントされてlive editorから出れなくなってしまってる

https://github.com/user-attachments/assets/39ff677f-fa73-4b85-9096-af9eb78c1466



### AFTER

タブキー次のフォーカス可能な要素に移動ができる

https://github.com/user-attachments/assets/3fcffeeb-bc38-4eb3-b981-fc1bc135b382




<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
