### PR TITLE
fix: コンポーネント一覧の index.json を Chromatic から取得する

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "export:zip-images": "tsx ./scripts/zipImages.ts",
     "update:ui-data": "tsx ./scripts/fetch-ui-data.ts",
     "update:smarthr-ui.css": "tsx scripts/update-smarthr-ui-css.ts",
+    "pregenerate:thumbnails": "run-s update:ui-data",
     "generate:thumbnails": "cd ./scripts/component-thumbnails && pnpm install && cd ../.. && tsx ./scripts/component-thumbnails/componentThumbnails.ts",
     "copy:smarthr-ui-css": "cp node_modules/smarthr-ui/smarthr-ui.css public/",
     "upgrade:smarthr-ui": "pnpm -r upgrade smarthr-ui@latest",

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -5,10 +5,15 @@
 
 ## データの取得
 
-1. 最新バージョン（https://story.smarthr-ui.devにデプロイされているもの）の`index.json`を取得
+1. 利用中のバージョンのStorybook（Chromaticのパーマリンク）の`index.json`を取得
 1. `index.json`から各コンポーネントの名前、属するグループ名などを抜き出す
 1. 抜き出した情報を元に各コンポーネントの記事 (MDX) のパスを作成
 1. 記事が存在する場合データを登録
+
+`index.json`は https://story.smarthr-ui.dev から取得していましたが、Netlifyの内部ビルダーからアクセスできず
+ビルドが失敗するため、Chromaticのパーマリンクから取得しています。
+パーマリンクの生成に使うコミットハッシュは`getUIData.ts`（`scripts/fetch-ui-data.ts`が作るキャッシュ）から取得しているため、
+この関数を使う前に`pnpm update:ui-data`が実行されている必要があります。
 
 ### サムネイル画像の生成
 

--- a/src/lib/fetchComponentCaptures.ts
+++ b/src/lib/fetchComponentCaptures.ts
@@ -2,9 +2,18 @@ import fs from 'fs/promises';
 import { cwd } from 'node:process';
 import path from 'path';
 
+import { SHRUI_CHROMATIC_ID } from '@/constants/application';
+import { UI_COMMIT_HASH } from '@/lib/getUIData';
+
 import type { StoryIndex } from '@storybook/types';
 
 const STORYBOOK_URL = 'https://story.smarthr-ui.dev';
+
+// NOTE:
+// story.smarthr-ui.dev はNetlifyの内部ビルダーからアクセスできないため、`index.json` は
+// ComponentStoryと同じく、利用中のバージョンのChromaticのパーマリンクから取得する。
+// iframeUrlはブラウザ（とサムネイル生成のPuppeteer）からのアクセスなので story.smarthr-ui.dev のままにしている。
+const CHROMATIC_STORYBOOK_URL = `https://${UI_COMMIT_HASH}--${SHRUI_CHROMATIC_ID}.chromatic.com/`;
 
 type StoryKind = {
   kindName: string;
@@ -73,8 +82,11 @@ const doesFileExist = async (...filePaths: string[]) => {
  * @returns StoryGroup[]
  */
 export async function fetchComponentCaptures() {
-  const indexJsonUrl = new URL('index.json', STORYBOOK_URL);
+  const indexJsonUrl = new URL('index.json', CHROMATIC_STORYBOOK_URL);
   const response = await fetch(indexJsonUrl.toString());
+  if (!response.ok) {
+    throw new Error(`Chromatic から index.json を取得できませんでした: ${response.statusText}`);
+  }
 
   const storiesJson: StoryIndex = await response.json();
 


### PR DESCRIPTION
Netlifyの内部ビルダーが story.smarthr-ui.dev にアクセスできなくなっため、`fetchComponentCaptures()` の index.json の取得先を ComponentStory と同じ Chromatic のパーマリンクに変更します。

iframeUrl はブラウザとサムネイル生成のPuppeteerからのアクセスなので story.smarthr-ui.dev のままにしています。

サムネイルのキャッシュ(thumbnails-cache.json) も従来どおり有効なまま機能します。

Chromaticパーマリンクのコミットハッシュは `getUIData.ts`（ `fetch-ui-data.ts` が作るキャッシュ）から 取得するため、`pnpm run generate:thumbnails` でも先に update:ui-data が走るように `pregenerate:thumbnails` を追加しています。

参照先が最新のStorybookからリリース済みバージョンのStorybookに変わるため、コンポーネント一覧に Fieldset と FormControl が追加されます。どちらも記事とサムネイル画像は存在していましが、最新のStorybookの構成が変わった影響で一覧から漏れていました。このPRで正常化します。