### PR TITLE
fix: 「よくあるテーブル」ページのリンク先のミスを修正する

### DIFF
--- a/src/content/articles/products/design-patterns/smarthr-table/index.mdx
+++ b/src/content/articles/products/design-patterns/smarthr-table/index.mdx
@@ -101,7 +101,7 @@ Tableは表示する情報が多くなるとデフォルトで横スクロール
 
 - [Heading](/products/components/heading/)を使用し、適切な見出しレベルを設定してください。
 - 多くの場合、`{オブジェクト名}`という表記を採用しています。
-    - [よくあるテーブルの見出しに「一覧」はつけない](../../../products/contents/app-writing/#h2-9)
+    - [よくあるテーブルの見出しに「一覧」はつけない](/products/contents/ui-text/app-writing/#h2-5)
 
 [画面タイトル](/products/components/heading/page-heading/)が`よくあるテーブル`の見出しを兼ねる場合は、タイトルエリアを省略できます。  
 ただし、後述の[テーブル操作エリア](#h3-2)が生じる場合はテーブルの左上に不要な余白が生まれるため、見出しを省略できません。


### PR DESCRIPTION
## 課題・背景

よくあるテーブルの中にあるリンク（ `よくあるテーブルの見出しに「一覧」はつけない` 部分）が404になっている。
https://smarthr.design/products/design-patterns/smarthr-table/#h3-1

<img width="661" height="300" alt="スクリーンショット 2026-08-06 16 38 35" src="https://github.com/user-attachments/assets/0ce8f152-6356-4d27-a1f5-ffca65298e54" />

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
- リンク先を修正した

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 他にもデッドリンクになっている箇所はたくさんあるが、たくさんすぎるので別PRで対応します。

<!--
e.g.
- 見た目の調整
-->

## 動作確認

Preview で確認お願いします

https://deploy-preview-2351--smarthr-design-system.netlify.app/products/design-patterns/smarthr-table/#h3-1

<!--
- ファイルでの確認で十分だよ。
- Previewでみてね。
-->