### PR TITLE
chore: smarthr-uiをv99.1.0に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-instantsearch-core": "^7.41.0",
     "react-live": "^4.1.8",
     "smarthr-normalize-css": "^1.1.0",
-    "smarthr-ui": "^98.1.0",
+    "smarthr-ui": "^99.1.0",
     "styled-components": "^6.5.0",
     "typescript": "^6.0.3",
     "yaml": "^2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       smarthr-ui:
-        specifier: ^98.1.0
-        version: 98.1.0(@types/react@19.2.17)(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@9.4.0)(tsx@4.23.6)(typescript@6.0.3)(yaml@2.9.0)
+        specifier: ^99.1.0
+        version: 99.1.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.6)(yaml@2.9.0)
       styled-components:
         specifier: ^6.5.0
         version: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -220,8 +220,8 @@ importers:
         specifier: ^5.2.3
         version: 5.2.3
       smarthr-ui:
-        specifier: ^98.1.0
-        version: 98.1.0(@types/react@19.2.17)(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@9.4.0)(tsx@4.23.6)(typescript@5.9.3)(yaml@2.9.0)
+        specifier: ^99.1.0
+        version: 99.1.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.6)(yaml@2.9.0)
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -993,8 +993,8 @@ packages:
   '@formatjs/fast-memoize@3.1.7':
     resolution: {integrity: sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==}
 
-  '@formatjs/icu-messageformat-parser@3.5.14':
-    resolution: {integrity: sha512-jDvgtoLqe3U6yzoBlToMTkWBe38qSi7LN7kFlnXzd5ig8nn+4tSlED0xtEtdYakZVZGJJY2rW1D5xS3BFZh6kA==}
+  '@formatjs/icu-messageformat-parser@3.5.16':
+    resolution: {integrity: sha512-kl6b/4D56gjGZi4ZewSmvXbalHwjOUI5ogEHPZqw42goeXTTrL7/yuPzvdrvr0QigDtvaOeb+UeMf62jks43Yg==}
 
   '@formatjs/icu-messageformat-parser@3.5.8':
     resolution: {integrity: sha512-uZLvzLFN7iV2l8cbDdROwgKGtdELeLI4bpnsuz1DnyscHDxn8TdDE0anHzcfjtWK66XYCllGLV3Mi3CYcEPg/g==}
@@ -3410,8 +3410,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  intl-messageformat@11.2.11:
-    resolution: {integrity: sha512-aDG5bvFRbQvRoT2Bh9FV6yV8t7o0MjEGknZ6pnin5Wt52PJwaBOHDfvz+oPEe78Pl3InQYKugBgCdXijLj6viQ==}
+  intl-messageformat@11.2.13:
+    resolution: {integrity: sha512-JaPaE6TIX+TAS5XLhDUh41geLw4QfBHX4s5pW8Km+L9fVC8HzB9yOuhbh4EMR/F1+8C6b9qk4763Cv+LdOG1kg==}
 
   intl-messageformat@11.2.5:
     resolution: {integrity: sha512-zaROHiUsnlSFXVypU54AsQuAm3DLmmSH8KfDhiUuG1XZ9NTQ4o3xlxIJYVNmeWAklyp3CWg0lhexNUnee8PsYQ==}
@@ -4731,8 +4731,8 @@ packages:
     peerDependencies:
       react: ^19.2.8
 
-  react-draggable@4.7.0:
-    resolution: {integrity: sha512-kTpANmKWVnFXiZ76Ag2ZowiFStuBYnJ606PI1TbUsOg29/400/JNIxI9+CuenhiAqFuXWJffz6F4UI3R51kUug==}
+  react-draggable@4.7.1:
+    resolution: {integrity: sha512-wa3tzfFnYt3yaZLuyU58fl1TNunfWfBekDgWhZA1+gb2jnp42wZ0ymuopR6M5kqDYmm4hKmzGlcKWjZf3Zb6RQ==}
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
@@ -5266,8 +5266,8 @@ packages:
   smarthr-normalize-css@1.1.0:
     resolution: {integrity: sha512-RNi5bkp8dYvZs/yqOihZ+an5Wf3oXiBMRRvSYhCKNhV+Qkg1otqIxmP3ELUWVwMZx9v+zZG1LLAJ0sxPkHXOcg==}
 
-  smarthr-ui@98.1.0:
-    resolution: {integrity: sha512-VZmItW/RtwpGURqcocpMkPjTKGJNRAM2uNwO1olnec03l/EecJx0ler5WZKakt3sPNcv5KAVQB5LWOaJ1wRTCg==}
+  smarthr-ui@99.1.0:
+    resolution: {integrity: sha512-UbP4pV/LqSMCxzAtxzl5mLPzpPHzEDOBqaEgFJ57PrYBiDtCZNTXmAxwqifj2gzbWdfSSXLXVW6Hwc2GOLoGsg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -7002,7 +7002,7 @@ snapshots:
 
   '@formatjs/fast-memoize@3.1.7': {}
 
-  '@formatjs/icu-messageformat-parser@3.5.14':
+  '@formatjs/icu-messageformat-parser@3.5.16':
     dependencies:
       '@formatjs/icu-skeleton-parser': 2.1.11
 
@@ -7969,22 +7969,6 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.64.0
-      eslint: 9.39.5(jiti@1.21.7)(supports-color@9.4.0)
-      ignore: 7.0.6
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3))(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -8017,18 +8001,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3(supports-color@9.4.0)
-      eslint: 9.39.5(jiti@1.21.7)(supports-color@9.4.0)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
@@ -8050,15 +8022,6 @@ snapshots:
       debug: 4.4.3(supports-color@9.4.0)
       eslint: 9.39.5(jiti@1.21.7)(supports-color@9.4.0)
       typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.64.0(supports-color@9.4.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.66.0
-      debug: 4.4.3(supports-color@9.4.0)
-      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8090,33 +8053,13 @@ snapshots:
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/visitor-keys': 8.66.0
 
-  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
   '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.66.0(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
   '@typescript-eslint/tsconfig-utils@8.66.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
-
-  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@9.4.0)
-      eslint: 9.39.5(jiti@1.21.7)(supports-color@9.4.0)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/type-utils@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
@@ -8133,21 +8076,6 @@ snapshots:
   '@typescript-eslint/types@8.64.0': {}
 
   '@typescript-eslint/types@8.66.0': {}
-
-  '@typescript-eslint/typescript-estree@8.64.0(supports-color@9.4.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.64.0(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3(supports-color@9.4.0)
-      minimatch: 10.2.5
-      semver: 7.8.5
-      tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/typescript-estree@8.64.0(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
@@ -8176,17 +8104,6 @@ snapshots:
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@9.4.0)(typescript@5.9.3)
-      eslint: 9.39.5(jiti@1.21.7)(supports-color@9.4.0)
-      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10034,10 +9951,10 @@ snapshots:
       hasown: 2.0.3
       side-channel: 1.1.0
 
-  intl-messageformat@11.2.11:
+  intl-messageformat@11.2.13:
     dependencies:
       '@formatjs/fast-memoize': 3.1.7
-      '@formatjs/icu-messageformat-parser': 3.5.14
+      '@formatjs/icu-messageformat-parser': 3.5.16
 
   intl-messageformat@11.2.5:
     dependencies:
@@ -11661,7 +11578,7 @@ snapshots:
       react: 19.2.8
       scheduler: 0.27.0
 
-  react-draggable@4.7.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-draggable@4.7.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -12405,18 +12322,18 @@ snapshots:
     transitivePeerDependencies:
       - styled-components
 
-  smarthr-ui@98.1.0(@types/react@19.2.17)(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@9.4.0)(tsx@4.23.6)(typescript@5.9.3)(yaml@2.9.0):
+  smarthr-ui@99.1.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.6)(yaml@2.9.0):
     dependencies:
       '@smarthr/wareki': 1.3.1
       dayjs: 1.11.21
       decimal.js: 10.6.0
-      intl-messageformat: 11.2.11
+      intl-messageformat: 11.2.13
       lodash.merge: 4.6.2
       lodash.range: 3.2.0
       polished: 4.3.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      react-draggable: 4.7.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-draggable: 4.7.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-icons: 5.7.0(react@19.2.8)
       react-innertext: 1.1.5(@types/react@19.2.17)(react@19.2.8)
       react-intl: 10.1.6(@types/react@19.2.17)(react@19.2.8)
@@ -12425,42 +12342,9 @@ snapshots:
       styled-components: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tailwind-variants: 0.3.1(tailwindcss@3.4.19(tsx@4.23.6)(yaml@2.9.0))
       tailwindcss: 3.4.19(tsx@4.23.6)(yaml@2.9.0)
-      typescript-eslint: 8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@types/react'
-      - eslint
-      - supports-color
       - tsx
-      - typescript
-      - yaml
-
-  smarthr-ui@98.1.0(@types/react@19.2.17)(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)(styled-components@6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@9.4.0)(tsx@4.23.6)(typescript@6.0.3)(yaml@2.9.0):
-    dependencies:
-      '@smarthr/wareki': 1.3.1
-      dayjs: 1.11.21
-      decimal.js: 10.6.0
-      intl-messageformat: 11.2.11
-      lodash.merge: 4.6.2
-      lodash.range: 3.2.0
-      polished: 4.3.1
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-draggable: 4.7.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-icons: 5.7.0(react@19.2.8)
-      react-innertext: 1.1.5(@types/react@19.2.17)(react@19.2.8)
-      react-intl: 10.1.6(@types/react@19.2.17)(react@19.2.8)
-      react-pdf: 9.2.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-transition-group: 4.4.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      styled-components: 6.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      tailwind-variants: 0.3.1(tailwindcss@3.4.19(tsx@4.23.6)(yaml@2.9.0))
-      tailwindcss: 3.4.19(tsx@4.23.6)(yaml@2.9.0)
-      typescript-eslint: 8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - eslint
-      - supports-color
-      - tsx
-      - typescript
       - yaml
 
   smol-toml@1.6.1: {}
@@ -13033,10 +12917,6 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
-
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -13124,17 +13004,6 @@ snapshots:
   typescript-auto-import-cache@0.3.6:
     dependencies:
       semver: 7.8.5
-
-  typescript-eslint@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@9.4.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@5.9.3)
-      eslint: 9.39.5(jiti@1.21.7)(supports-color@9.4.0)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   typescript-eslint@8.64.0(eslint@9.39.5(jiti@1.21.7)(supports-color@9.4.0))(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:

--- a/public/smarthr-ui.css
+++ b/public/smarthr-ui.css
@@ -1074,10 +1074,6 @@ a {
   min-width: 0;
 }
 
-.shr-min-w-\[0\] {
-  min-width: 0;
-}
-
 .shr-min-w-\[1\.75em\] {
   min-width: 1.75em;
 }
@@ -2236,10 +2232,6 @@ a {
 
 .shr-border-default\/50 {
   border-color: rgb(214 211 208 / 0.5);
-}
-
-.shr-border-disabled {
-  border-color: rgb(214 211 208 / 50%);
 }
 
 .shr-border-green {
@@ -4537,6 +4529,10 @@ a {
   pointer-events: none;
 }
 
+.has-\[\.smarthr-ui-DropZone-Button\:disabled\]\:shr-cursor-not-allowed:has(.smarthr-ui-DropZone-Button:disabled) {
+  cursor: not-allowed;
+}
+
 .has-\[\:disabled\]\:shr-cursor-default:has(:disabled) {
   cursor: default;
 }
@@ -4547,6 +4543,10 @@ a {
 
 .has-\[\:disabled\]\:shr-border-\[theme\(borderColor\.default\)\]:has(:disabled) {
   border-color: #d6d3d0;
+}
+
+.has-\[\:disabled\]\:shr-border-disabled:has(:disabled) {
+  border-color: rgb(214 211 208 / 50%);
 }
 
 .has-\[\[aria-invalid\]\]\:shr-border-danger:has([aria-invalid]) {
@@ -4585,6 +4585,11 @@ a {
 
 .has-\[\+_\&\]\:shr-pb-2:has(+ .has-\[\+_\&\]\:shr-pb-2) {
   padding-bottom: 32px;
+}
+
+.has-\[\:disabled\]\:shr-text-disabled:has(:disabled) {
+  --tw-text-opacity: 1;
+  color: rgb(193 189 183 / var(--tw-text-opacity, 1));
 }
 
 .has-\[\.smarthr-ui-ModelessDialog-handle\:focus-visible\]\:shr-transition-colors:has(.smarthr-ui-ModelessDialog-handle:focus-visible) {
@@ -4627,6 +4632,15 @@ a {
 .has-\[input\:disabled\:not\(\:checked\)\]\:before\:shr-bg-\[theme\(textColor\.disabled\)\]:has(input:disabled:not(:checked))::before {
   content: var(--tw-content);
   background-color: #c1bdb7;
+}
+
+.has-\[\:disabled\]\:hover\:shr-border-disabled:hover:has(:disabled) {
+  border-color: rgb(214 211 208 / 50%);
+}
+
+.has-\[\:disabled\]\:hover\:shr-text-disabled:hover:has(:disabled) {
+  --tw-text-opacity: 1;
+  color: rgb(193 189 183 / var(--tw-text-opacity, 1));
 }
 
 .shr-group\/label:has(:hover,:focus-visible) .group-has-\[\:hover\2c \:focus-visible\]\/label\:shr-not-sr-only {
@@ -4818,6 +4832,16 @@ a {
 
 .data-\[favorite\=\"false\"\]\:shr-grid-cols-\[1fr_1rem\][data-favorite="false"] {
   grid-template-columns: 1fr 1rem;
+}
+
+.data-\[error\]\:shr-border-danger[data-error] {
+  --tw-border-opacity: 1;
+  border-color: rgb(224 30 90 / var(--tw-border-opacity, 1));
+}
+
+.data-\[files-dragged-over\]\:shr-border-main[data-files-dragged-over] {
+  --tw-border-opacity: 1;
+  border-color: rgb(0 119 199 / var(--tw-border-opacity, 1));
 }
 
 .data-\[active\=false\]\:shr-bg-white[data-active="false"] {
@@ -5114,6 +5138,11 @@ a {
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   }
 
+  .forced-colors\:shr-outline {
+    outline-style: solid;
+    outline-color: #0077c7;
+  }
+
   .forced-colors\:before\:shr-bg-\[ButtonBorder\]::before {
     content: var(--tw-content);
     background-color: ButtonBorder;
@@ -5176,25 +5205,26 @@ a {
   white-space: normal;
 }
 
-.\[\&\&\&\]\:shr-border-\[theme\(backgroundColor\.column\)\].\[\&\&\&\]\:shr-border-\[theme\(backgroundColor\.column\)\].\[\&\&\&\]\:shr-border-\[theme\(backgroundColor\.column\)\] {
-  border-color: #f8f7f6;
-}
-
-.\[\&\&\&\]\:shr-border-default\/50.\[\&\&\&\]\:shr-border-default\/50.\[\&\&\&\]\:shr-border-default\/50 {
-  border-color: rgb(214 211 208 / 0.5);
-}
-
 .\[\&\&\&\]\:shr-border-transparent.\[\&\&\&\]\:shr-border-transparent.\[\&\&\&\]\:shr-border-transparent {
   border-color: transparent;
 }
 
-.\[\&\&\&\]\:shr-bg-column.\[\&\&\&\]\:shr-bg-column.\[\&\&\&\]\:shr-bg-column {
-  --tw-bg-opacity: 1;
-  background-color: rgb(248 247 246 / var(--tw-bg-opacity, 1));
+.\[\&\&\&\]\:has-\[\[aria-invalid\]\]\:shr-border-danger:has([aria-invalid]).\[\&\&\&\]\:has-\[\[aria-invalid\]\]\:shr-border-danger:has([aria-invalid]).\[\&\&\&\]\:has-\[\[aria-invalid\]\]\:shr-border-danger:has([aria-invalid]) {
+  --tw-border-opacity: 1;
+  border-color: rgb(224 30 90 / var(--tw-border-opacity, 1));
 }
 
 .has-\[\:disabled\]\:\[\&\&\&\]\:shr-border-default\/50.has-\[\:disabled\]\:\[\&\&\&\]\:shr-border-default\/50.has-\[\:disabled\]\:\[\&\&\&\]\:shr-border-default\/50:has(:disabled) {
   border-color: rgb(214 211 208 / 0.5);
+}
+
+.has-\[\[readonly\]\:not\(\:disabled\)\]\:\[\&\&\&\]\:shr-border-\[theme\(backgroundColor\.column\)\].has-\[\[readonly\]\:not\(\:disabled\)\]\:\[\&\&\&\]\:shr-border-\[theme\(backgroundColor\.column\)\].has-\[\[readonly\]\:not\(\:disabled\)\]\:\[\&\&\&\]\:shr-border-\[theme\(backgroundColor\.column\)\]:has([readonly]:not(:disabled)) {
+  border-color: #f8f7f6;
+}
+
+.has-\[\[readonly\]\:not\(\:disabled\)\]\:\[\&\&\&\]\:shr-bg-column.has-\[\[readonly\]\:not\(\:disabled\)\]\:\[\&\&\&\]\:shr-bg-column.has-\[\[readonly\]\:not\(\:disabled\)\]\:\[\&\&\&\]\:shr-bg-column:has([readonly]:not(:disabled)) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(248 247 246 / var(--tw-bg-opacity, 1));
 }
 
 .aria-current-page\:\[\&\&\&\]\:shr-cursor-default.aria-current-page\:\[\&\&\&\]\:shr-cursor-default.aria-current-page\:\[\&\&\&\]\:shr-cursor-default[aria-current="page"] {
@@ -5680,6 +5710,10 @@ a {
 .\[\&\:not\(\[aria-checked\=\"true\"\]\)\:not\(\:last-child\)\:focus-visible\]\:after\:shr-block:not([aria-checked="true"]):not(:last-child):focus-visible::after {
   content: var(--tw-content);
   display: block;
+}
+
+.\[\&\:not\(\[data-files-dragged-over\]\)\]\:shr-border-dashed:not([data-files-dragged-over]) {
+  border-style: dashed;
 }
 
 .\[\&\:not\(\[href\]\)\]\:shr-cursor-not-allowed:not([href]) {
@@ -6346,12 +6380,21 @@ a {
   list-style-type: none;
 }
 
-.smarthr-ui-Base > .smarthr-ui-AccordionPanel .smarthr-ui-AccordionPanel-item:first-child .\[\.smarthr-ui-Base_\>_\.smarthr-ui-AccordionPanel_\.smarthr-ui-AccordionPanel-item\:first-child_\&\]\:shr-rounded-t-l {
+.smarthr-ui-Input:has(:disabled) .\[\.smarthr-ui-Input\:has\(\:disabled\)_\&\]\:shr-text-disabled {
+  --tw-text-opacity: 1;
+  color: rgb(193 189 183 / var(--tw-text-opacity, 1));
+}
+
+.smarthr-ui-Input:has(:disabled) .\[\.smarthr-ui-Input\:has\(\:disabled\)_\&\]\:shr-opacity-100 {
+  opacity: 1;
+}
+
+.smarthr-ui-Panel > .smarthr-ui-AccordionPanel .smarthr-ui-AccordionPanel-item:first-child .\[\.smarthr-ui-Panel_\>_\.smarthr-ui-AccordionPanel_\.smarthr-ui-AccordionPanel-item\:first-child_\&\]\:shr-rounded-t-l {
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
 }
 
-.smarthr-ui-Base > .smarthr-ui-AccordionPanel .smarthr-ui-AccordionPanel-item:last-child .\[\.smarthr-ui-Base_\>_\.smarthr-ui-AccordionPanel_\.smarthr-ui-AccordionPanel-item\:last-child_\&\]\:shr-rounded-b-l {
+.smarthr-ui-Panel > .smarthr-ui-AccordionPanel .smarthr-ui-AccordionPanel-item:last-child .\[\.smarthr-ui-Panel_\>_\.smarthr-ui-AccordionPanel_\.smarthr-ui-AccordionPanel-item\:last-child_\&\]\:shr-rounded-b-l {
   border-bottom-right-radius: 8px;
   border-bottom-left-radius: 8px;
 }
@@ -6435,6 +6478,16 @@ a {
 [aria-sort="none"] .\[\[aria-sort\=\"none\"\]_\&\]\:shr-text-disabled {
   --tw-text-opacity: 1;
   color: rgb(193 189 183 / var(--tw-text-opacity, 1));
+}
+
+[data-active="false"]>.\[\[data-active\=\"false\"\]\>\&\]\:shr-rounded-b-l {
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+[data-active="false"]>.\[\[data-active\=\"false\"\]\>\&\]\:shr-py-1 {
+  padding-top: 16px;
+  padding-bottom: 16px;
 }
 
 [data-current=false]:not(:first-child) .\[\[data-current\=false\]\:not\(\:first-child\)_\&\:focus-visible\]\:before\:shr-block:focus-visible::before {

--- a/scripts/component-thumbnails/thumbnails-cache.json
+++ b/scripts/component-thumbnails/thumbnails-cache.json
@@ -23,12 +23,6 @@
     "iframeUrl": "https://story.smarthr-ui.dev/iframe.html?id=components-badge--badge-control&viewMode=story&shortcuts=false&singleStory=true",
     "displayName": "Badge"
   },
-  "Components/Base-Components-Base.png": {
-    "kindName": "Components/Base",
-    "thumbnailFileName": "Components-Base.png",
-    "iframeUrl": "https://story.smarthr-ui.dev/iframe.html?id=components-base--base-control&viewMode=story&shortcuts=false&singleStory=true",
-    "displayName": "Base"
-  },
   "Components/BottomFixedArea（非推奨）-Components-BottomFixedArea（非推奨）.png": {
     "kindName": "Components/BottomFixedArea（非推奨）",
     "thumbnailFileName": "Components-BottomFixedArea（非推奨）.png",

--- a/scripts/generate-skills/mapping/component-dir-map.json
+++ b/scripts/generate-skills/mapping/component-dir-map.json
@@ -1,0 +1,4 @@
+{
+  "Panel": "base",
+  "Groupbox": "base/base-column"
+}

--- a/scripts/generate-skills/package.json
+++ b/scripts/generate-skills/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "js-yaml": "^5.2.3",
-    "smarthr-ui": "^98.1.0"
+    "smarthr-ui": "^99.1.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/src/content/articles/products/components/base/base-column/index.mdx
+++ b/src/content/articles/products/components/base/base-column/index.mdx
@@ -11,6 +11,7 @@ import { Text } from 'smarthr-ui'
 
 [Base](/products/components/base/)や[Dialog](/products/components/dialog/)の内部で視覚的に要素をグルーピングするコンポーネントです。Base内やダイアログコンテンツ内でコンテンツを囲んで「[ブロック](/products/design-patterns/visual-grouping/#h3-6)」領域として示すときに使います。
 
+// TODO: v99.3.1 で `Panel` に戻す
 <ComponentStory name="Groupbox" />
 
 ## デザインパターン

--- a/src/content/articles/products/components/base/base-column/index.mdx
+++ b/src/content/articles/products/components/base/base-column/index.mdx
@@ -46,4 +46,5 @@ import { Text } from 'smarthr-ui'
 
 ## Props
 
+// TODO: v99.3.1 で `Panel` に戻す
 <ComponentPropsTable name="Groupbox" />

--- a/src/content/articles/products/components/base/base-column/index.mdx
+++ b/src/content/articles/products/components/base/base-column/index.mdx
@@ -11,7 +11,7 @@ import { Text } from 'smarthr-ui'
 
 [Base](/products/components/base/)や[Dialog](/products/components/dialog/)の内部で視覚的に要素をグルーピングするコンポーネントです。Base内やダイアログコンテンツ内でコンテンツを囲んで「[ブロック](/products/design-patterns/visual-grouping/#h3-6)」領域として示すときに使います。
 
-<ComponentStory name="BaseColumn" />
+<ComponentStory name="Groupbox" />
 
 ## デザインパターン
 
@@ -45,4 +45,4 @@ import { Text } from 'smarthr-ui'
 
 ## Props
 
-<ComponentPropsTable name="BaseColumn" />
+<ComponentPropsTable name="Groupbox" />

--- a/src/content/articles/products/components/base/index.mdx
+++ b/src/content/articles/products/components/base/index.mdx
@@ -13,7 +13,7 @@ import DoAndDont from '@/components/article/DoAndDont.astro'
 
 [矩形](/products/design-patterns/visual-grouping/#h3-3)で視覚的に要素をグルーピングするコンポーネントです。ページ背景上でコンテンツを囲んで「[セクション](/products/design-patterns/visual-grouping/#h3-5)」領域として示すときに使います。
 
-<ComponentStory name="Base" />
+<ComponentStory name="Panel" />
 
 ## 使用上の注意
 
@@ -223,7 +223,7 @@ Baseの上にBaseを重ねることもレイヤー順序を把握しづらくさ
 
 ## Props
 
-<ComponentPropsTable name="Base" />
+<ComponentPropsTable name="Panel" />
 
 
 ## 関連リンク

--- a/src/content/articles/products/components/base/index.mdx
+++ b/src/content/articles/products/components/base/index.mdx
@@ -224,6 +224,7 @@ Baseの上にBaseを重ねることもレイヤー順序を把握しづらくさ
 
 ## Props
 
+// TODO: v99.3.1 で `Base` に戻す
 <ComponentPropsTable name="Panel" />
 
 

--- a/src/content/articles/products/components/base/index.mdx
+++ b/src/content/articles/products/components/base/index.mdx
@@ -13,6 +13,7 @@ import DoAndDont from '@/components/article/DoAndDont.astro'
 
 [矩形](/products/design-patterns/visual-grouping/#h3-3)で視覚的に要素をグルーピングするコンポーネントです。ページ背景上でコンテンツを囲んで「[セクション](/products/design-patterns/visual-grouping/#h3-5)」領域として示すときに使います。
 
+// TODO: v99.3.1 で `Base` に戻す
 <ComponentStory name="Panel" />
 
 ## 使用上の注意

--- a/src/content/articles/products/components/formatter/date-formatter/checklist.yaml
+++ b/src/content/articles/products/components/formatter/date-formatter/checklist.yaml
@@ -1,5 +1,5 @@
 items:
   # 使用上の注意 > 日付をフォーマットする機能だけ必要な場合
   - severity: must
-    text: 'フォーマットされた日付の文字列だけが必要な場合は `useIntl` の `formatDate` を使う'
+    text: 'フォーマットされた日付の文字列だけが必要な場合は `useDateFormat` の `formatDate` を使う'
     source_section: '使用上の注意 > 日付をフォーマットする機能だけ必要な場合'

--- a/src/content/articles/products/components/formatter/date-formatter/index.mdx
+++ b/src/content/articles/products/components/formatter/date-formatter/index.mdx
@@ -15,11 +15,11 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 ### 日付をフォーマットする機能だけ必要な場合
 
 DateFormatterは日付を`time`要素としてレンダリングします。  
-フォーマットされた日付の文字列だけが必要な場合は、`useIntl`の`formatDate`を使用してください。
+フォーマットされた日付の文字列だけが必要な場合は、`useDateFormat`の`formatDate`を使用してください。
 
 ```tsx editable noIframe withStyled
 const FormatDateExample = () => {
-  const { formatDate } = useIntl()
+  const { formatDate } = useDateFormat()
   return (
     <span>今日は{formatDate({ date: new Date(2025, 7 - 1, 10) })}ではありません。</span>
   )

--- a/src/content/articles/products/components/formatter/time-formatter/checklist.yaml
+++ b/src/content/articles/products/components/formatter/time-formatter/checklist.yaml
@@ -1,5 +1,5 @@
 items:
   # 使用上の注意 > 時刻をフォーマットする機能だけ必要な場合
   - severity: must
-    text: 'フォーマットされた時刻の文字列だけが必要な場合は `useIntl` の `formatTime` を使う'
+    text: 'フォーマットされた時刻の文字列だけが必要な場合は `useDateFormat` の `formatTime` を使う'
     source_section: '使用上の注意 > 時刻をフォーマットする機能だけ必要な場合'

--- a/src/content/articles/products/components/formatter/time-formatter/index.mdx
+++ b/src/content/articles/products/components/formatter/time-formatter/index.mdx
@@ -15,11 +15,11 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 ### 時刻をフォーマットする機能だけ必要な場合
 
 TimeFormatterは時刻を`time`要素としてレンダリングします。  
-フォーマットされた時刻の文字列だけが必要な場合は、`useIntl`の`formatTime`を使用してください。
+フォーマットされた時刻の文字列だけが必要な場合は、`useDateFormat`の`formatTime`を使用してください。
 
 ```tsx editable noIframe withStyled
 const FormatTimeExample = () => {
-  const { formatTime } = useIntl()
+  const { formatTime } = useDateFormat()
   return (
     <span>現在時刻は{formatTime({ date: new Date(2026, 4, 18, 14, 30, 0) })}です。</span>
   )

--- a/src/content/articles/products/components/formatter/timestamp-formatter/checklist.yaml
+++ b/src/content/articles/products/components/formatter/timestamp-formatter/checklist.yaml
@@ -1,5 +1,5 @@
 items:
   # 使用上の注意 > タイムスタンプをフォーマットする機能だけ必要な場合
   - severity: must
-    text: 'フォーマットされたタイムスタンプの文字列だけが必要な場合は `useIntl` の `formatTimestamp` を使う'
+    text: 'フォーマットされたタイムスタンプの文字列だけが必要な場合は `useDateFormat` の `formatTimestamp` を使う'
     source_section: '使用上の注意 > タイムスタンプをフォーマットする機能だけ必要な場合'

--- a/src/content/articles/products/components/formatter/timestamp-formatter/index.mdx
+++ b/src/content/articles/products/components/formatter/timestamp-formatter/index.mdx
@@ -15,11 +15,11 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 ### タイムスタンプをフォーマットする機能だけ必要な場合
 
 TimestampFormatterは日付と時刻を`time`要素としてレンダリングします。  
-フォーマットされたタイムスタンプの文字列だけが必要な場合は、`useIntl`の`formatTimestamp`を使用してください。
+フォーマットされたタイムスタンプの文字列だけが必要な場合は、`useDateFormat`の`formatTimestamp`を使用してください。
 
 ```tsx editable noIframe withStyled
 const FormatTimestampExample = () => {
-  const { formatTimestamp } = useIntl()
+  const { formatTimestamp } = useDateFormat()
   return (
     <span>更新日時：{formatTimestamp({ date: new Date(2026, 4, 18, 14, 30, 0) })}</span>
   )


### PR DESCRIPTION
## 課題・背景

SHRデザインシステムのsmarthr-ui をv99.1.0に更新する。
https://github.com/kufu/smarthr-ui/releases/tag/smarthr-ui-v99.1.0

公開済みの最新はv99.2.0だが、`renovate.json`の`minimumReleaseAge: 7 days`と社内npmのsafe-chainにより公開から7日未満のバージョンは取得できないため、v99.1.0までとした。v99.2.0とv99.1.1は7日経過後に別途更新する。

## やったこと

- バージョン更新

## やらなかったこと

- `base`/`base-column`ページのURL移行。smarthr-ui側が`Panel as Base`の別名exportとclassNameのalias（[#6727](https://github.com/kufu/smarthr-ui/issues/6727)）を維持しているため実害がなく、リダイレクトの要否など別途判断が必要なため

## 動作確認

- https://deploy-preview-2382--smarthr-design-system.netlify.app/products


## checklist.yaml の更新

Formatter系3コンポーネント（date-formatter / time-formatter / timestamp-formatter）は`checklist.yaml`に`useIntl`の記述が残っていたため修正し、本PRに含めている。

`base` / `base-column`は`index.mdx`を変更しているが、`ComponentStory` / `ComponentPropsTable`の参照名を差し替えただけでルールに相当する記述に変更がないため、`checklist.yaml`に差分は出ない。

- [x] 一部のコンポーネントで差分が出なかった（差分あり・なしが混在）→ `skip-checklist-update` ラベルを付与

