### PR TITLE
chore: CI で npm install 時のライフサイクルスクリプト実行を無効化する

### DIFF
--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -3,6 +3,9 @@ name: Deploy to netlify
 on:
   workflow_dispatch:
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   build-prod:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -35,6 +35,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   generate:
     # フォーク PR からのトリガーは構造上発生しないが、念のため二重防御。

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 2 * * 1' # Monday, 2am(UTC+0)
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/netlify-clear-cache-deploy.yml
+++ b/.github/workflows/netlify-clear-cache-deploy.yml
@@ -3,6 +3,9 @@ name: 'Clear cache and deploy site on Netlify'
 on:
   workflow_dispatch:
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '30 2 * * 1' # Monday, 2:30am(UTC+0)
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -23,6 +23,9 @@ concurrency:
   group: validate-skills-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 課題・背景

pre/postinstall スクリプトを悪用したサプライチェーン攻撃が発生している。
新しい npm ではデフォルトでライフサイクルスクリプトが無効化されているが、一部のワークフローでは古い npm がピン留めされているため、リポジトリ全体で明示的に無効化する。

## やったこと
- `.github/workflows/` 配下の全 7 ワークフローファイルに、トップレベルの `env:` で `NPM_CONFIG_IGNORE_SCRIPTS: 'true'` を追加
  - `deploy-to-netlify.yml`
  - `generate-skills.yml`
  - `link-check.yml`
  - `lint.yml`
  - `netlify-clear-cache-deploy.yml`
  - `storybook-check.yml`
  - `validate-skills.yml`

## やらなかったこと
- ワークフロー内容自体のリファクタリングや整形、action のバージョン更新は行っていない（`env:` 追加のみ）

## 動作確認
- 全ファイルが有効な YAML としてパースできることを確認
- `NPM_CONFIG_IGNORE_SCRIPTS` が各ファイルに 1 箇所のみ存在することを確認
- 対象ファイル数（7件）と diff のファイル数が一致することを確認

## checklist.yaml の更新

index.mdx を変更していないため、この節は不要（ワークフロー YAML のみの変更）。

## キャプチャ

画面の変更なし。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kufu/smarthr-design-system/pull/2353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->