### PR TITLE
docs: Text の icon 説明追加と leading / 余白ガイドの整合

### DIFF
--- a/src/content/articles/products/components/text/index.mdx
+++ b/src/content/articles/products/components/text/index.mdx
@@ -110,6 +110,20 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
 </Stack>
 ```
 
+### アイコン
+`icon` propsでテキストの左右に[Icon](/products/components/icon/)を配置できます。
+
+アイコンのみを渡すと、テキストの左（プレフィックス）に配置されます。`prefix`・`suffix`・`gap`を指定すると、左右の配置やテキストとの間隔を制御できます。  
+アイコンの色や代替テキストの扱いは、[Icon](/products/components/icon/)を参照してください。
+
+```tsx editable
+<Stack>
+  <Text icon={<FaFileLinesIcon color="TEXT_GREY" />}>左にアイコンがあるテキスト</Text>
+  <Text icon={{ suffix: <FaCircleInfoIcon color="TEXT_GREY" /> }}>右にアイコンがあるテキスト</Text>
+  <Text icon={{ prefix: <FaLightbulbIcon color="MAIN" />, gap: 0.5 }}>間隔を広げたテキスト</Text>
+</Stack>
+```
+
 
 
 ## 使い方チェックリスト

--- a/src/content/articles/products/components/text/index.mdx
+++ b/src/content/articles/products/components/text/index.mdx
@@ -87,7 +87,7 @@ import ComponentStory from '@/components/article/ComponentStory.astro'
   <Text leading="NONE">行送りがないテキスト<br />行送りがないテキスト</Text>
   <Text leading="TIGHT">行送りが狭いテキスト<br />行送りが狭いテキスト</Text>
   <Text leading="NORMAL">通常の行送りのテキスト<br />通常の行送りのテキスト</Text>
-  <Text leading="RELEXED">行送りが広いテキスト<br />行送りが広いテキスト</Text>
+  <Text leading="LOOSE">行送りが広いテキスト<br />行送りが広いテキスト</Text>
 </Stack>
 ```
 

--- a/src/content/articles/products/design-patterns/spacing-layout-pattern/index.mdx
+++ b/src/content/articles/products/design-patterns/spacing-layout-pattern/index.mdx
@@ -156,7 +156,7 @@ SmartHRの製品開発では、人間の認知に関する以下の法則を考�
 
 | 場所 | デスクトップ・モバイル | 補足 |
 | :--- | :--- | :--- |
-| 1. [StatusLabel](/products/components/status-label/)やアイコンなどの要素をテキストと組み合わせる場合 | `0.5（8px）`<br />または<br />`0.25（4px）` | [InformationPanel](/products/components/information-panel/)や[FormControl](/products/components/form-control/)、[Fieldset](/products/components/fieldset/)、[TextLink](/products/components/text-link/)を利用することで、自動的に適用されます。その他の場合は、[Cluster](/products/components/layout/cluster/)を使用して余白を指定してください。 |
+| 1. [StatusLabel](/products/components/status-label/)やアイコンなどの要素をテキストと組み合わせる場合 | `0.5（8px）`<br />または<br />`0.25（4px）` | [Heading（icon props）](/products/components/heading/)、[InformationPanel](/products/components/information-panel/)や[FormControl](/products/components/form-control/)、[Fieldset](/products/components/fieldset/)、[Text（icon props）](/products/components/text/)、[TextLink](/products/components/text-link/)などを利用することで自動的に適用されます。コンポーネントで対応していない場合は、[Cluster](/products/components/layout/cluster/)を使用して余白を指定してください。 |
 | 2. フォームを水平方向に配置する場合 | `1（16px）` |  |
 | 3. [Checkbox](/products/components/checkbox/)や[RadioButton](/products/components/radio-button/)のcolumn-gap | `1.5（24px）` | [Cluster](/products/components/layout/cluster/)を使用して余白を指定してください。 |
 | 4. [Button](/products/components/button/)同士の間 | `0.5（8px）`<br />または<br />`1（16px）` |  |

--- a/src/content/articles/products/design-tokens/leading.mdx
+++ b/src/content/articles/products/design-tokens/leading.mdx
@@ -16,4 +16,4 @@ CSSでは`line-height`を指しています。
 | `NONE`    | 1    | [ラベルテキスト](/products/design-tokens/typography/#h3-4) |
 | `TIGHT`   | 1.25 | [Dialogのタイトル](/products/components/dialog/)、[Heading](/products/components/heading/)、[NotificationBar](/products/components/notification-bar/) |
 | `NORMAL`（標準）  | 1.5  | [段落テキスト](/products/design-tokens/typography/#h3-3) |
-| `RELAXED` | 1.75 | [Text](/products/components/text/)コンポーネントの`leading` propsでは`LOOSE`を指定してください。 |
+| `LOOSE` | 1.75 |  |

--- a/src/content/articles/products/design-tokens/leading.mdx
+++ b/src/content/articles/products/design-tokens/leading.mdx
@@ -16,6 +16,4 @@ CSSでは`line-height`を指しています。
 | `NONE`    | 1    | [ラベルテキスト](/products/design-tokens/typography/#h3-4) |
 | `TIGHT`   | 1.25 | [Dialogのタイトル](/products/components/dialog/)、[Heading](/products/components/heading/)、[NotificationBar](/products/components/notification-bar/) |
 | `NORMAL`（標準）  | 1.5  | [段落テキスト](/products/design-tokens/typography/#h3-3) |
-| `RELAXED` | 1.75 | |
-
-## ［WIP］コード
+| `RELAXED` | 1.75 | [Text](/products/components/text/)コンポーネントの`leading` propsでは`LOOSE`を指定してください。 |


### PR DESCRIPTION
## 課題・背景
* テキストとアイコンの組み合わせをAIが実装する際、Clusterで実装してくる理由が、[アイコンやラベルなどの小さい要素間のマージン](https://smarthr.design/products/design-patterns/spacing-layout-pattern/#h4-6)にTextなどがないためだったので追加したい。
* Textに `icon` props が説明がそもそもない
* 行送りトークンの `RELAXED` は、theme にはいるが、Text や TailwindCSS のプロパティでは `LOOSE` を使うので AI が誤解しないようにしたい。

## やったこと
- 余白・レイアウトパターンで、アイコンとテキストの余白が自動適用されるコンポーネントとして Heading / Text の `icon` props を追記
- Text に `icon` props の説明とサンプルを追加
- 行送りが `RELAXED` を `LOOSE` に修正

## やらなかったこと
- `RELAXED` は、theme にはいるが、多くの実装では `LOOSE` を使うと思うので寄せました。

## 動作確認
https://deploy-preview-2414--smarthr-design-system.netlify.app/products/design-patterns/spacing-layout-pattern/#h4-6
https://deploy-preview-2414--smarthr-design-system.netlify.app/products/components/text/#h3-8
https://deploy-preview-2414--smarthr-design-system.netlify.app/products/design-tokens/leading/#h2-0

## checklist.yaml の更新

- [ ] checklist.yaml に差分が出たコンポーネントは、その差分を PR に含めた
- [ ] 一部のコンポーネントで差分が出なかった（差分あり・なしが混在）→ `skip-checklist-update` ラベルを付与
- [x] すべてのコンポーネントで差分が出なかった → `skip-checklist-update` ラベルを付与

Text の `種類 > アイコン` は「〜できます」の機能説明のみで、checklist に載せる指示文がないため未更新。

## キャプチャ
なし


Made with [Cursor](https://cursor.com)