### PR TITLE
docs: checklist.yaml 更新の PR テンプレ／CONTRIBUTING を充実

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,14 +30,15 @@ e.g.
 ## checklist.yaml の更新
 
 <!--
-コンポーネントの index.mdx を変更/追加した場合のみチェックしてください。
+コンポーネントの index.mdx / _components/*.mdx を変更・追加した場合は、まず生成/更新スキル（generate-checklist / update-checklist）を実行してください。更新要否はスキルが判定します（typo・description のみの軽微な変更でも、まずスキルを実行）。
+index.mdx を変更していない場合は、この節を削除して構いません。
+差分が出なかった理由（スキルの報告内容）を description に記載するとレビューしやすくなります。
 詳細は CONTRIBUTING.md「smarthr-ui コンポーネント向け AI スキルの整備」を参照。
 -->
 
-- [ ] checklist.yaml を新規作成 or 更新した
-- [ ] generate-checklist SKILL の判定でスキップ対象だった（理由: ）→ `skip-checklist-update` ラベルを付与
-- [ ] index.mdx の変更が軽微（typo / description のみ等）→ `skip-checklist-update` ラベルを付与
-- [ ] index.mdx の変更なし
+- [ ] checklist.yaml に差分が出たコンポーネントは、その差分を PR に含めた
+- [ ] 一部のコンポーネントで差分が出なかった（差分あり・なしが混在）→ `skip-checklist-update` ラベルを付与
+- [ ] すべてのコンポーネントで差分が出なかった → `skip-checklist-update` ラベルを付与
 
 ## キャプチャ
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,9 +183,11 @@ PRを出すと、GitHub Actionsで以下が自動実行されます。
 
 `checklist-sync`が失敗した場合の対応は以下のいずれか:
 
-1. ローカルで`checklist.yaml`を更新（または新規作成）してPRに追加
-2. `generate-checklist` SKILLの判定で「スキップ対象」だった場合 → スキップ理由をPR descriptionに書き、PRに `skip-checklist-update` ラベルを付与
-3. typo / description のみ等の軽微修正で更新不要な場合 → PRに `skip-checklist-update` ラベルを付与
+まず対象コンポーネントで生成/更新スキル（`generate-checklist` / `update-checklist`）を実行します。typo・descriptionのみの軽微な変更でも、更新要否は作業者が判断せずスキルに委ねます。実行結果に応じて以下のいずれかで対応します。
+
+1. スキルが差分を出した場合 → その`checklist.yaml`をPRに含める
+2. スキルを実行したが差分が出なかった場合（既存項目でカバー済み、または新規コンポーネントでスキップ判定）→ 差分が出なかった理由をPR descriptionに書き、PRに `skip-checklist-update` ラベルを付与
+3. 複数コンポーネントを変更し、一部は差分あり・一部は差分なしが混在する場合 → 差分ありの`checklist.yaml`をPRに含めたうえで、`checklist-sync`は現状PR単位判定のため `skip-checklist-update` ラベルを付与する。このときラベルは「更新がない」意味ではなく「CIをPR単位でスキップする」ためのもの。差分が出なかったコンポーネントと理由はPR descriptionに明記し、レビュアーが妥当性を確認できるようにする
 
 **スキップ判定の典型例**（`generate-checklist` SKILLが自動判定します）:
 


### PR DESCRIPTION
## 課題・背景

複数コンポーネントを 1 PR で扱い、一部は `checklist.yaml` の差分あり・一部は差分なし（更新スキルを実行したが既存項目でカバー済み等）という**混在ケース**が、従来の PR テンプレ・CONTRIBUTING でカバーされていなかった。

実際に [#2155](https://github.com/kufu/smarthr-design-system/pull/2155) 等で発生し、`checklist-sync` CI の通し方（`skip-checklist-update` ラベルが PR 単位）と作業者の判断に迷いが出た（[Slack スレッド](https://kufuinc.slack.com/archives/C018J0A6DCH/p1781603165673389)）。

まずはテンプレ・ドキュメントの充実で運用を観察する。コンポーネント単位のスキップ宣言を CI でパースする収束案は、必要に応じて後続で検討。

## やったこと
- PR テンプレ「checklist.yaml の更新」節を再構成
  - 「まず生成/更新スキルを実行」に集約し、更新要否を作業者に判断させない（typo・description のみでもまずスキル実行）
  - 純更新 / 混在 / 純スキップの 3 パターンをチェックで明示
  - 自己矛盾していた「index.mdx の変更なし」項目を削除（変更がなければ節ごと削除する旨をコメント化）
- CONTRIBUTING の `checklist-sync` 失敗時の対応をスキル実行起点に整理し、混在ケースを追記

## やらなかったこと
- CI（`checklist-sync`）の仕組み変更。`skip-checklist-update` は現状どおり PR 単位スキップ
- コンポーネント単位スキップ宣言の CI パース（収束案）→ 運用観察後に判断

## 動作確認
- ファイル差分で確認（テンプレ・ドキュメントのみの変更でロジック影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)