### PR TITLE
fix: 内部リンクを末尾スラッシュ付きの正規URLに揃える

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -56,7 +56,7 @@ const { isArticlePage } = Astro.props;
                 <ul>
                   {depth2Pages.map(({ id, data }) => (
                     <li>
-                      <a class="link" href={`/${id}`}>
+                      <a class="link" href={`/${id}/`}>
                         {data.title}
                       </a>
                     </li>

--- a/src/components/Sidebar/RecursiveSidebarItem.astro
+++ b/src/components/Sidebar/RecursiveSidebarItem.astro
@@ -24,7 +24,8 @@ if (items.length <= 0) {
     return (
       <li>
         <div class={`depth${depth}Item`}>
-          <a href={item.link} aria-current={item.link === currentPath}>
+          {/* href は末尾スラッシュ付きの正規URLにする。省略するとホスティング側で301を挟む */}
+          <a href={`${item.link}/`} aria-current={item.link === currentPath}>
             {item.title}
           </a>
           {item.children.length > 0 && (

--- a/src/components/Sidebar/SidebarItems.astro
+++ b/src/components/Sidebar/SidebarItems.astro
@@ -21,7 +21,8 @@ const { path, items, showDepth1Item = false } = Astro.props;
         {/* 第1階層 */}
         {showDepth1Item && (
           <h2 class="depth1Heading">
-            <a href={depth1Item.link} aria-current={depth1Item.link === path}>
+            {/* href は末尾スラッシュ付きの正規URLにする。省略するとホスティング側で301を挟む */}
+            <a href={`${depth1Item.link}/`} aria-current={depth1Item.link === path}>
               {depth1Item.title}
             </a>
           </h2>

--- a/src/components/article/PageIndex.astro
+++ b/src/components/article/PageIndex.astro
@@ -37,7 +37,8 @@ subPages.sort((a, b) => (a.data.order && b.data.order ? a.data.order - b.data.or
           <>
             {/* ページ内目次（IndexNav）のリンク先になるため、見出しには必ずidを振る */}
             <Heading class="pageTitleHeading" id={`${Heading}-${pageFileName}`}>
-              <a href={join('/', page.id)}>{page.data.deprecated ? `${page.data.title}（非推奨）` : page.data.title}</a>
+              {/* href は末尾スラッシュ付きの正規URLにする。join() は末尾スラッシュを落とすため使わない */}
+              <a href={`/${page.id}/`}>{page.data.deprecated ? `${page.data.title}（非推奨）` : page.data.title}</a>
             </Heading>
             {hasSlot ? <Fragment set:html={description} /> : <p>{description}</p>}
           </>

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -70,7 +70,7 @@ const nextSidebarItem = currentPageIndex < sidebarItemLength ? (flatArticleMetaI
               prevSidebarItem !== null && (
                 <li class="prevArticleLinkWrapper">
                   <RoundedBoxLink
-                    path={prevSidebarItem.link}
+                    path={`${prevSidebarItem.link}/`}
                     label="前へ"
                     title={prevSidebarItem.title}
                     align="left"
@@ -83,7 +83,7 @@ const nextSidebarItem = currentPageIndex < sidebarItemLength ? (flatArticleMetaI
               nextSidebarItem !== null && (
                 <li class="nextArticleLinkWrapper">
                   <RoundedBoxLink
-                    path={nextSidebarItem.link}
+                    path={`${nextSidebarItem.link}/`}
                     label="次へ"
                     title={nextSidebarItem.title}
                     align="right"


### PR DESCRIPTION
## 課題・背景

本番でサイドナビからページ遷移すると、画面全体が真っ白なまま復帰しない事象が発生しています。原因はキャッシュされた 301 リダイレクトでした。

サイドナビ・フッター・前後ページリンク・`PageIndex` が出力する href は末尾スラッシュなし（例: `/products/design-patterns/wizard`）ですが、`build.format` は既定の `directory` なので正規URLは末尾スラッシュ付きです。そのためホスティング側が 301 を返しています。

この 301 には `cache-control` / `etag` / `vary` がいずれも付いていません。

```
HTTP/2 301
content-type: text/html
location: /products/design-patterns/wizard/
content-length: 98
```

HTTP 仕様上 301 は既定でキャッシュ可能で、鮮度情報がなければブラウザは恒久的にキャッシュし、再検証のきっかけもありません。サイドナビだけで1ページに198本のリンクがこの 301 を指しており、prefetch（Safari は `rel=prefetch` 非対応のため実 `fetch()` にフォールバックする）がそれを一斉に先読みして、恒久キャッシュエントリを大量生成していました。

Safari での切り分け結果:

| 環境 | 永続キャッシュ | 再現 |
| --- | --- | --- |
| 本番・通常モード | あり | する |
| 本番・プライベートモード | なし | しない |
| Deploy Preview・通常モード | あり | する |
| Deploy Preview・「キャッシュを無効にする」 | 無効 | しない |

## やったこと

- `href` を出力している箇所を、末尾スラッシュ付きの正規URLに変更
  - `src/components/Sidebar/SidebarItems.astro`
  - `src/components/Sidebar/RecursiveSidebarItem.astro`
  - `src/layouts/ArticleLayout.astro`（前後ページリンク）
  - `src/components/Footer.astro`
  - `src/components/article/PageIndex.astro`（`join()` が末尾スラッシュを落とすため `/${page.id}/` に変更）

`link` は href と識別子を兼ねているため、`aria-current` や `startsWith` の比較、`mergeAndFilterItems` の正規表現には手を入れず、**href を出力する箇所だけ**を変更しています。検索ページとヘッダ（`navigationItem.json`）は元から末尾スラッシュ付きでした。

## やらなかったこと

- prefetch 設定（`prefetchAll: true` × `defaultStrategy: 'viewport'`）の変更。1ページで103リクエスト・5.20MB という実測値があり別途見直す価値はありますが、本件の原因ではないため含めていません
- `astro.config.mjs` への `trailingSlash: 'always'` の追加。再発防止になりますが、サイト全体のURL方針に関わるため分けています
- 記事本文（MDX）内のリンクの表記統一。今回の変更で 301 を踏むリンクは 0 本になっています

## 動作確認

- `pnpm astro build` 成功（334ページ、エラー0）
- ビルド後の `dist` 全334ページを走査し、**ページリンク 110,926 本すべてが末尾スラッシュ付き**であること（301 を踏むリンクが 0 本であること）を確認
  - 変更前は同じ走査で 31 本残っており、`PageIndex.astro` 由来と判明したため追加で修正
- サイドナビの `aria-current`（現在ページのハイライト）とアコーディオンの開閉が従来どおり動くこと

Deploy Preview で、通常モードのままサイドナビを渡り歩いて白画面が出ないことを確認してください。既に壊れたキャッシュを持っているブラウザでは、一度キャッシュを消してから試す必要があります。

## キャプチャ

画面上の見た目の変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)