### PR TITLE
Headingページにアクセシビリティの考慮点追加

### DIFF
--- a/src/content/articles/products/components/heading/checklist.yaml
+++ b/src/content/articles/products/components/heading/checklist.yaml
@@ -10,3 +10,11 @@ items:
   - severity: must
     text: '画面のタイトルには PageHeading コンポーネントを使う'
     source_section: '種類 > 画面タイトル'
+
+  # アクセシビリティ > 開発時の考慮点 > HTMLの見出しレベルが`h1`～`h6`の順になっているかを確認する
+  - severity: must
+    text: 'HTMLの見出しレベルが`h1`～`h6`の順になっているかを確認する'
+    source_section: 'アクセシビリティ > 開発時の考慮点 > HTMLの見出しレベルが`h1`～`h6`の順になっているかを確認する'
+    sub_items:
+      - '`Heading`のタイプ（`type`props）とHTMLの見出しレベル（`h2`～`h6`）が合致しているか'
+      - 'ページにある見出しが`h1`～`h6`の順でマークアップされているか'

--- a/src/content/articles/products/components/heading/index.mdx
+++ b/src/content/articles/products/components/heading/index.mdx
@@ -170,10 +170,11 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
 ## アクセシビリティ
 ### 開発時の考慮点
 #### HTMLの見出しレベルが`h1`～`h6`の順になっているかを確認する
-HTMLの見出しレベルは[SectioningContent](https://smarthr.design/products/components/sectioning-content/)を併用することで自動的に決定されます。
+[PageHeading](http://localhost:4321/products/components/heading/page-heading)は`h1`要素が自動的に設定されます。
+以降のHTMLの見出しレベルは[SectioningContent](https://smarthr.design/products/components/sectioning-content/)を併用することで自動的に決定されます。
 実装後、HTMLを見て以下を確認してください。
-- `Heading`のタイプ（`type`props）とHTMLの見出しレベル（`h1`～`h6`）が合致しているか
-- 見出しレベルを`h1`～`h6`の順で使用しているか
+- `Heading`のタイプ（`type`props）とHTMLの見出しレベル（`h2`～`h6`）が合致しているか
+- ページにある見出しが`h1`～`h6`の順でマークアップされているか
 
 ### 関連ページ
 

--- a/src/content/articles/products/components/heading/index.mdx
+++ b/src/content/articles/products/components/heading/index.mdx
@@ -168,6 +168,12 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
 ![アウトラインに合わせた使用例](./images/heading-sample.png)
 
 ## アクセシビリティ
+### 開発時の考慮点
+#### HTMLの見出しレベルが`h1`～`h6`の順になっているかを確認する
+HTMLの見出しレベルは[SectioningContent](https://smarthr.design/products/components/sectioning-content/)を併用することで自動的に決定されます。
+実装後、HTMLを見て以下を確認してください。
+- `Heading`のタイプ（`type`props）とHTMLの見出しレベル（`h1`～`h6`）が合致しているか
+- 見出しレベルを`h1`～`h6`の順で使用しているか
 
 ### 関連ページ
 

--- a/src/content/articles/products/components/heading/index.mdx
+++ b/src/content/articles/products/components/heading/index.mdx
@@ -170,7 +170,7 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
 ## アクセシビリティ
 ### 開発時の考慮点
 #### HTMLの見出しレベルが`h1`～`h6`の順になっているかを確認する
-[PageHeading](http://localhost:4321/products/components/heading/page-heading)は`h1`要素が自動的に設定され、以降の見出しは[SectioningContent](https://smarthr.design/products/components/sectioning-content/)を併用することで自動的に見出しレベルが設定されます。
+[PageHeading](https://smarthr.design/products/components/heading/page-heading/)は`h1`要素が自動的に設定され、以降の見出しは[SectioningContent](https://smarthr.design/products/components/sectioning-content/)を併用することで自動的に見出しレベルが設定されます。
 実装後、HTMLを見て以下を確認してください。
 - `Heading`のタイプ（`type`props）とHTMLの見出しレベル（`h2`～`h6`）が合致しているか
 - ページにある見出しが`h1`～`h6`の順でマークアップされているか

--- a/src/content/articles/products/components/heading/index.mdx
+++ b/src/content/articles/products/components/heading/index.mdx
@@ -170,8 +170,7 @@ SmartHR UIでは、タイプ（`type`props）で種類を指定できます。
 ## アクセシビリティ
 ### 開発時の考慮点
 #### HTMLの見出しレベルが`h1`～`h6`の順になっているかを確認する
-[PageHeading](http://localhost:4321/products/components/heading/page-heading)は`h1`要素が自動的に設定されます。
-以降のHTMLの見出しレベルは[SectioningContent](https://smarthr.design/products/components/sectioning-content/)を併用することで自動的に決定されます。
+[PageHeading](http://localhost:4321/products/components/heading/page-heading)は`h1`要素が自動的に設定され、以降の見出しは[SectioningContent](https://smarthr.design/products/components/sectioning-content/)を併用することで自動的に見出しレベルが設定されます。
 実装後、HTMLを見て以下を確認してください。
 - `Heading`のタイプ（`type`props）とHTMLの見出しレベル（`h2`～`h6`）が合致しているか
 - ページにある見出しが`h1`～`h6`の順でマークアップされているか


### PR DESCRIPTION
## 課題・背景
- これまでアクセシビリティガイドラインをもとにした試験では、[3-2. 見出しがh1〜h6でマークアップされている](https://smarthr.design/accessibility/guidelines/markup-heading/)　の項目で、HTMLの見出しレベルの抜けや乱れが度々見つかっています。
- Headingは見出しレベルh2〜h6に対応する外観を設定できます。
SectioningContentを併用することによりHTMLの見出しレベルが自動で調整されますが、レンダリングされた見出しレベルの確認作業が明記されておらず、見出しの外観とHTMLの見出しレベルとの差異に気づきづらい状態でした。

## やったこと
- Headingコンポーネントのアクセシビリティセクションに、以下の考慮点を追記。
　1. `Heading`のタイプ（`type`props）とHTMLの見出しレベル（`h2`～`h6`）が合致しているか
　2. ページにある見出しが`h1`～`h6`の順でマークアップされているか

memo：Headingはセクションタイトルから順に使用することが求められているので、HeadingとSectioningContent、PageHeadingを適切に使用すれば確認事項1および2を達成できると考えています。

## やらなかったこと
- 「開発時の考慮点」というタイトルの変更
　- 「開発」という言葉が広い意味で使われるためより明確な文言がないか別途検討します。

## 動作確認
PRのスクショかPreviewをごらんください。
Previewページ：https://deploy-preview-2354--smarthr-design-system.netlify.app/products/components/heading/

## checklist.yaml の更新

<!--
コンポーネントの index.mdx / _components/*.mdx を変更・追加した場合は、まず生成/更新スキル（generate-checklist / update-checklist）を実行してください。更新要否はスキルが判定します（typo・description のみの軽微な変更でも、まずスキルを実行）。
index.mdx を変更していない場合は、この節を削除して構いません。
差分が出なかった理由（スキルの報告内容）を description に記載するとレビューしやすくなります。
詳細は CONTRIBUTING.md「smarthr-ui コンポーネント向け AI スキルの整備」を参照。
-->

- [x] checklist.yaml に差分が出たコンポーネントは、その差分を PR に含めた
- [ ] 一部のコンポーネントで差分が出なかった（差分あり・なしが混在）→ `skip-checklist-update` ラベルを付与
- [ ] すべてのコンポーネントで差分が出なかった → `skip-checklist-update` ラベルを付与

## キャプチャ
<img width="739" height="588" alt="スクリーンショット 2026-08-06 16 22 12" src="https://github.com/user-attachments/assets/ffcef25f-51ed-427a-af5e-d54e7d46c8b4" />
<img width="699" height="174" alt="スクリーンショット 2026-08-06 18 18 34" src="https://github.com/user-attachments/assets/aebeb108-cba2-43cd-9fa4-d8a0df18edba" />
