### PR TITLE
Internationalization関連のページへの古いリンクからのリダイレクトを直したい

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -80,7 +80,8 @@
 /accessibility/link-text /accessibility/insight/link-text
 /accessibility/low-vision /accessibility/insight/low-vision
 /accessibility/low-vision-check-list/* /accessibility/insight/low-vision-check-list/:splat
-/accessibility/multilingual /accessibility/multilingual-guidelines
+/accessibility/multilingual /accessibility/multilingual-standards/
+/accessibility/insight/multilingual /accessibility/multilingual-standards/
 /accessibility/yasashii-nihongo/* /accessibility/insight/yasashii-nihongo/:splat
 /accessibility/status/* /accessibility/standards-and-process/status/:splat
 /products/design-process/usability-test/* /products/usability/usability-test/:splat


### PR DESCRIPTION
## 課題・背景

古いページが一時的に`insights` の下に配置されている状態でGoogleにインデックスされてしまい、今はエラーになっている。
それをちゃんとリダイレクトしたい。

## やったこと
- redirectに古いリンクも追記
- 宛先を変更した

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 他は何も触っていない

<!--
e.g.
- 見た目の調整
-->

## 動作確認
不要

## checklist.yaml の更新

<!--
コンポーネントの index.mdx を変更/追加した場合のみチェックしてください。
詳細は CONTRIBUTING.md「smarthr-ui コンポーネント向け AI スキルの整備」を参照。
-->

- [ ] checklist.yaml を新規作成 or 更新した
- [ ] generate-checklist SKILL の判定でスキップ対象だった（理由: ）→ `skip-checklist-update` ラベルを付与
- [ ] index.mdx の変更が軽微（typo / description のみ等）→ `skip-checklist-update` ラベルを付与
- [x] index.mdx の変更なし

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
