### PR TITLE
SearchBoxの例文テキストから須磨英知を削除

### DIFF
--- a/src/components/search/Search/SearchBox.tsx
+++ b/src/components/search/Search/SearchBox.tsx
@@ -45,7 +45,7 @@ function CustomSearchBox(props: UseSearchBoxProps) {
     <>
       {/* 検索インプット部分 */}
       <div className={styles.inputOuter}>
-        <p id="desc-for-search-input">例：Button、画面キャプチャ、用字用語、須磨英知など</p>
+        <p id="desc-for-search-input">例：Button、画面キャプチャ、用字用語など</p>
         <Input
           width="100%"
           prefix={<FaMagnifyingGlassIcon className={styles.searchIcon} aria-label="検索" />}


### PR DESCRIPTION
## 課題・背景
須磨英知という削除された項目が検索例に羅列されていたので削除した

https://kufuinc.slack.com/archives/C018J0A6DCH/p1783488376779879

## やったこと
SearchBoxのdesc-for-search-inputを修正

## 動作確認
https://deploy-preview-2315--smarthr-design-system.netlify.app/

## checklist.yaml の更新
実行していません

- [ ] checklist.yaml に差分が出たコンポーネントは、その差分を PR に含めた
- [ ] 一部のコンポーネントで差分が出なかった（差分あり・なしが混在）→ `skip-checklist-update` ラベルを付与
- [ ] すべてのコンポーネントで差分が出なかった → `skip-checklist-update` ラベルを付与

## キャプチャ

|Before|After|
| --- | --- |
|<img width="1728" height="808" alt="スクリーンショット 2026-07-24 14 31 12" src="https://github.com/user-attachments/assets/a3f5bf5f-714b-4eac-815f-47202763bf98" />|<img width="1728" height="809" alt="スクリーンショット 2026-07-24 14 34 38" src="https://github.com/user-attachments/assets/83dcfbc0-f3c6-42e4-9a4e-6909c594b048" />|


