### PR TITLE
色のトークンの記述を更新

### DIFF
--- a/src/components/IndexNav/index.tsx
+++ b/src/components/IndexNav/index.tsx
@@ -22,8 +22,9 @@ export default function IndexNav({ targetId, headings, ignoreH3Nav = false }: Pr
       const target = document.getElementById(targetId);
       if (!target) return;
 
-      const headingList = Array.from(target.querySelectorAll('h2, h3')).filter(
-        (element) => !(element.tagName === 'H3' && ignoreH3Nav),
+      // getNestedHeadings と同じ条件で見出しを集める
+      const headingList = Array.from(target.querySelectorAll('h2, h3, h4[data-index-nav]')).filter(
+        (element) => !(element.tagName !== 'H2' && ignoreH3Nav),
       );
 
       const _currentHeading = headingList.find((element, index) => {

--- a/src/components/article/TokenTitle.astro
+++ b/src/components/article/TokenTitle.astro
@@ -1,0 +1,67 @@
+---
+import { FaLinkIcon } from 'smarthr-ui';
+
+type Props = {
+  name: string;
+};
+
+const { name } = Astro.props;
+
+// トークン名をそのままフラグメント識別子にする（例: #TEXT_DISABLED）
+const id = name;
+---
+
+{/* data-index-nav: ページ内目次（IndexNav）に含める h4 であることを示す */}
+<h4 class="wrapper" id={id} data-index-nav>
+  <a href={`#${id}`}>
+    <code>{name}</code>
+    <FaLinkIcon className="icon" />
+  </a>
+</h4>
+
+<style lang="scss">
+  /*
+   * 記事本文の見出しスタイル（ArticleLayout の `.mdxStyleWrapper[…] h4`）を打ち消したいため、
+   * 属性セレクタを併記して詳細度を上げている
+   */
+  .wrapper[data-index-nav] {
+    /* 表のセル内で使うため、大きい文字サイズと上マージンを打ち消す */
+    margin-block: 0;
+    font-size: var(--font-size-18);
+    line-height: 1.5;
+    font-weight: normal;
+    scroll-margin-top: 80px;
+
+    a {
+      /*
+       * inline ではトークン名が長いときにアイコンだけが次の行に折り返され、
+       * 非表示（visibility: hidden）のまま空行になってしまうため inline-flex にする
+       */
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      color: inherit;
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        code {
+          text-decoration: underline;
+        }
+
+        .icon {
+          visibility: visible;
+        }
+      }
+    }
+
+    code {
+      font-size: inherit;
+    }
+
+    .icon {
+      visibility: hidden;
+      font-size: var(--font-size-14);
+    }
+  }
+</style>

--- a/src/content/articles/products/design-tokens/color.mdx
+++ b/src/content/articles/products/design-tokens/color.mdx
@@ -452,7 +452,7 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 以下の場合に使います。
 
 - 画面内で強調させたい最も重要な操作要素の背景色
-- 選択状態を表すための背景色・線
+- 選択状態を表すための背景色、線
 
 コンポーネント内部での使用例：variant propsが`primary`の[Button](/products/components/button) の背景色、選択状態の[Checkbox](/products/components/checkbox/)の背景色
 
@@ -464,7 +464,7 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 以下の場合に使います。
 
-- 視覚的グルーピングに使う背景色
+- 視覚的グルーピングのための矩形の背景色
 - 操作可能な状態を示すための背景色
 
 コンポーネント内部での使用例：[Base](/products/components/base/)の背景色、[Dialog](/products/components/dialog/)の背景色、操作可能な状態の[Checkbox](/products/components/checkbox/)の背景色
@@ -482,15 +482,15 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 #### 使用上の注意
 
-警告時（削除前などのアクション前）には`WARNING_YELLOW`を使ってください。
+エラー状態や破壊的操作ではないが、注意を促す警告には`WARNING_YELLOW`を使ってください。
 
 ### `WARNING_YELLOW`
 
-警告を示す要素の背景色、線の色に使います。
+警告を示す要素の背景色、線に使います。
 
 #### 使用上の注意
 
-削除の実行アクションには`DANGER`を使ってください。
+エラー状態や、破壊的な操作を示す場合には`DANGER`を使ってください。
 
 ### `TEXT_BLACK`
 
@@ -503,32 +503,27 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 ### `TEXT_GREY`
 
-本文に対して補足として扱う文字の色に使います。
+以下の場合に使います。
 
-コンポーネント内部での使用例：[DefinitionList](/products/components/definition-list/)の文字の色、[Heading](/products/components/heading/)の文字の色
+- 本文に対しての補足の文字色
+- 文字の階層や強弱を文字の大きさ（ジャンプ率）で表現しづらい場合の文字色
 
-#### 使用上の注意
-
-通常の文字の色には`TEXT_BLACK`を使ってください。
+コンポーネント内部での使用例：[DefinitionList](/products/components/definition-list/)の文字色、[Heading](/products/components/heading/)の文字色
 
 ### `TEXT_LINK`
 
 以下の場合に使います。
 
-- リンクを表す文字の色、下線
-- インタラクション可能な要素の文字の色
+- リンクを表す文字色、下線
+- インタラクション可能な要素の文字色
 
-コンポーネント内部での使用例：variant propsが`tertiary`の[Button](/products/components/button/)の文字の色
-
-#### 使用上の注意
-
-文字やアイコン以外の塗りつぶしや線には`MAIN`を使ってください。
+コンポーネント内部での使用例：[TextLink](/products/components/text-link/)、variant propsが`tertiary`の[Button](/products/components/button/)の文字色
 
 ### `TEXT_DISABLED`
 
-非活性状態を表す文字の色に使います。
+非活性状態を表す文字色に使います。
 
-コンポーネント内部での使用例：非活性状態の[Button](/products/components/button/)の文字の色
+コンポーネント内部での使用例：非活性状態の[Button](/products/components/button/)の文字色
 
 #### 使用上の注意
 
@@ -538,9 +533,9 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 ### `TEXT_WHITE`
 
-`DANGER`、`MAIN`などの強い塗りの上にある文字の色に使います。
+`DANGER`、`MAIN`などの強い塗りの上にある文字色に使います。
 
-コンポーネント内部での使用例：variant propsが`primary`の[Button](/products/components/button/)の文字の色
+コンポーネント内部での使用例：variant propsが`primary`の[Button](/products/components/button/)の文字色
 
 #### 使用上の注意
 
@@ -554,7 +549,7 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 ### `ACTION_BACKGROUND`
 
-操作する要素を配置するための視覚的グルーピングとして、前後の背景に`WHITE`、`OVER_BACKGROUND`、`COLUMN`などが使われており差別化するときに使います。
+周囲の要素の背景色に`WHITE`、`OVER_BACKGROUND`、`COLUMN`などがすでに使われている状況で、操作要素を配置する領域をそれらと区別したい場合に背景色として使います。
 
 コンポーネント内部での使用例：[Table](/products/components/table)のTableBulkActionAreaの背景色
 
@@ -567,7 +562,7 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 以下の場合に使います。
 
 - テーブルヘッダーの背景色
-- 視覚的グルーピングの`OVER_BACKGROUND`以上のネストが必要なとき
+- 視覚的グルーピングの`COLUMN`以上のネストが必要なとき
 
 コンポーネント内部での使用例：[Table](/products/components/table)のテーブルヘッダーの背景色
 

--- a/src/content/articles/products/design-tokens/color.mdx
+++ b/src/content/articles/products/design-tokens/color.mdx
@@ -451,89 +451,84 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 以下の場合に使います。
 
-- 画面内で最も重要度が高く、ユーザーのアクションを促す要素
-  - [Button](/products/components/button) などの主要なコンポーネントの背景色、枠線
-  - [Checkbox](/products/components/checkbox/)、[RadioButton](/products/components/radio-button/) などの選択状態（アクティブ）を表す背景色、枠線
-  - ユーザーのアクション（操作）を促す主要なアイコン
-- フォーカスリングの枠線
+- 画面内で強調させたい最も重要な操作要素の背景色
+- 選択状態を表すための背景色・線
+
+コンポーネント内部での使用例：variant propsが`primary`の[Button](/products/components/button) の背景色、選択状態の[Checkbox](/products/components/checkbox/)の背景色
 
 #### 使用上の注意
 
-- テキストには使わない
-  - `TEXT_LINK`を使ってください。
+テキストには`TEXT_LINK`を使ってください。
 
 ### `WHITE`
 
-[Base](/products/components/base/)、[Dialog](/products/components/dialog/)などのコンポーネントの背景色に使います。
+以下の場合に使います。
+
+- 視覚的グルーピングに使う背景色
+- 操作可能な状態を示すための背景色
+
+コンポーネント内部での使用例：[Base](/products/components/base/)の背景色、[Dialog](/products/components/dialog/)の背景色、操作可能な状態の[Checkbox](/products/components/checkbox/)の背景色
 
 #### 使用上の注意
 
-- テキストには使わない
-  - `TEXT_WHITE`を使ってください。
+テキストには`TEXT_WHITE`を使ってください。
 
 ### `DANGER`
 
 以下の場合に使います。
 
-- エラー時のコンポーネントの文字色、背景色、線
-- 削除など破壊的な変更を行なうアイコン、ボタン、文字色、背景色、枠線
+- エラー状態を示す要素の背景色、線
+- 削除など破壊的な操作を示す要素の背景色、線
 
 #### 使用上の注意
 
-- 警告時には使わない（削除前などのアクション前）
-  - `WARNING_YELLOW`を使ってください。
+警告時（削除前などのアクション前）には`WARNING_YELLOW`を使ってください。
 
 ### `WARNING_YELLOW`
 
-以下の場合に使います。
-
-- 警告時のコンポーネントの背景色、WarningIconなどのアイコン
-- 削除やUndoなどの破壊的アクションをする前の注意に使う
+警告を示す要素の背景色、線の色に使います。
 
 #### 使用上の注意
 
-- 削除の実行アクションには使わない
-  - `DANGER`を使ってください。
+削除の実行アクションには`DANGER`を使ってください。
 
 ### `TEXT_BLACK`
 
-以下の場合に使います。
-
-- 基本的な文字の色、アイコンの色
-- [Button](/products/components/button/)などのコンポーネントの通常時の文字の色
+標準的な[見出し](https://smarthr.design/products/design-tokens/typography/#h3-2)、[段落テキスト](https://smarthr.design/products/design-tokens/typography/#h3-3)、[ラベルテキスト](https://smarthr.design/products/design-tokens/typography/#h3-4)に使います。
+**特別な意図がない場合にはこのトークンを選択します**。
 
 #### 使用上の注意
 
-- ジャンプ率が文字の大きさで確保できないときは使わない
-  - `TEXT_GREY`を使うことでジャンプ率を確保してください。
+ジャンプ率が文字の大きさで確保できないときは`TEXT_GREY`を使ってください。
 
 ### `TEXT_GREY`
 
-以下の場合に使います。
+本文に対して補足として扱う文字の色に使います。
 
-- `TEXT_BLACK`からジャンプ率を確保するときに使う文字の色、アイコンの色
-- [DefinitionList](/products/components/definition-list/)、[Heading](/products/components/heading/)などのジャンプ率を確保した見出しコンポーネントの文字の色
+コンポーネント内部での使用例：[DefinitionList](/products/components/definition-list/)の文字の色、[Heading](/products/components/heading/)の文字の色
 
 #### 使用上の注意
 
-- 通常の文字の色には使わない
-  - 基本的には`TEXT_BLACK`を使ってください。
+通常の文字の色には`TEXT_BLACK`を使ってください。
 
 ### `TEXT_LINK`
 
 以下の場合に使います。
 
-- リンクを表す文字の色、下線、アイコン
-- [Button](/products/components/button/)の`tertiary`の文字の色
+- リンクを表す文字の色、下線
+- インタラクション可能な要素の文字の色
+
+コンポーネント内部での使用例：variant propsが`tertiary`の[Button](/products/components/button/)の文字の色
 
 #### 使用上の注意
 
-- 文字やアイコン以外の塗りつぶしや線には使わない
-  - `MAIN`を使ってください。
+文字やアイコン以外の塗りつぶしや線には`MAIN`を使ってください。
 
 ### `TEXT_DISABLED`
 
-[Button](/products/components/button/)、[Input](/products/components/input/)などの非活性状態を表す文字の色に使います。
+非活性状態を表す文字の色に使います。
+
+コンポーネント内部での使用例：非活性状態の[Button](/products/components/button/)の文字の色
 
 #### 使用上の注意
 
@@ -543,50 +538,46 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 ### `TEXT_WHITE`
 
-[Button](/products/components/button/)などの`DANGER`、`MAIN`に対して使う文字、アイコンの色に使います。
+`DANGER`、`MAIN`などの強い塗りの上にある文字の色に使います。
+
+コンポーネント内部での使用例：variant propsが`primary`の[Button](/products/components/button/)の文字の色
 
 #### 使用上の注意
 
-- 線や塗りには使わない
-  - `WHITE`を使ってください。
+線や塗りには`WHITE`を使ってください。
 
 ### `BORDER`
 
-以下の場合に使います。
+線の色に使います。
 
-- 基本的な枠線・罫線の色
-- [Button](/products/components/button/)などの通常時のコンポーネントの枠線
+コンポーネント内部での使用例：variant propsが`secondary`の[Button](/products/components/button/)の枠線の色
 
 ### `ACTION_BACKGROUND`
 
-以下の場合に使います。
+操作する要素を配置するための視覚的グルーピングとして、前後の背景に`WHITE`、`OVER_BACKGROUND`、`COLUMN`などが使われており差別化するときに使います。
 
-- `TableBulkActionArea`の背景色
-- `OVER_BACKGROUND`の上に置く色として使われることもあります
+コンポーネント内部での使用例：[Table](/products/components/table)のTableBulkActionAreaの背景色
 
 #### 使用上の注意
 
-- テーブルヘッダーの背景色では使わない
-  - `HEAD`を使ってください。
+テーブルヘッダーの背景色には`HEAD`を使ってください。
 
 ### `HEAD`
 
 以下の場合に使います。
 
 - テーブルヘッダーの背景色
-- 視覚的グルーピングの`COLUMN`以上のネストが必要なとき
+- 視覚的グルーピングの`OVER_BACKGROUND`以上のネストが必要なとき
+
+コンポーネント内部での使用例：[Table](/products/components/table)のテーブルヘッダーの背景色
 
 #### 使用上の注意
 
-- TableBulkActionAreaでは使わない
-  - `ACTION_BACKGROUND`を使ってください。
+TableBulkActionAreaには`ACTION_BACKGROUND`を使ってください。
 
 ### `OVER_BACKGROUND`
 
-以下の場合に使います。
-
-- `BACKGROUND`の上で使う囲み色（要素をグルーピングするときに使う色）
-- hover時に`COLUMN`を使っている場合の背景色
+`BACKGROUND`の上で使う囲み色（要素をグルーピングするときに使う色）に使います。
 
 #### 使用上の注意
 
@@ -597,27 +588,25 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 ### `COLUMN`
 
-以下の場合に使います。
+`WHITE`の上で使う囲み色（要素をグルーピングするときに使う色）に使います。
 
-- `WHITE`の上で使う囲み色（要素をグルーピングするときに使う色）
-- [DropZone](/products/components/drop-zone/)、[SideNav](/products/components/side-nav/)などのコンポーネントの背景色
+コンポーネント内部での使用例：[DropZone](/products/components/drop-zone/)の背景色、[SideNav](/products/components/side-nav/)の背景色
 
 #### 使用上の注意
 
 - 画面の背景色では使わない
   - `BACKGROUND`を使ってください。
 - `BACKGROUND`の上では使わない
-  - 色が`BACKGROUND`と同じため、`BACKGROUND`の上にはおかないでください。
+  - 色が`BACKGROUND`と同じなため、`BACKGROUND`の上にはおかないでください。
   - `OVER_BACKGROUND`を使ってください。
 
 ### `BACKGROUND`
 
-画面の背景色に使います。
+ページの最背面の背景色に使います。
 
 #### 使用上の注意
 
-- `WHITE`の上では使わない
-  - `COLUMN`を使ってください。
+`WHITE`の上では`COLUMN`を使ってください。
 
 ### `OVERLAY`
 
@@ -633,7 +622,7 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 ### `TRANSPARENT`
 
-コンポーネントの枠線などを消すときに使います。
+例外的に、コンポーネントの枠線などを消すときに使います。
 
 ### `CHART_COLOR`
 

--- a/src/content/articles/products/design-tokens/color.mdx
+++ b/src/content/articles/products/design-tokens/color.mdx
@@ -6,6 +6,8 @@ order: 1
 
 import ColorPalette from '@/components/article/ColorPalette.astro'
 import ColorPalettesWrapper from '@/components/article/ColorPaletteWrapper.astro'
+import { Table, Td, Th, BaseColumn, ResponseMessage } from 'smarthr-ui'
+import TableWrapper from '@/components/article/TableWrapper.astro'
 
 プロダクトを構成するために必要な最低限の色を定義しています。
 
@@ -15,102 +17,627 @@ import ColorPalettesWrapper from '@/components/article/ColorPaletteWrapper.astro
 
 ## セマンティックトークン
 
-### メイン
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>トークン名</Th>
+        <Th>色</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td><code>MAIN</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#0077c7', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#0077c7</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,119,199)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>WHITE</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#fff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#fff</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,255,255)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>DANGER</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#e01e5a', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#e01e5a</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(224,30,90)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>WARNING_YELLOW</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#ffcc17', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#ffcc17</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,204,23)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_BLACK</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#23221e', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#23221e</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(35,34,30)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_GREY</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#706d65', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#706d65</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(112,109,101)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_LINK</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#0071c1', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#0071c1</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,113,193)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_DISABLED</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#c1bdb7', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#c1bdb7</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(193,189,183)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>TEXT_WHITE</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#fff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#fff</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,255,255)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>BORDER</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#d6d3d0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#d6d3d0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(214,211,208)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>ACTION_BACKGROUND</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#d6d3d0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#d6d3d0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(214,211,208)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>HEAD</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#edebe8', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#edebe8</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(237,235,232)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>OVER_BACKGROUND</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#f2f1f0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#f2f1f0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(242,241,240)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>COLUMN</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#f8f7f6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#f8f7f6</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(248,247,246)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>BACKGROUND</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#f8f7f6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#f8f7f6</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(248,247,246)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>OVERLAY</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: 'rgba(3,3,2,0.15)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>rgba(3,3,2,0.15)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>SCRIM</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: 'rgba(3,3,2,0.5)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>rgba(3,3,2,0.5)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>TRANSPARENT</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: 'rgba(255,255,255,0)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>rgba(255,255,255,0)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_1</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#00c4cc', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#00c4cc</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,196,204)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_2</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#ffcd00', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#ffcd00</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,205,0)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_3</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#ff9100', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#ff9100</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,145,0)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_4</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#e65537', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#e65537</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(230,85,55)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_5</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#2d4b9b', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#2d4b9b</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(45,75,155)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_6</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#2d7df0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#2d7df0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(45,125,240)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_7</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#69d7ff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#69d7ff</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(105,215,255)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_8</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#4bb47d', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#4bb47d</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(75,180,125)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_9</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#05878c', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#05878c</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(5,135,140)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>CHART_COLOR_10</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#005a64', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#005a64</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,90,100)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_1</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#a1e3e6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#a1e3e6</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(161,227,230)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_2</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#00c4cc', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#00c4cc</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,196,204)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_3</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#00acb3', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#00acb3</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,172,179)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_4</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#05868b', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#05868b</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(5,134,139)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_5</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#055659', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#055659</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(5,86,89)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>SINGLE_CHART_COLOR_6</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#033033', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#033033</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(3,48,51)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+      <tr>
+        <Td><code>OTHER_CHART_COLOR</code></Td>
+        <Td>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <div style={{ width: '48px', height: '48px', backgroundColor: '#ebebeb', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+            <div>
+              <div>#ebebeb</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(235,235,235)</div>
+            </div>
+          </div>
+        </Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
 
-プライマリーカラーである`MAIN`と、コンポーネントのベースカラーとなる`WHITE`を定めています。
+### `MAIN`
 
-プライマリーカラーは、プロダクトの印象を司る箇所に使います。具体的な使用箇所は、各コンポーネントを参照してください。
+以下の場合に使います。
 
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#0077c7" colorName="MAIN" description="プライマリーカラー（プロダクトの印象を司る箇所に使う）" />
-  <ColorPalette colorValue="#fff" colorName="WHITE" description="コンポーネントの背景色（Baseコンポーネントなど）" />
-</ColorPalettesWrapper>
+- 画面内で最も重要度が高く、ユーザーのアクションを促す要素
+  - [Button](/products/components/button) などの主要なコンポーネントの背景色、枠線
+  - [Checkbox](/products/components/checkbox/)、[RadioButton](/products/components/radio-button/) などの選択状態（アクティブ）を表す背景色、枠線
+  - ユーザーのアクション（操作）を促す主要なアイコン
+- フォーカスリングの枠線
 
+#### 使用上の注意
 
-### アクセント
-コンテキストに応じた色を定めています。
+- テキストには使わない
+  - `TEXT_LINK`を使ってください。
 
-`MAIN`と合わせて、ユーザーのメインアクションや、アクションに対する結果、ヘルプの表示、オブジェクトの状態を表します。
+### `WHITE`
 
-具体的な使用箇所は、各コンポーネントを参照してください。
+[Base](/products/components/base/)、[Dialog](/products/components/dialog/)などのコンポーネントの背景色に使います。
 
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#e01e5a" colorName="DANGER" description="エラー色（操作前に、個人情報の流出や金銭的／法的リスクなど、強い警告をする場合も含む）" />
-  <ColorPalette colorValue="#ffcc17" colorName="WARNING_YELLOW" description="警告色（削除やUndoなどの破壊的アクションをする前の注意に使う）。必ずTEXT_BLACKと組み合わせて使う" />
-</ColorPalettesWrapper>
+#### 使用上の注意
 
+- テキストには使わない
+  - `TEXT_WHITE`を使ってください。
 
-### 文字
+### `DANGER`
 
-テキストの状態に応じた文字の色を定めています。
+以下の場合に使います。
 
-強調などの文字スタイルは、[タイポグラフィ](/products/design-tokens/typography/)を参照してください。
+- エラー時のコンポーネントの文字色、背景色、線
+- 削除など破壊的な変更を行なうアイコン、ボタン、文字色、背景色、枠線
 
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#23221e" colorName="TEXT_BLACK" description="基本的な文字の色" />
-  <ColorPalette colorValue="#706d65" colorName="TEXT_GREY" description="TEXT_BLACKからジャンプ率を確保するときに使う文字の色" />
-  <ColorPalette colorValue="#0071c1" colorName="TEXT_LINK" description="リンクを表す文字の色" />
-  <ColorPalette colorValue="#c1bdb7" colorName="TEXT_DISABLED" description="disabled状態を表す文字の色" />
-  <ColorPalette colorValue="#fff" colorName="TEXT_WHITE" description="暗い地色やMAINに対して使う文字の色" />
-</ColorPalettesWrapper>
+#### 使用上の注意
 
+- 警告時には使わない（削除前などのアクション前）
+  - `WARNING_YELLOW`を使ってください。
 
-### コンポーネント
+### `WARNING_YELLOW`
 
-コンポーネントを構成する要素に必要な色を定めています。
+以下の場合に使います。
 
-具体的な使用箇所は、各コンポーネントを参照してください。
+- 警告時のコンポーネントの背景色、WarningIconなどのアイコン
+- 削除やUndoなどの破壊的アクションをする前の注意に使う
 
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#d6d3d0" colorName="BORDER" description="枠線・罫線の色" />
-  <ColorPalette colorValue="#d6d3d0" colorName="ACTION_BACKGROUND" description="TableBulkActionAreaの背景色" />
-  <ColorPalette colorValue="#edebe8" colorName="HEAD" description="テーブルヘッダーの背景色" />
-  <ColorPalette colorValue="#f2f1f0" colorName="OVER_BACKGROUND" description="BACKGROUNDの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette colorValue="#f8f7f6" colorName="COLUMN" description="WHITEの上で使う囲み色（要素をグルーピングするときに使う色）" />
-  <ColorPalette colorValue="#f8f7f6" colorName="BACKGROUND" description="画面の背景色" />
-  <ColorPalette colorValue="rgba(3,3,2,0.15)" colorName="OVERLAY" description="ボタンなどhover時に重ねる色" />
-  <ColorPalette colorValue="rgba(3,3,2,0.5)" colorName="SCRIM" description="モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色" />
-  <ColorPalette colorValue="rgba(255,255,255,0)" colorName="TRANSPARENT" description="デザインツールだけで使う専用スタイル。コンポーネントの枠線などを消すときのAppearanceに使用" />
-</ColorPalettesWrapper>
+#### 使用上の注意
 
+- 削除の実行アクションには使わない
+  - `DANGER`を使ってください。
 
-### チャート（グラフ）
+### `TEXT_BLACK`
 
-チャートで使用する色を定めています。チャートには指定された順序で色を使用します。
+以下の場合に使います。
 
-#### 多色チャート
+- 基本的な文字の色、アイコンの色
+- [Button](/products/components/button/)などのコンポーネントの通常時の文字の色
 
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#00c4cc" colorName="CHART_COLOR_1" description="多色チャート色1" />
-  <ColorPalette colorValue="#ffcd00" colorName="CHART_COLOR_2" description="多色チャート色2" />
-  <ColorPalette colorValue="#ff9100" colorName="CHART_COLOR_3" description="多色チャート色3" />
-  <ColorPalette colorValue="#e65537" colorName="CHART_COLOR_4" description="多色チャート色4" />
-  <ColorPalette colorValue="#2d4b9b" colorName="CHART_COLOR_5" description="多色チャート色5" />
-  <ColorPalette colorValue="#2d7df0" colorName="CHART_COLOR_6" description="多色チャート色6" />
-  <ColorPalette colorValue="#69d7ff" colorName="CHART_COLOR_7" description="多色チャート色7" />
-  <ColorPalette colorValue="#4bb47d" colorName="CHART_COLOR_8" description="多色チャート色8" />
-  <ColorPalette colorValue="#05878c" colorName="CHART_COLOR_9" description="多色チャート色9" />
-  <ColorPalette colorValue="#005a64" colorName="CHART_COLOR_10" description="多色チャート色10" />
-</ColorPalettesWrapper>
+#### 使用上の注意
 
-#### 単色チャート
+- ジャンプ率が文字の大きさで確保できないときは使わない
+  - `TEXT_GREY`を使うことでジャンプ率を確保してください。
 
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#a1e3e6" colorName="SINGLE_CHART_COLOR_1" description="単色チャート色1" />
-  <ColorPalette colorValue="#00c4cc" colorName="SINGLE_CHART_COLOR_2" description="単色チャート色2" />
-  <ColorPalette colorValue="#00acb3" colorName="SINGLE_CHART_COLOR_3" description="単色チャート色3" />
-  <ColorPalette colorValue="#05868b" colorName="SINGLE_CHART_COLOR_4" description="単色チャート色4" />
-  <ColorPalette colorValue="#055659" colorName="SINGLE_CHART_COLOR_5" description="単色チャート色5" />
-  <ColorPalette colorValue="#033033" colorName="SINGLE_CHART_COLOR_6" description="単色チャート色6" />
-</ColorPalettesWrapper>
+### `TEXT_GREY`
 
-#### その他のチャート色
+以下の場合に使います。
 
-その他のチャート色は、チャート内の「その他」を示す項目に使います。
+- `TEXT_BLACK`からジャンプ率を確保するときに使う文字の色、アイコンの色
+- [DefinitionList](/products/components/definition-list/)、[Heading](/products/components/heading/)などのジャンプ率を確保した見出しコンポーネントの文字の色
 
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="#ebebeb" colorName="OTHER_CHART_COLOR" description="「その他」項目に使う色" />
-</ColorPalettesWrapper>
+#### 使用上の注意
+
+- 通常の文字の色には使わない
+  - 基本的には`TEXT_BLACK`を使ってください。
+
+### `TEXT_LINK`
+
+以下の場合に使います。
+
+- リンクを表す文字の色、下線、アイコン
+- [Button](/products/components/button/)の`tertiary`の文字の色
+
+#### 使用上の注意
+
+- 文字やアイコン以外の塗りつぶしや線には使わない
+  - `MAIN`を使ってください。
+
+### `TEXT_DISABLED`
+
+[Button](/products/components/button/)、[Input](/products/components/input/)などの非活性状態を表す文字の色に使います。
+
+#### 使用上の注意
+
+- 単なるグレーテキストの場合は使わない
+  - ジャンプ率を確保したいだけのときは`TEXT_GREY`を使ってください。
+- 線や塗りの色には使わない
+
+### `TEXT_WHITE`
+
+[Button](/products/components/button/)などの`DANGER`、`MAIN`に対して使う文字、アイコンの色に使います。
+
+#### 使用上の注意
+
+- 線や塗りには使わない
+  - `WHITE`を使ってください。
+
+### `BORDER`
+
+以下の場合に使います。
+
+- 基本的な枠線・罫線の色
+- [Button](/products/components/button/)などの通常時のコンポーネントの枠線
+
+### `ACTION_BACKGROUND`
+
+以下の場合に使います。
+
+- `TableBulkActionArea`の背景色
+- `OVER_BACKGROUND`の上に置く色として使われることもあります
+
+#### 使用上の注意
+
+- テーブルヘッダーの背景色では使わない
+  - `HEAD`を使ってください。
+
+### `HEAD`
+
+以下の場合に使います。
+
+- テーブルヘッダーの背景色
+- 視覚的グルーピングの`COLUMN`以上のネストが必要なとき
+
+#### 使用上の注意
+
+- TableBulkActionAreaでは使わない
+  - `ACTION_BACKGROUND`を使ってください。
+
+### `OVER_BACKGROUND`
+
+以下の場合に使います。
+
+- `BACKGROUND`の上で使う囲み色（要素をグルーピングするときに使う色）
+- hover時に`COLUMN`を使っている場合の背景色
+
+#### 使用上の注意
+
+- 画面の背景色では使わない
+  - `BACKGROUND`を使ってください。
+- [Base](/products/components/base/)の中など、`WHITE`の上では使わない
+  - `COLUMN`を使ってください。
+
+### `COLUMN`
+
+以下の場合に使います。
+
+- `WHITE`の上で使う囲み色（要素をグルーピングするときに使う色）
+- [DropZone](/products/components/drop-zone/)、[SideNav](/products/components/side-nav/)などのコンポーネントの背景色
+
+#### 使用上の注意
+
+- 画面の背景色では使わない
+  - `BACKGROUND`を使ってください。
+- `BACKGROUND`の上では使わない
+  - 色が`BACKGROUND`と同じため、`BACKGROUND`の上にはおかないでください。
+  - `OVER_BACKGROUND`を使ってください。
+
+### `BACKGROUND`
+
+画面の背景色に使います。
+
+#### 使用上の注意
+
+- `WHITE`の上では使わない
+  - `COLUMN`を使ってください。
+
+### `OVERLAY`
+
+<BaseColumn className="shr-mt-1">
+  <ResponseMessage status="info">現在`OVERLAY`は使用されていません。</ResponseMessage>
+</BaseColumn>
+
+ボタンなどhover時に重ねる色に使います。
+
+### `SCRIM`
+
+モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色に使います。
+
+### `TRANSPARENT`
+
+コンポーネントの枠線などを消すときに使います。
+
+### `CHART_COLOR`
+
+チャート（グラフ）内の色に使います。
 
 
 ## プリミティブトークン

--- a/src/content/articles/products/design-tokens/color.mdx
+++ b/src/content/articles/products/design-tokens/color.mdx
@@ -8,6 +8,7 @@ import ColorPalette from '@/components/article/ColorPalette.astro'
 import ColorPalettesWrapper from '@/components/article/ColorPaletteWrapper.astro'
 import { Table, Td, Th, BaseColumn, ResponseMessage } from 'smarthr-ui'
 import TableWrapper from '@/components/article/TableWrapper.astro'
+import TokenTitle from '@/components/article/TokenTitle.astro'
 
 プロダクトを構成するために必要な最低限の色を定義しています。
 
@@ -17,611 +18,486 @@ import TableWrapper from '@/components/article/TableWrapper.astro'
 
 ## セマンティックトークン
 
+### メイン
+
+プライマリーカラーである`MAIN`と、コンポーネントのベースカラーとなる`WHITE`を定めています。
+
+プライマリーカラーは、プロダクトの印象を司る箇所に使います。具体的な使用箇所は、各コンポーネントを参照してください。
+
 <TableWrapper>
   <Table>
     <thead>
       <tr>
-        <Th>トークン名</Th>
-        <Th>色</Th>
+        <Th>トークン名/色</Th>
+        <Th>利用用途</Th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <Td><code>MAIN</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#0077c7', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#0077c7', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
             <div>
+              <TokenTitle name="MAIN" />
               <div>#0077c7</div>
               <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,119,199)</div>
             </div>
           </div>
         </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          - 画面内で強調させたい最も重要な操作要素の背景色
+          - 選択状態を表すための背景色、線
+
+          コンポーネント内部での使用例：
+          - variant propsが`primary`の[Button](/products/components/button) の背景色
+          - 選択状態の[Checkbox](/products/components/checkbox/)の背景色
+        </Td>
       </tr>
       <tr>
-        <Td><code>WHITE</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#fff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#fff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
             <div>
+              <TokenTitle name="WHITE" />
               <div>#fff</div>
               <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,255,255)</div>
             </div>
           </div>
         </Td>
-      </tr>
-      <tr>
-        <Td><code>DANGER</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#e01e5a', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#e01e5a</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(224,30,90)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>WARNING_YELLOW</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#ffcc17', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#ffcc17</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,204,23)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>TEXT_BLACK</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#23221e', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#23221e</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(35,34,30)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>TEXT_GREY</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#706d65', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#706d65</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(112,109,101)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>TEXT_LINK</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#0071c1', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#0071c1</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,113,193)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>TEXT_DISABLED</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#c1bdb7', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#c1bdb7</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(193,189,183)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>TEXT_WHITE</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#fff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#fff</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,255,255)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>BORDER</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#d6d3d0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#d6d3d0</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(214,211,208)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>ACTION_BACKGROUND</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#d6d3d0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#d6d3d0</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(214,211,208)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>HEAD</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#edebe8', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#edebe8</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(237,235,232)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>OVER_BACKGROUND</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#f2f1f0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#f2f1f0</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(242,241,240)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>COLUMN</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#f8f7f6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#f8f7f6</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(248,247,246)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>BACKGROUND</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#f8f7f6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#f8f7f6</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(248,247,246)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>OVERLAY</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: 'rgba(3,3,2,0.15)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>rgba(3,3,2,0.15)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>SCRIM</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: 'rgba(3,3,2,0.5)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>rgba(3,3,2,0.5)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>TRANSPARENT</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: 'rgba(255,255,255,0)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>rgba(255,255,255,0)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_1</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#00c4cc', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#00c4cc</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,196,204)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_2</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#ffcd00', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#ffcd00</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,205,0)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_3</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#ff9100', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#ff9100</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,145,0)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_4</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#e65537', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#e65537</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(230,85,55)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_5</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#2d4b9b', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#2d4b9b</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(45,75,155)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_6</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#2d7df0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#2d7df0</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(45,125,240)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_7</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#69d7ff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#69d7ff</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(105,215,255)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_8</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#4bb47d', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#4bb47d</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(75,180,125)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_9</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#05878c', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#05878c</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(5,135,140)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>CHART_COLOR_10</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#005a64', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#005a64</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,90,100)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>SINGLE_CHART_COLOR_1</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#a1e3e6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#a1e3e6</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(161,227,230)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>SINGLE_CHART_COLOR_2</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#00c4cc', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#00c4cc</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,196,204)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>SINGLE_CHART_COLOR_3</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#00acb3', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#00acb3</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,172,179)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>SINGLE_CHART_COLOR_4</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#05868b', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#05868b</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(5,134,139)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>SINGLE_CHART_COLOR_5</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#055659', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#055659</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(5,86,89)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>SINGLE_CHART_COLOR_6</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#033033', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#033033</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(3,48,51)</div>
-            </div>
-          </div>
-        </Td>
-      </tr>
-      <tr>
-        <Td><code>OTHER_CHART_COLOR</code></Td>
-        <Td>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <div style={{ width: '48px', height: '48px', backgroundColor: '#ebebeb', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' }}></div>
-            <div>
-              <div>#ebebeb</div>
-              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(235,235,235)</div>
-            </div>
-          </div>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          - 視覚的グルーピングのための矩形の背景色
+          - 操作可能な状態を示すための背景色
+
+          コンポーネント内部での使用例：
+          - [Base](/products/components/base/)の背景色
+          - [Dialog](/products/components/dialog/)の背景色
+          - 操作可能な状態の[Checkbox](/products/components/checkbox/)の背景色
+
+          使用上の注意：
+          - テキストには`TEXT_WHITE`を使ってください。
         </Td>
       </tr>
     </tbody>
   </Table>
 </TableWrapper>
 
-### `MAIN`
-
-以下の場合に使います。
-
-- 画面内で強調させたい最も重要な操作要素の背景色
-- 選択状態を表すための背景色、線
-
-コンポーネント内部での使用例：variant propsが`primary`の[Button](/products/components/button) の背景色、選択状態の[Checkbox](/products/components/checkbox/)の背景色
-
-#### 使用上の注意
-
-テキストには`TEXT_LINK`を使ってください。
-
-### `WHITE`
-
-以下の場合に使います。
-
-- 視覚的グルーピングのための矩形の背景色
-- 操作可能な状態を示すための背景色
-
-コンポーネント内部での使用例：[Base](/products/components/base/)の背景色、[Dialog](/products/components/dialog/)の背景色、操作可能な状態の[Checkbox](/products/components/checkbox/)の背景色
-
-#### 使用上の注意
-
-テキストには`TEXT_WHITE`を使ってください。
-
-### `DANGER`
-
-以下の場合に使います。
-
-- エラー状態を示す要素の背景色、線
-- 削除など破壊的な操作を示す要素の背景色、線
-
-#### 使用上の注意
-
-エラー状態や破壊的操作ではないが、注意を促す警告には`WARNING_YELLOW`を使ってください。
-
-### `WARNING_YELLOW`
-
-警告を示す要素の背景色、線に使います。
-
-#### 使用上の注意
-
-エラー状態や、破壊的な操作を示す場合には`DANGER`を使ってください。
-
-### `TEXT_BLACK`
-
-標準的な[見出し](https://smarthr.design/products/design-tokens/typography/#h3-2)、[段落テキスト](https://smarthr.design/products/design-tokens/typography/#h3-3)、[ラベルテキスト](https://smarthr.design/products/design-tokens/typography/#h3-4)に使います。
-**特別な意図がない場合にはこのトークンを選択します**。
-
-#### 使用上の注意
-
-ジャンプ率が文字の大きさで確保できないときは`TEXT_GREY`を使ってください。
-
-### `TEXT_GREY`
-
-以下の場合に使います。
-
-- 本文に対しての補足の文字色
-- 文字の階層や強弱を文字の大きさ（ジャンプ率）で表現しづらい場合の文字色
-
-コンポーネント内部での使用例：[DefinitionList](/products/components/definition-list/)の文字色、[Heading](/products/components/heading/)の文字色
-
-### `TEXT_LINK`
-
-以下の場合に使います。
-
-- リンクを表す文字色、下線
-- インタラクション可能な要素の文字色
-
-コンポーネント内部での使用例：[TextLink](/products/components/text-link/)、variant propsが`tertiary`の[Button](/products/components/button/)の文字色
-
-### `TEXT_DISABLED`
-
-非活性状態を表す文字色に使います。
-
-コンポーネント内部での使用例：非活性状態の[Button](/products/components/button/)の文字色
-
-#### 使用上の注意
-
-- 単なるグレーテキストの場合は使わない
-  - ジャンプ率を確保したいだけのときは`TEXT_GREY`を使ってください。
-- 線や塗りの色には使わない
-
-### `TEXT_WHITE`
-
-`DANGER`、`MAIN`などの強い塗りの上にある文字色に使います。
-
-コンポーネント内部での使用例：variant propsが`primary`の[Button](/products/components/button/)の文字色
-
-#### 使用上の注意
-
-線や塗りには`WHITE`を使ってください。
-
-### `BORDER`
-
-線の色に使います。
-
-コンポーネント内部での使用例：variant propsが`secondary`の[Button](/products/components/button/)の枠線の色
-
-### `ACTION_BACKGROUND`
-
-周囲の要素の背景色に`WHITE`、`OVER_BACKGROUND`、`COLUMN`などがすでに使われている状況で、操作要素を配置する領域をそれらと区別したい場合に背景色として使います。
-
-コンポーネント内部での使用例：[Table](/products/components/table)のTableBulkActionAreaの背景色
-
-#### 使用上の注意
-
-テーブルヘッダーの背景色には`HEAD`を使ってください。
-
-### `HEAD`
-
-以下の場合に使います。
-
-- テーブルヘッダーの背景色
-- 視覚的グルーピングの`COLUMN`以上のネストが必要なとき
-
-コンポーネント内部での使用例：[Table](/products/components/table)のテーブルヘッダーの背景色
-
-#### 使用上の注意
-
-TableBulkActionAreaには`ACTION_BACKGROUND`を使ってください。
-
-### `OVER_BACKGROUND`
-
-`BACKGROUND`の上で使う囲み色（要素をグルーピングするときに使う色）に使います。
-
-#### 使用上の注意
-
-- 画面の背景色では使わない
-  - `BACKGROUND`を使ってください。
-- [Base](/products/components/base/)の中など、`WHITE`の上では使わない
-  - `COLUMN`を使ってください。
-
-### `COLUMN`
-
-`WHITE`の上で使う囲み色（要素をグルーピングするときに使う色）に使います。
-
-コンポーネント内部での使用例：[DropZone](/products/components/drop-zone/)の背景色、[SideNav](/products/components/side-nav/)の背景色
-
-#### 使用上の注意
-
-- 画面の背景色では使わない
-  - `BACKGROUND`を使ってください。
-- `BACKGROUND`の上では使わない
-  - 色が`BACKGROUND`と同じなため、`BACKGROUND`の上にはおかないでください。
-  - `OVER_BACKGROUND`を使ってください。
-
-### `BACKGROUND`
-
-ページの最背面の背景色に使います。
-
-#### 使用上の注意
-
-`WHITE`の上では`COLUMN`を使ってください。
-
-### `OVERLAY`
-
-<BaseColumn className="shr-mt-1">
-  <ResponseMessage status="info">現在`OVERLAY`は使用されていません。</ResponseMessage>
-</BaseColumn>
-
-ボタンなどhover時に重ねる色に使います。
-
-### `SCRIM`
-
-モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色に使います。
-
-### `TRANSPARENT`
-
-例外的に、コンポーネントの枠線などを消すときに使います。
-
-### `CHART_COLOR`
-
-チャート（グラフ）内の色に使います。
+### アクセント
+
+コンテキストに応じた色を定めています。
+
+`MAIN`と合わせて、ユーザーのメインアクションや、アクションに対する結果、ヘルプの表示、オブジェクトの状態を表します。
+
+具体的な使用箇所は、各コンポーネントを参照してください。
+
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>トークン名/色</Th>
+        <Th>利用用途</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#e01e5a', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="DANGER" />
+              <div>#e01e5a</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(224,30,90)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          - エラー状態を示す要素の背景色、線
+          - 削除など破壊的な操作を示す要素の背景色、線
+
+          使用上の注意：
+          - エラー状態や破壊的操作ではないが、注意を促す警告には`WARNING_YELLOW`を使ってください。
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#ffcc17', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="WARNING_YELLOW" />
+              <div>#ffcc17</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,204,23)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          警告を示す要素の背景色、線に使います。
+
+          使用上の注意：
+
+          - エラー状態や、破壊的な操作を示す場合には`DANGER`を使ってください。
+        </Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
+
+### 文字
+
+テキストの状態に応じた文字の色を定めています。
+
+強調などの文字スタイルは、[タイポグラフィ](/products/design-tokens/typography/)を参照してください。
+
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>トークン名/色</Th>
+        <Th>利用用途</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#23221e', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="TEXT_BLACK" />
+              <div>#23221e</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(35,34,30)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          標準的な[見出し](https://smarthr.design/products/design-tokens/typography/#h3-2)、[段落テキスト](https://smarthr.design/products/design-tokens/typography/#h3-3)、[ラベルテキスト](https://smarthr.design/products/design-tokens/typography/#h3-4)に使います。
+          **特別な意図がない場合にはこのトークンを選択します**。
+
+          使用上の注意：
+          - ジャンプ率が文字の大きさで確保できないときは`TEXT_GREY`を使ってください。
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#706d65', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="TEXT_GREY" />
+              <div>#706d65</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(112,109,101)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          - 本文に対しての補足の文字色
+          - 文字の階層や強弱を文字の大きさ（ジャンプ率）で表現しづらい場合の文字色
+
+          コンポーネント内部での使用例：
+          - [DefinitionList](/products/components/definition-list/)の文字色
+          - [Heading](/products/components/heading/)の文字色
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#0071c1', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="TEXT_LINK" />
+              <div>#0071c1</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(0,113,193)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          - リンクを表す文字色、下線
+          - インタラクション可能な要素の文字色
+
+          コンポーネント内部での使用例：
+          - [TextLink](/products/components/text-link/)
+          - variant propsが`tertiary`の[Button](/products/components/button/)の文字色
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#c1bdb7', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="TEXT_DISABLED" />
+              <div>#c1bdb7</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(193,189,183)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          非活性状態を表す文字色に使います。
+
+          コンポーネント内部での使用例：
+          - 非活性状態の[Button](/products/components/button/)の文字色
+
+          使用上の注意：
+          - 単なるグレーテキストの場合は使わない
+            - ジャンプ率を確保したいだけのときは`TEXT_GREY`を使ってください。
+          - 線や塗りの色には使わない
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#fff', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="TEXT_WHITE" />
+              <div>#fff</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(255,255,255)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          `DANGER`、`MAIN`などの強い塗りの上にある文字色に使います。
+
+          コンポーネント内部での使用例：
+          - variant propsが`primary`の[Button](/products/components/button/)の文字色
+
+          使用上の注意：
+          - 線や塗りには`WHITE`を使ってください。
+        </Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
+
+### 線
+
+線の色を定めています。
+具体的な使用箇所は、各コンポーネントを参照してください。
+
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>トークン名/色</Th>
+        <Th>利用用途</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#d6d3d0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="BORDER" />
+              <div>#d6d3d0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(214,211,208)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          線の色に使います。
+
+          コンポーネント内部での使用例：
+          - variant propsが`secondary`の[Button](/products/components/button/)の枠線の色
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: 'rgba(255,255,255,0)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="TRANSPARENT" />
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgba(255,255,255,0)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          例外的に、コンポーネントの枠線などを消すときに使います。
+        </Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
+
+### 背景
+
+背景の色を定めています。
+具体的な使用箇所は、各コンポーネントを参照してください。
+
+<TableWrapper>
+  <Table>
+    <thead>
+      <tr>
+        <Th>トークン名/色</Th>
+        <Th>利用用途</Th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#d6d3d0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="ACTION_BACKGROUND" />
+              <div>#d6d3d0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(214,211,208)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          周囲の要素の背景色に`WHITE`、`OVER_BACKGROUND`、`COLUMN`などがすでに使われている状況で、操作要素を配置する領域をそれらと区別したい場合に背景色として使います。
+
+          コンポーネント内部での使用例：
+          - [Table](/products/components/table)のTableBulkActionRowの背景色
+
+          使用上の注意：
+          - テーブルヘッダーの背景色には`HEAD`を使ってください。
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#edebe8', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="HEAD" />
+              <div>#edebe8</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(237,235,232)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          - テーブルヘッダーの背景色
+          - 視覚的グルーピングの`COLUMN`以上のネストが必要なとき
+
+          コンポーネント内部での使用例：
+          - [Table](/products/components/table)のテーブルヘッダーの背景色
+
+          使用上の注意：
+          - TableBulkActionRowには`ACTION_BACKGROUND`を使ってください。
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#f2f1f0', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="OVER_BACKGROUND" />
+              <div>#f2f1f0</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(242,241,240)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          `BACKGROUND`の上で使う囲み色（要素をグルーピングするときに使う色）に使います。
+
+          使用上の注意：
+          - 画面の背景色では使わない
+            - `BACKGROUND`を使ってください。
+          - [Base](/products/components/base/)の中など、`WHITE`の上では使わない
+            - `COLUMN`を使ってください。
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#f8f7f6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="COLUMN" />
+              <div>#f8f7f6</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(248,247,246)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          `WHITE`の上で使う囲み色（要素をグルーピングするときに使う色）に使います。
+
+          コンポーネント内部での使用例：
+          - [DropZone](/products/components/drop-zone/)の背景色
+          - [SideNav](/products/components/side-nav/)の背景色
+
+          使用上の注意：
+          - 画面の背景色では使わない
+            - `BACKGROUND`を使ってください。
+          - `BACKGROUND`の上では使わない
+            - 色が`BACKGROUND`と同じなため、`BACKGROUND`の上にはおかないでください。
+            - `OVER_BACKGROUND`を使ってください。
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: '#f8f7f6', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="BACKGROUND" />
+              <div>#f8f7f6</div>
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgb(248,247,246)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          ページの最背面の背景色に使います。
+
+          使用上の注意：
+          - `WHITE`の上では`COLUMN`を使ってください。
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: 'rgba(3,3,2,0.15)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="OVERLAY" />
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgba(3,3,2,0.15)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          ボタンなどhover時に重ねる色に使います。
+          <BaseColumn className="shr-mt-1">
+            <ResponseMessage status="info">現在`OVERLAY`は使用されていません。</ResponseMessage>
+          </BaseColumn>
+        </Td>
+      </tr>
+      <tr>
+        <Td style={{ verticalAlign: 'top', padding: '20px 16px' }}>
+          <div>
+            <div style={{ width: '126px', height: '80px', backgroundColor: 'rgba(3,3,2,0.5)', flexShrink: 0, boxShadow: 'rgb(235, 236, 240) 0 0 0 1.2px' , marginBottom: '8px' }}></div>
+            <div>
+              <TokenTitle name="SCRIM" />
+              <div style={{ fontSize: '0.857rem', color: '#706d65' }}>rgba(3,3,2,0.5)</div>
+            </div>
+          </div>
+        </Td>
+        <Td style={{ verticalAlign: 'top', padding: '12px 16px' }}>
+          モーダル表示時のスクリム（モーダルの下の画面に重ねる）の色に使います。
+        </Td>
+      </tr>
+    </tbody>
+  </Table>
+</TableWrapper>
+
+### チャート（グラフ）
+
+チャートで使用する色を定めています。チャートには指定された順序で色を使用します。
+
+#### 多色チャート
+
+<ColorPalettesWrapper>
+  <ColorPalette colorValue="#00c4cc" colorName="CHART_COLOR_1" description="多色チャート色1"/>
+  <ColorPalette colorValue="#ffcd00" colorName="CHART_COLOR_2" description="多色チャート色2"/>
+  <ColorPalette colorValue="#ff9100" colorName="CHART_COLOR_3" description="多色チャート色3" />
+  <ColorPalette colorValue="#e65537" colorName="CHART_COLOR_4" description="多色チャート色4" />
+  <ColorPalette colorValue="#2d4b9b" colorName="CHART_COLOR_5" description="多色チャート色5" />
+  <ColorPalette colorValue="#2d7df0" colorName="CHART_COLOR_6" description="多色チャート色6" />
+  <ColorPalette colorValue="#69d7ff" colorName="CHART_COLOR_7" description="多色チャート色7" />
+  <ColorPalette colorValue="#4bb47d" colorName="CHART_COLOR_8" description="多色チャート色8" />
+  <ColorPalette colorValue="#05878c" colorName="CHART_COLOR_9" description="多色チャート色9"/>
+  <ColorPalette colorValue="#005a64" colorName="CHART_COLOR_10" description="多色チャート色10"/>
+</ColorPalettesWrapper>
+
+#### 単色チャート
+
+<ColorPalettesWrapper>
+  <ColorPalette colorValue="#a1e3e6" colorName="SINGLE_CHART_COLOR_1" description="単色チャート色1"/>
+  <ColorPalette colorValue="#00c4cc" colorName="SINGLE_CHART_COLOR_2" description="単色チャート色2"/>
+  <ColorPalette colorValue="#00acb3" colorName="SINGLE_CHART_COLOR_3" description="単色チャート色3" />
+  <ColorPalette colorValue="#05868b" colorName="SINGLE_CHART_COLOR_4" description="単色チャート色4" />
+  <ColorPalette colorValue="#055659" colorName="SINGLE_CHART_COLOR_5" description="単色チャート色5" />
+  <ColorPalette colorValue="#033033" colorName="SINGLE_CHART_COLOR_6" description="単色チャート色6" />
+</ColorPalettesWrapper>
 
 
 ## プリミティブトークン
@@ -729,7 +605,7 @@ TableBulkActionAreaには`ACTION_BACKGROUND`を使ってください。
   <ColorPalette colorValue="#fff" colorName="新" />
 </ColorPalettesWrapper>
 
-### コンポーネント
+### 線
 #### BORDER
 
 <ColorPalettesWrapper>
@@ -737,6 +613,14 @@ TableBulkActionAreaには`ACTION_BACKGROUND`を使ってください。
   <ColorPalette colorValue="#d6d6d6" colorName="旧" />
 </ColorPalettesWrapper>
 
+#### TRANSPARENT
+
+<ColorPalettesWrapper>
+  <ColorPalette colorValue="rgba(255,255,255,0)" colorName="新 ※変更なし" />
+  <ColorPalette colorValue="rgba(255,255,255,0)" colorName="旧" />
+</ColorPalettesWrapper>
+
+### 背景
 #### ACTION_BACKGROUND（新のみ）
 
 <ColorPalettesWrapper>
@@ -781,11 +665,4 @@ TableBulkActionAreaには`ACTION_BACKGROUND`を使ってください。
 <ColorPalettesWrapper>
   <ColorPalette colorValue="rgba(3,3,3,0.4)" colorName="新" />
   <ColorPalette colorValue="rgba(0,0,0,0.5)" colorName="旧" />
-</ColorPalettesWrapper>
-
-#### TRANSPARENT
-
-<ColorPalettesWrapper>
-  <ColorPalette colorValue="rgba(255,255,255,0)" colorName="新 ※変更なし" />
-  <ColorPalette colorValue="rgba(255,255,255,0)" colorName="旧" />
 </ColorPalettesWrapper>

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -331,6 +331,12 @@ const nextSidebarItem = currentPageIndex < sidebarItemLength ? (flatArticleMetaI
         :global(ol:first-child) {
           margin-block-start: 0;
         }
+
+        /* 「使用上の注意：」などのリード文に続くリストは、リード文とひと続きに見せる */
+        :global(p + ul),
+        :global(p + ol) {
+          margin-block-start: 0;
+        }
       }
     }
 

--- a/src/lib/getNestedHeadings.ts
+++ b/src/lib/getNestedHeadings.ts
@@ -12,7 +12,7 @@ export type NestedHeading = {
 };
 
 /**
- * MDXファイル内の見出し (h2, h3) を取得する
+ * MDXファイル内の見出し (h2, h3, および data-index-nav が付いた h4) を取得する
  *
  * article.render() の戻りに含まれる `headings` には Markdown 部分の見出ししか含まれていません
  * MDX内に埋め込めまれたコンポーネントによって作成された見出しも含めて取得するためにこの関数を使用します
@@ -43,16 +43,18 @@ export async function getNestedHeadings(content: AstroComponentFactory, ignoreH3
   const contentHtml = await container.renderToString(content);
 
   // HTML をパースしてh2, h3タグを取得
+  // h4は数が多くなりがちなため、data-index-nav が付いているものだけを対象にする
   const doc = parse(contentHtml);
-  const headingTags = doc.querySelectorAll(ignoreH3Nav ? 'h2' : 'h2, h3');
+  const headingTags = doc.querySelectorAll(ignoreH3Nav ? 'h2' : 'h2, h3, h4[data-index-nav]');
 
   // ネストした形に整形
   const nestedHeadings: NestedHeading[] = [];
 
   headingTags.forEach((heading, index) => {
-    const depth = heading.tagName === 'H2' ? 2 : 3;
+    const depth = heading.tagName === 'H2' ? 2 : heading.tagName === 'H3' ? 3 : 4;
     const slug = heading.getAttribute('id') ?? `${heading.tagName.toLowerCase()}-c${index}`;
-    const text = heading.textContent;
+    // 見出しの中でアイコンなどを組み合わせている場合に前後の空白が入るため、trimする
+    const text = heading.textContent.trim();
 
     if (depth === 2) {
       nestedHeadings.push({
@@ -63,18 +65,33 @@ export async function getNestedHeadings(content: AstroComponentFactory, ignoreH3
       return;
     }
 
-    if (depth === 3 && !ignoreH3Nav) {
-      // 親となる階層がない場合、仮の親となるアイテムをpushする
-      if (!nestedHeadings[nestedHeadings.length - 1]) {
-        nestedHeadings.push({ slug: '', children: [] });
-      }
+    if (ignoreH3Nav) return;
 
-      nestedHeadings[nestedHeadings.length - 1].children.push({
+    // 親となる階層がない場合、仮の親となるアイテムをpushする
+    if (!nestedHeadings[nestedHeadings.length - 1]) {
+      nestedHeadings.push({ slug: '', children: [] });
+    }
+    const h2Children = nestedHeadings[nestedHeadings.length - 1].children;
+
+    if (depth === 3) {
+      h2Children.push({
         slug,
         text,
         children: [],
       });
+      return;
     }
+
+    // depth === 4
+    if (!h2Children[h2Children.length - 1]) {
+      h2Children.push({ slug: '', children: [] });
+    }
+
+    h2Children[h2Children.length - 1].children.push({
+      slug,
+      text,
+      children: [],
+    });
   });
 
   return nestedHeadings;


### PR DESCRIPTION
## 課題・背景

AIリーダブル用に合わせて色のトークンの記述を見直して更新

## やったこと
- セマンティックトークンの色の記述を変更・追加
- セマンティックトークンの一覧をテーブル形式に変更（別PLのものを流用）

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 

<!--
e.g.
- 見た目の調整
-->

## 動作確認
<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->

## checklist.yaml の更新

<!--
コンポーネントの index.mdx を変更/追加した場合のみチェックしてください。
詳細は CONTRIBUTING.md「smarthr-ui コンポーネント向け AI スキルの整備」を参照。
-->

- [ ] checklist.yaml を新規作成 or 更新した
- [ ] generate-checklist SKILL の判定でスキップ対象だった（理由: ）→ `skip-checklist-update` ラベルを付与
- [ ] index.mdx の変更が軽微（typo / description のみ等）→ `skip-checklist-update` ラベルを付与
- [ ] index.mdx の変更なし

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
