### PR TITLE
fix: <PageIndex /> コンポーネントで書き出した見出しに IndexNav のページ内リンクが紐づかないバグを修正する

### DIFF
--- a/src/components/article/PageIndex.astro
+++ b/src/components/article/PageIndex.astro
@@ -65,7 +65,7 @@ subPages.sort((a, b) => (a.data.order && b.data.order ? a.data.order - b.data.or
     font-weight: bold;
 
     a {
-      text-decoration: undeline;
+      text-decoration: underline;
     }
   }
 </style>

--- a/src/components/article/PageIndex.astro
+++ b/src/components/article/PageIndex.astro
@@ -35,7 +35,8 @@ subPages.sort((a, b) => (a.data.order && b.data.order ? a.data.order - b.data.or
 
         return (
           <>
-            <Heading class="pageTitleHeadings">
+            {/* ページ内目次（IndexNav）のリンク先になるため、見出しには必ずidを振る */}
+            <Heading class="pageTitleHeading" id={`${Heading}-${pageFileName}`}>
               <a href={join('/', page.id)}>{page.data.deprecated ? `${page.data.title}（非推奨）` : page.data.title}</a>
             </Heading>
             {hasSlot ? <Fragment set:html={description} /> : <p>{description}</p>}


### PR DESCRIPTION
## 課題・背景

コンポーネントのディレクトリ配下にある index.mdx を抽出してページ内に展開できる `<PageIndex />` ですが、展開された内容に id 属性がなく、ページ右側の IndexNav のページ内リンクが機能していませんでした。

例えば [TextLink コンポーネントページ](https://smarthr.design/products/components/text-link/)の HelpLink と UpwardLink。

<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
- PageIndexが出力する Heading 要素に id 属性をつけた
- クラスセレクタが合っていなかったのを揃えた
- アンダーラインを出すCSSがtypoで効いてなかったのを直した

## 動作確認

Previewで以下の画面を確認してください。（他にもありますが3つ程度で十分かと）

- [TextLink](https://deploy-preview-2371--smarthr-design-system.netlify.app/products/components/text-link/) の HelpLink / UpwardLink のリンク
- [ページテンプレート](https://deploy-preview-2371--smarthr-design-system.netlify.app/operational-guideline/page-template/)
- [Combobox](https://deploy-preview-2371--smarthr-design-system.netlify.app/products/components/combobox/)