### PR TITLE
chore: vite で未使用の import で warning が出ていたのを修正する

### DIFF
--- a/src/content/articles/accessibility/standards-and-process/status/application/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/application/index.mdx
@@ -3,7 +3,6 @@ title: '申請・承認'
 description: 'SmartHRの申請機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 4
 ---
-import { Table, Td, Text, Th } from 'smarthr-ui'
 
 ## プロセス:申請を提出する
 ### 概要

--- a/src/content/articles/accessibility/standards-and-process/status/distribution/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/distribution/index.mdx
@@ -3,7 +3,7 @@ title: '文書配付'
 description: 'SmartHRの文書配付機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 3
 ---
-import { Table, Text, Td, Th } from 'smarthr-ui'
+import { Table, Th } from 'smarthr-ui'
 
 ## プロセス: 書類に合意する
 ### 概要

--- a/src/content/articles/accessibility/standards-and-process/status/employee-info/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/employee-info/index.mdx
@@ -3,7 +3,6 @@ title: '従業員情報'
 description: 'SmartHRの従業員情報機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 7
 ---
-import { Table, Text, Td, Th } from 'smarthr-ui'
 
 ## プロセス:従業員情報を変更する
 ### 概要

--- a/src/content/articles/accessibility/standards-and-process/status/entrance-procedures/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/entrance-procedures/index.mdx
@@ -3,7 +3,6 @@ title: '入社手続き・雇用契約'
 description: 'SmartHRの入社手続き・雇用契約機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 1
 ---
-import { Table, Td, Text, Th } from 'smarthr-ui'
 
 ## プロセス:招待メールから入社手続きをする
 ### 概要

--- a/src/content/articles/accessibility/standards-and-process/status/evaluation/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/evaluation/index.mdx
@@ -3,7 +3,7 @@ title: '人事評価'
 description: 'SmartHRの人事評価機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 9
 ---
-import { Table, Text, Td, Th } from 'smarthr-ui'
+import { Table, Th } from 'smarthr-ui'
 
 ## プロセス: 評価を提出する
 ### 概要

--- a/src/content/articles/accessibility/standards-and-process/status/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/index.mdx
@@ -3,8 +3,6 @@ title: '検証結果'
 description: 'SmartHR 各機能のアクセシビリティ検証結果を掲載しています。'
 ---
 
-import { Table, Td, Text, Th } from 'smarthr-ui'
-
 SmartHRでは、[アクセシビリティ方針](https://accessibility.smarthr.co.jp/development/)で掲げる目標を達成するため、製品のアクセシビリティ検証を進めています。
 
 ## 情報アクセシビリティ自己評価様式

--- a/src/content/articles/accessibility/standards-and-process/status/national-identity-number/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/national-identity-number/index.mdx
@@ -3,7 +3,6 @@ title: 'マイナンバー管理'
 description: 'SmartHRのマイナンバー管理機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 6
 ---
-import { Table, Text, Td, Th } from 'smarthr-ui'
 
 ## プロセス:マイナンバーを提出する
 ### 概要

--- a/src/content/articles/accessibility/standards-and-process/status/payslips/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/payslips/index.mdx
@@ -3,7 +3,7 @@ title: 'Web給与明細'
 description: 'SmartHRのWeb給与明細機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 2
 ---
-import { Table, Text, Td, Th } from 'smarthr-ui'
+import { Table, Th } from 'smarthr-ui'
 
 ## プロセス: 給与明細の確認
 ### 概要

--- a/src/content/articles/accessibility/standards-and-process/status/personal-settings/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/personal-settings/index.mdx
@@ -3,7 +3,6 @@ title: '個人設定'
 description: 'SmartHRの個人設定機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 5
 ---
-import { Table, Text, Td, Th } from 'smarthr-ui'
 
 ## プロセス:アカウントを設定する
 ### 概要

--- a/src/content/articles/accessibility/standards-and-process/status/procedure/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/procedure/index.mdx
@@ -3,7 +3,6 @@ title: '手続き'
 description: 'SmartHRの各種手続き機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 8
 ---
-import { Table, Text, Td, Th } from 'smarthr-ui'
 
 
 ## プロセス：扶養家族を追加する

--- a/src/content/articles/accessibility/standards-and-process/status/skill/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/skill/index.mdx
@@ -3,7 +3,7 @@ title: 'スキル管理'
 description: 'SmartHRのスキル管理機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 10
 ---
-import { Table, Td, Text, Th } from 'smarthr-ui'
+import { Table, Th } from 'smarthr-ui'
 
 ## プロセス: 申請を提出する
 ### 概要

--- a/src/content/articles/accessibility/standards-and-process/status/survey/index.mdx
+++ b/src/content/articles/accessibility/standards-and-process/status/survey/index.mdx
@@ -3,7 +3,7 @@ title: '従業員サーベイ'
 description: 'SmartHRの従業員サーベイ機能のアクセシビリティ対応状況と検証結果を掲載しています。'
 order: 11
 ---
-import { Table, Text, Td, Th } from 'smarthr-ui'
+import { Table, Th } from 'smarthr-ui'
 
 ## プロセス: サーベイに回答する
 ### 概要

--- a/src/content/articles/operational-guideline/page-template/style-template.mdx
+++ b/src/content/articles/operational-guideline/page-template/style-template.mdx
@@ -5,7 +5,7 @@ order: 1
 ---
 
 import { Image } from 'astro:assets'
-import { Button, Cluster, FaCirclePlusIcon, Table, Td, Th, Text } from 'smarthr-ui'
+import { Button, Cluster, Table, Td, Th, Text } from 'smarthr-ui'
 import ComponentPreview from '@/components/ComponentPreview/ComponentPreview'
 import DoAndDont from '@/components/article/DoAndDont.astro'
 import TableWrapper from '@/components/article/TableWrapper.astro'

--- a/src/content/articles/products/components/button/index.mdx
+++ b/src/content/articles/products/components/button/index.mdx
@@ -3,7 +3,7 @@ title: 'Button'
 description: 'button要素の代替として操作や処理を実行するコンポーネントです。ユーザーに操作を促すとき、フォームを送信するとき、アクションを選択するときに使います。'
 ---
 
-import { Base, BaseColumn, Button, FormControl, Input, Stack, Cluster, FaCaretDownIcon, FaCloudArrowDownIcon, FaFilterIcon, FaCirclePlusIcon, NotificationBar, ResponseMessage } from 'smarthr-ui'
+import { Base, BaseColumn, Button, FormControl, Input, Stack, Cluster, FaCaretDownIcon, FaCloudArrowDownIcon, FaFilterIcon, FaCirclePlusIcon } from 'smarthr-ui'
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import { OpenInNewTabIconInAnchorButton, SampleButton } from './_components'

--- a/src/content/articles/products/components/chip/index.mdx
+++ b/src/content/articles/products/components/chip/index.mdx
@@ -5,7 +5,6 @@ description: 'テキストをタグのように装飾して表示するための
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import Checklist from '@/components/article/Checklist/Checklist.astro'
-import { Chip, Cluster, FaCircleXmarkIcon, Stack, UnstyledButton } from 'smarthr-ui'
 
 テキストをタグのように装飾して表示するためのコンポーネントです。
 

--- a/src/content/articles/products/components/combobox/multi-combobox/index.mdx
+++ b/src/content/articles/products/components/combobox/multi-combobox/index.mdx
@@ -3,7 +3,7 @@ title: 'MultiCombobox'
 description: '選択肢から複数の値を選択しつつテキスト入力での絞り込みや値追加もできる選択コンポーネントです。6個以上の選択肢から検索しながら複数を選択するときに使います。'
 ---
 import { Image } from 'astro:assets'
-import { Text, MultiCombobox, Cluster, BaseColumn, ResponseMessage } from 'smarthr-ui'
+import { Text, Cluster, BaseColumn, ResponseMessage } from 'smarthr-ui'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import Checklist from '@/components/article/Checklist/Checklist.astro'

--- a/src/content/articles/products/components/combobox/single-combobox/index.mdx
+++ b/src/content/articles/products/components/combobox/single-combobox/index.mdx
@@ -3,7 +3,7 @@ title: 'SingleCombobox'
 description: '選択肢から1つの値を選択しつつテキスト入力での絞り込みや値追加もできる選択コンポーネントです。6個以上の選択肢から検索しながら1つを選択するときに使います。'
 ---
 import { Image } from 'astro:assets'
-import { SingleCombobox, Cluster, Text, BaseColumn, ResponseMessage } from 'smarthr-ui'
+import { Cluster, Text, BaseColumn, ResponseMessage } from 'smarthr-ui'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import Checklist from '@/components/article/Checklist/Checklist.astro'

--- a/src/content/articles/products/components/dropdown/dropdown-menu-button/index.mdx
+++ b/src/content/articles/products/components/dropdown/dropdown-menu-button/index.mdx
@@ -6,7 +6,7 @@ import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import Checklist from '@/components/article/Checklist/Checklist.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import { Image } from 'astro:assets'
-import { ResponseMessage, BaseColumn, Cluster, Text, DropdownMenuButton, FaCaretDownIcon, FaEllipsisIcon } from 'smarthr-ui'
+import { ResponseMessage, BaseColumn, Cluster, Text, FaCaretDownIcon } from 'smarthr-ui'
 import DoAndDont from '@/components/article/DoAndDont.astro'
 
 import DropdownMenuButtonPanelWidthDo from '../images/dropdown-menu-button-panel-width-do.png'

--- a/src/content/articles/products/components/error-screen/index.mdx
+++ b/src/content/articles/products/components/error-screen/index.mdx
@@ -12,7 +12,6 @@ import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import Checklist from '@/components/article/Checklist/Checklist.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import PageIndex from '@/components/article/PageIndex.astro'
-import { Button, Center, Cluster, ErrorScreen, Stack, Text, TextLink } from 'smarthr-ui'
 
 エラーを全画面で表示するためのプリミティブコンポーネントです。Auth/Forbidden/NotFound/Unauthorized/Unexpectedの各ErrorScreenで実現できない独自のエラー画面を提供するときに使います。
 

--- a/src/content/articles/products/components/heading/index.mdx
+++ b/src/content/articles/products/components/heading/index.mdx
@@ -9,7 +9,7 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 import CodeBlock from '@/components/article/CodeBlock.astro'
 import TableWrapper from '@/components/article/TableWrapper.astro'
 
-import { Heading, Stack, Table, Td, Th, Text } from 'smarthr-ui'
+import { Heading, Table, Td, Th } from 'smarthr-ui'
 
 見出し要素の代替として直後のコンテンツの見出しを示すコンポーネントです。「[セクション](/products/design-patterns/visual-grouping/#h3-5)」や「[ブロック](/products/design-patterns/visual-grouping/#h3-6)」に見出しをつけるときに使います。
 

--- a/src/content/articles/products/components/heading/page-heading/index.mdx
+++ b/src/content/articles/products/components/heading/page-heading/index.mdx
@@ -6,7 +6,7 @@ import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import Checklist from '@/components/article/Checklist/Checklist.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import TableWrapper from '@/components/article/TableWrapper.astro'
-import { Heading, PageHeading, Table, Td, Th, Text } from 'smarthr-ui'
+import { Table, Td, Th, Text } from 'smarthr-ui'
 
 画面全体の最上位見出しを表示するためのコンポーネントです。`h1`要素として画面タイトルを示すときに使います。
 

--- a/src/content/articles/products/components/icon/index.mdx
+++ b/src/content/articles/products/components/icon/index.mdx
@@ -11,26 +11,13 @@ import { ButtonWithPlusIcon, ButtonWithFilterIcon } from './components/ButtonExa
 import { AvatarIcon } from './components/AvatarIcon'
 import { ChipWithButton } from './components/ChipWithButton'
 import {
-  FaAddressBookIcon,
-  FaAddressCardIcon,
-  FaAnglesLeftIcon,
-  FaAnglesRightIcon,
   FaCirclePlusIcon,
   FaArrowRightIcon,
-  FaUserLargeIcon,
   FaPenIcon,
-  FaCircleXmarkIcon,
-  OpenInNewTabIcon,
-  WarningIcon,
-  FaGearIcon,
   Cluster,
-  Text,
-  TextLink,
   Button,
-  Td,
   DefinitionList,
   DefinitionListItem,
-  Chip,
 } from 'smarthr-ui'
 
 意味やアクションを視覚的に表すアイコンを表示するためのコンポーネントです。[Button](/products/components/button/)に削除・追加・編集などのアクションを明示するとき、[DefinitionList](/products/components/definition-list/)などのスペースが取れない項目に「編集可能」を示すなど状態を併記するときに使います。

--- a/src/content/articles/products/components/input/index.mdx
+++ b/src/content/articles/products/components/input/index.mdx
@@ -9,7 +9,7 @@ import Checklist from '@/components/article/Checklist/Checklist.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import PageIndex from '@/components/article/PageIndex.astro'
 import DoAndDont from '@/components/article/DoAndDont.astro'
-import { BaseColumn, Cluster, CurrencyInput, FaMagnifyingGlassIcon, Text } from 'smarthr-ui'
+import { Cluster, CurrencyInput, Text } from 'smarthr-ui'
 import Grid from '@/components/article/Grid.astro'
 import ImgWithDesc from '@/components/article/ImgWithDesc.astro'
 

--- a/src/content/articles/products/components/segmented-control/index.mdx
+++ b/src/content/articles/products/components/segmented-control/index.mdx
@@ -41,7 +41,7 @@ SegmentedControlは異なる状態を切り替えるためのコンポーネン�
 - `S`サイズのSegmentedControlを使用する（どうしようもないときにのみ）
 
 import DoAndDont from '@/components/article/DoAndDont.astro'
-import { BaseColumn, Cluster, Center, Text } from 'smarthr-ui'
+import { BaseColumn, Cluster, Text } from 'smarthr-ui'
 import { Dont, DoWithWrap, DoWithReel } from './_components'
 
 <Cluster gap={{ row: 0, column: 1 }}>

--- a/src/content/articles/products/components/table/index.mdx
+++ b/src/content/articles/products/components/table/index.mdx
@@ -20,7 +20,6 @@ relatedComponents:
 import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import Checklist from '@/components/article/Checklist/Checklist.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
-import { Button, BulkActionRow, Table, Cluster } from 'smarthr-ui'
 
 `table`要素の代替として表形式でデータを表示するためのコンポーネントです。データを行列で一覧表示するとき、レコードを並べて比較するビューを提示するときに使います。
 

--- a/src/content/articles/products/components/textarea/index.mdx
+++ b/src/content/articles/products/components/textarea/index.mdx
@@ -7,7 +7,7 @@ import ComponentPropsTable from '@/components/article/ComponentPropsTable.astro'
 import Checklist from '@/components/article/Checklist/Checklist.astro'
 import ComponentStory from '@/components/article/ComponentStory.astro'
 import DoAndDont from '@/components/article/DoAndDont.astro'
-import { Cluster, FormControl, Text, Textarea } from 'smarthr-ui'
+import { Cluster, Text } from 'smarthr-ui'
 
 import textareaSizeDo from './images/textarea-size-do.png'
 import textareaSizeDont from './images/textarea-size-dont.png'

--- a/src/content/articles/products/components/tooltip/index.mdx
+++ b/src/content/articles/products/components/tooltip/index.mdx
@@ -2,22 +2,7 @@
 title: 'Tooltip'
 description: '補足説明テキストをホバーやフォーカスで一時的に表示するためのツールチップコンポーネントです。アイコンのみボタンへのラベル付け、LineClampで省略したテキストの全文表示など、限られたスペースで補足情報を添えるときに使います。'
 ---
-import {
-  WarningIcon,
-  FaArrowDownIcon,
-  FaArrowLeftIcon,
-  FaArrowRightIcon,
-  FaArrowUpIcon,
-  FaCircleInfoIcon,
-  FaCirclePlusIcon,
-  FaFileIcon,
-  FaUserLargeIcon,
-  TextLink,
-  Button,
-  Cluster,
-  Tooltip,
-  Text,
-} from 'smarthr-ui'
+import { FaCircleInfoIcon } from 'smarthr-ui'
 import { Image } from 'astro:assets'
 import ImgWithDesc from '@/components/article/ImgWithDesc.astro'
 import ComponentPreview from '@/components/ComponentPreview/ComponentPreview'

--- a/src/content/articles/products/design-patterns/drag-and-drop/index.mdx
+++ b/src/content/articles/products/design-patterns/drag-and-drop/index.mdx
@@ -6,7 +6,7 @@ order: 18
 import { Image } from 'astro:assets'
 import DoAndDont from '@/components/article/DoAndDont.astro'
 import ImgWithDesc from '@/components/article/ImgWithDesc.astro'
-import { BaseColumn, Cluster, ResponseMessage, Text, FaGripVerticalIcon, FaGripIcon, FaTriangleExclamationIcon } from 'smarthr-ui'
+import { Cluster, Text, FaGripVerticalIcon, FaGripIcon } from 'smarthr-ui'
 import doUseHandle from './images/smarthr-draggable-list-handle.png'
 import dontUseCard from './images/smarthr-draggable-list-card.png'
 import doCancelAction from './images/smarthr-draggable-list-cancellable.png'

--- a/src/content/articles/products/design-patterns/page-layout/index.mdx
+++ b/src/content/articles/products/design-patterns/page-layout/index.mdx
@@ -8,7 +8,7 @@ import DoAndDont from '@/components/article/DoAndDont.astro'
 import ImgWithDesc from '@/components/article/ImgWithDesc.astro'
 import Grid from '@/components/article/Grid.astro'
 import Caption from './_components/Caption.astro'
-import { Base, BaseColumn, Button, Cluster, FormControl, Heading, Input, NotificationBar, Stack, Text, ResponseMessage } from 'smarthr-ui'
+import { BaseColumn, Cluster, Text, ResponseMessage } from 'smarthr-ui'
 
 ビューポート内にどのような要素をどのような順序で配置するかをページレイアウトと呼びます。
 SmartHRプロダクトの基本的なページレイアウトのパターンをまとめています。


### PR DESCRIPTION
## 課題・背景

Netlify側のビルドで vite の WARNING が複数あるうち、未使用の import に対するものを潰しました。

https://app.netlify.com/projects/smarthr-design-system/deploys/6a791d70c00b36000876c278

<img width="1250" height="210" alt="スクリーンショット 2026-08-11 12 31 23" src="https://github.com/user-attachments/assets/16d25e71-60c5-4861-97b4-e2f4b614f1c2" />

## checklist.yaml の更新

<!--
コンポーネントの index.mdx / _components/*.mdx を変更・追加した場合は、まず生成/更新スキル（generate-checklist / update-checklist）を実行してください。更新要否はスキルが判定します（typo・description のみの軽微な変更でも、まずスキルを実行）。
index.mdx を変更していない場合は、この節を削除して構いません。
差分が出なかった理由（スキルの報告内容）を description に記載するとレビューしやすくなります。
詳細は CONTRIBUTING.md「smarthr-ui コンポーネント向け AI スキルの整備」を参照。
- [ ] checklist.yaml に差分が出たコンポーネントは、その差分を PR に含めた
- [ ] 一部のコンポーネントで差分が出なかった（差分あり・なしが混在）→ `skip-checklist-update` ラベルを付与
-->

- [x] すべてのコンポーネントで差分が出なかった → `skip-checklist-update` ラベルを付与

## 動作確認

- ビルドが通っている、が確認できればOKです。