### PR TITLE
docs: コンポーネントテンプレートに使い方チェックリスト節を追加

### DIFF
--- a/src/content/articles/operational-guideline/page-template/component-template.mdx
+++ b/src/content/articles/operational-guideline/page-template/component-template.mdx
@@ -23,6 +23,7 @@ order: 2
 
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
+import Checklist from '@/components/article/Checklist/Checklist.astro'
 
 コンポーネントの説明と主な利用シーンを書きます。  
 1文目には、frontmatterの`description`と同じ文を記載します。一覧ページや検索結果、AIによる索引にも使われるため、以下の書式ルールに則ってください。
@@ -198,12 +199,12 @@ import { DynamicMessageDialog } from './_components'
 主題に種類がなく、ライティングルールを書きたい場合はここに書きます。〇〇の使い方..などはこのグループに所属させます。AirTableも必要であれば埋め込めます。
 
 
-## アクセシビリティ
-主題全体に対するアクセシビリティの考え方として、特段言及したい場合は書きます。
-
-
 ## デザインパターン
 コンポーネント独自のデザインパターンがあればこのグループ内に書きます。基準サイズなどもこのセクションで書きます。
+
+
+## アクセシビリティ
+主題全体に対するアクセシビリティの考え方として、特段言及したい場合は書きます。
 
 
 ## モバイル
@@ -213,8 +214,16 @@ import { DynamicMessageDialog } from './_components'
 ただし、各セクションのなかでモバイル表示について言及するほうが都合がよい場合は、それぞれのセクションの中に書くことも問題ありません。
 
 
+## 使い方チェックリスト
+同ディレクトリの`checklist.yaml`の内容を読者向けに表示するセクションです。  
+`name`にはコンポーネント名（PascalCase。例: Button / ActionDialog）を指定します。見出しを目次に含めたい場合のみ`showHeading`を付けます。
+
+<Checklist name="Button" />
+
+
 ## Props
-コンポーネントが持つPropsを網羅して書きます。
+コンポーネントが持つPropsを網羅して書きます。  
+グループに複数のサブコンポーネント（例: Dialog 配下の DialogTrigger / DialogContent など）がある場合は、それぞれ`ComponentPropsTable`を並べ、区別のため`showTitle`を付けます。
 
 <ComponentPropsTable name="Button" />
 

--- a/src/content/articles/operational-guideline/page-template/component-template.mdx
+++ b/src/content/articles/operational-guideline/page-template/component-template.mdx
@@ -215,7 +215,7 @@ import { DynamicMessageDialog } from './_components'
 
 
 ## 使い方チェックリスト
-同ディレクトリの`checklist.yaml`の内容を読者向けに表示するセクションです。  
+同ディレクトリの`checklist.yaml`の内容を読者向けに表示するセクションです。（本文は不要です）  
 `name`にはコンポーネント名（PascalCase。例: Button / ActionDialog）を指定します。見出しを目次に含めたい場合のみ`showHeading`を付けます。
 
 <Checklist name="Button" />


### PR DESCRIPTION
## 課題・背景

使い方チェックリスト（`<Checklist />`）を checklist.yaml を持つ全コンポーネントへ展開しました（#2247 マージ済み）。今後追加される新規コンポーネントページでも同じ構成になるよう、コンポーネントページの雛形（`component-template.mdx`）にも反映します。

## やったこと

- `component-template.mdx` に「使い方チェックリスト」節（`<Checklist name="..." />`）と `Checklist` の import を追加。`## Props` の直前に配置。
- `## Props` 節に、同一グループのサブコンポーネントが複数ある場合は各 `ComponentPropsTable` を並べ、区別のため `showTitle` を付ける旨のガイドを追記。
- あわせてセクションの並びを調整（「デザインパターン」を「アクセシビリティ」の前に移動）。

## やらなかったこと

- 既存のコンポーネントページ（`products/components/**/index.mdx`）への反映は #2247 で対応済みのため本 PR では扱わない。
- テンプレートの他セクションの内容変更は行なわない。

## 動作確認

https://deploy-preview-2258--smarthr-design-system.netlify.app/operational-guideline/page-template/component-template/#h2-9

- `pnpm lint:check`（astro check）: 0 errors / 0 warnings。
- `pnpm lint:text`（textlint）: パス。
- pre-commit hook（lint-staged）通過。

## キャプチャ

|Before|After|
| --- | --- |
| テンプレートに「使い方チェックリスト」節なし | `## Props` の直前に「使い方チェックリスト」節を追加 |
