### PR TITLE
fix: combobox、single-combobox、multi-comboboxのリンクを修正し、リダイレクトを追加する

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -65,6 +65,9 @@
 /products/components/dropdown-button /products/components/dropdown/dropdown-menu-button
 /products/design-patterns/dropdown-button /products/components/dropdown/dropdown-menu-button
 /products/components/dropdown/dropdown-button /products/components/dropdown/dropdown-menu-button
+/products/components/combo-box /products/components/combobox
+/products/components/combo-box/single-combo-box /products/components/combobox/single-combobox
+/products/components/combo-box/multi-combo-box /products/components/combobox/multi-combobox
 /products/resource/components /products/resource
 /concept /introduction
 /concept/about /introduction/user

--- a/src/content/articles/products/components/checkbox/index.mdx
+++ b/src/content/articles/products/components/checkbox/index.mdx
@@ -22,7 +22,7 @@ import { Cluster, Text } from 'smarthr-ui'
 チェックボックスは選択肢を複数選択できる場合に使用します。
 
 - 複数の選択肢から単一選択しかできず、表示領域に余裕がある場合は原則として[RadioButton](/products/components/radio-button/)を検討してください。
-- 選択肢が多い場合や表示領域が狭い場合は、[MultiCombobox](/products/components/combo-box/multi-combo-box/)を検討してください。
+- 選択肢が多い場合や表示領域が狭い場合は、[MultiCombobox](/products/components/combobox/multi-combobox/)を検討してください。
 
 選択操作に関わるコンポーネントの使い分けは[選択コンポーネントの使い分け](/products/design-patterns/selection-component-usage/)を参照してください。
 

--- a/src/content/articles/products/components/radio-button/index.mdx
+++ b/src/content/articles/products/components/radio-button/index.mdx
@@ -28,7 +28,7 @@ import radioButtonMobileDont from './images/radio-button-mobile-dont.png';
 
 基本的に、選択肢の中から単一の値を選択して入力させる場合は、初期状態で選択肢が一覧しやすいラジオボタンを使用します。
 
-- 選択肢のラベルテキストが長大になる場合や、選択肢が表示領域内にすべて表示しきれないほど存在する場合では、[Select](/products/components/select/)や[SingleCombobox](/products/components/combo-box/single-combo-box/)も検討します。
+- 選択肢のラベルテキストが長大になる場合や、選択肢が表示領域内にすべて表示しきれないほど存在する場合では、[Select](/products/components/select/)や[SingleCombobox](/products/components/combobox/single-combobox/)も検討します。
   - ただし選択肢の一覧性が下がり、操作の手間が増えるので、選択肢の数が不定で予測できないなどの理由がない限りはラジオボタンの使用を推奨します。
 
 選択操作に関わるコンポーネントの使い分けは[選択コンポーネントの使い分け](/products/design-patterns/selection-component-usage/)を参照してください。

--- a/src/content/articles/products/components/select/index.mdx
+++ b/src/content/articles/products/components/select/index.mdx
@@ -30,7 +30,7 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 
 ### SingleComboboxとの使い分け
 
-単一選択かつ、ユーザーに選択肢をフィルタリングさせたい場合は[SingleCombobox](/products/components/combo-box/single-combo-box/)の使用を検討してください。
+単一選択かつ、ユーザーに選択肢をフィルタリングさせたい場合は[SingleCombobox](/products/components/combobox/single-combobox/)の使用を検討してください。
 
 ### 即時反映が期待されるビューの切り替えには使わない
 

--- a/src/content/articles/products/design-patterns/access-control-setting-pattern-core-features/index.mdx
+++ b/src/content/articles/products/design-patterns/access-control-setting-pattern-core-features/index.mdx
@@ -185,7 +185,7 @@ CRUD操作の「作成」「更新」「削除」は、基本的に「閲覧」�
 
 ![スクリーンショット: 操作権限項目を条件や範囲で指定したい場合の例](./images/access-control-setting-pattern16.png)
 
-より詳細に条件や範囲を指定したい場合は、[Select](/products/components/select/)や[MultiCombobox](/products/components/combo-box/)などの使用を検討します。
+より詳細に条件や範囲を指定したい場合は、[Select](/products/components/select/)や[MultiCombobox](/products/components/combobox/)などの使用を検討します。
 
 ![スクリーンショット: ドロップダウンリストやマルチコンボボックスを使用した操作権限項目の例](./images/access-control-setting-pattern17.png)
 

--- a/src/content/articles/products/design-patterns/permissions-settings.mdx
+++ b/src/content/articles/products/design-patterns/permissions-settings.mdx
@@ -141,7 +141,7 @@ TabBarのタイトルは左から`アカウント`、`{独自オブジェクト}
 
 #### 2. アカウントの選択
 
-SmartHRのアカウントを選択します。単一選択の場合は[SingleCombobox](/products/components/combo-box/)を使ってください。複数まとめて追加する場合は[MultiCombobox](/products/components/combo-box/)を使ってください。
+SmartHRのアカウントを選択します。単一選択の場合は[SingleCombobox](/products/components/combobox/)を使ってください。複数まとめて追加する場合は[MultiCombobox](/products/components/combobox/)を使ってください。
 
 ![スクリーンショット:アカウントのSingleComboboxを開いたとき](./images/permissions-settings/permissions-settings-dialog-account.png)
 
@@ -156,7 +156,7 @@ Comboboxのパネル内の説明には`{検索対象名1}、{検索対象名2}�
 
 操作の権限の指定には、[RadioButtonPanel](/products/components/radio-button-panel/)を使用してください。
 
-**「カスタム権限」** として、操作の権限をユーザーが増やせるプロダクトもあります。この場合は[SingleCombobox](/products/components/combo-box/)や[Select](/products/components/select/)を使ってください。
+**「カスタム権限」** として、操作の権限をユーザーが増やせるプロダクトもあります。この場合は[SingleCombobox](/products/components/combobox/)や[Select](/products/components/select/)を使ってください。
 
 #### 4. 独自の権限設定
 

--- a/src/content/articles/products/design-patterns/selection-component-usage/index.mdx
+++ b/src/content/articles/products/design-patterns/selection-component-usage/index.mdx
@@ -6,7 +6,7 @@ order: 25
 
 import { BaseColumn, Stack, Heading, Text, WarningIcon } from 'smarthr-ui'
 
-選択操作に関わるコンポーネント（[MultiCombobox](/products/components/combo-box/multi-combo-box/)、[SingleCombobox](/products/components/combo-box/single-combo-box/)、[Select](/products/components/select/)、[RadioButton](/products/components/radio-button/)、[RadioButtonPanel](/products/components/radio-button-panel/)、[Checkbox](/products/components/check-box/)、[Switch](/products/components/switch/)）の使い分けの基準を定義します。
+選択操作に関わるコンポーネント（[MultiCombobox](/products/components/combobox/multi-combobox/)、[SingleCombobox](/products/components/combobox/single-combobox/)、[Select](/products/components/select/)、[RadioButton](/products/components/radio-button/)、[RadioButtonPanel](/products/components/radio-button-panel/)、[Checkbox](/products/components/check-box/)、[Switch](/products/components/switch/)）の使い分けの基準を定義します。
 
 ## 基本的な考え方
 
@@ -39,8 +39,8 @@ import { BaseColumn, Stack, Heading, Text, WarningIcon } from 'smarthr-ui'
 ### 値を複数選択できるか
 項目ごとに、選択できる値が単一か複数かによってコンポーネントを絞り込めます。
 
-* 値が複数：[MultiCombobox](/products/components/combo-box/multi-combo-box/)、[Checkbox](/products/components/check-box/) が使用できます。
-* 値が単一：[Select](/products/components/select/)、[SingleCombobox](/products/components/combo-box/single-combo-box/)、[RadioButton](/products/components/radio-button/)、[RadioButtonPanel](/products/components/radio-button-panel/)、[Switch](/products/components/switch/) などの単一選択コンポーネントを使用します。
+* 値が複数：[MultiCombobox](/products/components/combobox/multi-combobox/)、[Checkbox](/products/components/check-box/) が使用できます。
+* 値が単一：[Select](/products/components/select/)、[SingleCombobox](/products/components/combobox/single-combobox/)、[RadioButton](/products/components/radio-button/)、[RadioButtonPanel](/products/components/radio-button-panel/)、[Switch](/products/components/switch/) などの単一選択コンポーネントを使用します。
 
 ### 選択を即時反映したいか
 ユーザーの操作をシステムに反映させるタイミングで判断します。
@@ -54,23 +54,23 @@ import { BaseColumn, Stack, Heading, Text, WarningIcon } from 'smarthr-ui'
 * 5個以下：選択肢を常に一覧表示できるコンポーネントを使用します。
     * [Checkbox](/products/components/check-box/)、[RadioButton](/products/components/radio-button/)、[RadioButtonPanel](/products/components/radio-button-panel/)
 * 6個以上：選択肢をドロップダウンで表示するコンポーネントを使用します。
-    * [SingleCombobox](/products/components/combo-box/single-combo-box/)、[MultiCombobox](/products/components/combo-box/multi-combo-box/)、[Select](/products/components/select/)
+    * [SingleCombobox](/products/components/combobox/single-combobox/)、[MultiCombobox](/products/components/combobox/multi-combobox/)、[Select](/products/components/select/)
 
 以下のような場合には、代替となるコンポーネントを利用できます。
 * 選択肢は5個以下だが、選択肢を格納して画面全体のレイアウトの都合を優先したい場合
-    * [Checkbox](/products/components/check-box/) → [MultiCombobox](/products/components/combo-box/multi-combo-box/)
+    * [Checkbox](/products/components/check-box/) → [MultiCombobox](/products/components/combobox/multi-combobox/)
     * [RadioButton](/products/components/radio-button/) → [Select](/products/components/select/)
 * 選択肢は6個以上だが、すべて選択肢を一覧表示してドロップダウンを開く手間を省きたい場合
     * [Select](/products/components/select/) → [RadioButton](/products/components/radio-button/)
-    * [SingleCombobox](/products/components/combo-box/single-combo-box/) → [RadioButton](/products/components/radio-button/)
-    * [MultiCombobox](/products/components/combo-box/multi-combo-box/) → [Checkbox](/products/components/check-box/)
+    * [SingleCombobox](/products/components/combobox/single-combobox/) → [RadioButton](/products/components/radio-button/)
+    * [MultiCombobox](/products/components/combobox/multi-combobox/) → [Checkbox](/products/components/check-box/)
 
 ### 検索機能が必要か
 検索機能が必要かどうかは、**ユーザーが選択肢の全体像や目的の項目の位置を容易に予測できるか**で判断してください。原則として以下の条件が揃う場合は、検索機能が必要な可能性が高いです。
 * 選択肢の数が多い
 * 選択肢の更新頻度が高い
 
-検索機能が必要な場合は、[SingleCombobox](/products/components/combo-box/single-combo-box/)（単一選択）または [MultiCombobox](/products/components/combo-box/multi-combo-box/)（複数選択）が使えます。
+検索機能が必要な場合は、[SingleCombobox](/products/components/combobox/single-combobox/)（単一選択）または [MultiCombobox](/products/components/combobox/multi-combobox/)（複数選択）が使えます。
 
 <BaseColumn className="shr-mt-2" padding={{ block: 1, inline: 1.5 }}>
   <Stack gap={0.25}>
@@ -93,8 +93,8 @@ import { BaseColumn, Stack, Heading, Text, WarningIcon } from 'smarthr-ui'
 ## 関連リンク
 
 - [Select](/products/components/select/)
-- [SingleCombobox](/products/components/combo-box/single-combo-box/)
-- [MultiCombobox](/products/components/combo-box/multi-combo-box/)
+- [SingleCombobox](/products/components/combobox/single-combobox/)
+- [MultiCombobox](/products/components/combobox/multi-combobox/)
 - [RadioButton](/products/components/radio-button/)
 - [RadioButtonPanel](/products/components/radio-button-panel/)
 - [Checkbox](/products/components/check-box/)


### PR DESCRIPTION
## 課題・背景

Combobox，SingleCombobox、MultiComboboxのファイル名変更の影響で、複数のリンク切れが発生された。

## やったこと

以下のようにリンクを修正し、リダイレクトを追加した。

| 修正前 | 修正後 |
| --- | --- |
| /products/components/combo-box | /products/components/combobox |
| /products/components/combo-box/single-combo-box | /products/components/combobox/single-combobox |
| /products/components/combo-box/multi-combo-box | /products/components/combobox/single-combobox |


## 動作確認

### リダイレクト

- https://deploy-preview-2346--smarthr-design-system.netlify.app/products/components/combo-box/ がリダイレクトされる
- https://deploy-preview-2346--smarthr-design-system.netlify.app/products/components/combo-box/single-combo-box/ がリダイレクトされる
- https://deploy-preview-2346--smarthr-design-system.netlify.app/products/components/combo-box/multi-combo-box/ がリダイレクトされる

### リンク

以下のページの Combobox、SingleCombobox、MultiComboboxへのリンクが切れていない

- [Checkbox](https://deploy-preview-2346--smarthr-design-system.netlify.app/products/components/checkbox/)
- [RadioButton](https://deploy-preview-2346--smarthr-design-system.netlify.app/products/components/radio-button/)
- [Select](https://deploy-preview-2346--smarthr-design-system.netlify.app/products/components/select/)
- [権限による表示制御](https://deploy-preview-2346--smarthr-design-system.netlify.app/products/design-patterns/access-control-pattern/)
- [選択コンポーネントの使い分け](https://deploy-preview-2346--smarthr-design-system.netlify.app/products/design-patterns/selection-component-usage/)