### PR TITLE
モバイル非対応画面を明示するガイドラインを追加

### DIFF
--- a/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
+++ b/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
@@ -3,7 +3,7 @@ title: 'モバイルレイアウト'
 description: 'モバイル対応をする基準と、その対応方法を定義します。'
 order: 5
 ---
-import DoAndDont from '@/components/article/DoAndDont.astro'
+
 import { BaseColumn, ResponseMessage } from 'smarthr-ui'
 
 モバイル対応をする基準と、その対応方法を定義します。
@@ -73,6 +73,80 @@ export const YourComponent = () => {
 }
 ```
 
+### モバイルからの利用を推奨しない管理者向けの画面にはNotificationBarを表示する
+
+モバイルからの利用を推奨しない管理者向けの画面には、デスクトップでの利用を促す[NotificationBar](/products/components/notification-bar/)を表示します。レスポンシブ/アダプティブレイアウトが十分に適用されていないことで、ユーザーのページの理解や操作が妨げられる可能性があるためです。
+
+`warning`の[NotificationBar](/products/components/notification-bar/)を表示します。文言は`管理者向け機能は、スマートフォンで正常に動作しない場合があります。`とし、[SmartHRの動作環境](https://support.smarthr.jp/ja/help/articles/360035170054/)への[HelpLink](/products/components/text-link/help-link/)も合わせて表示します。
+
+<div style="max-width: 448px">
+```tsx editable background=DOT hideCode
+<EnvironmentProvider environment={{ mobile: true }}>
+  <div className="shr-w-full shr-bg-background">
+    <AppHeader
+      appName="すごいアプリ"
+      currentTenantId="tenant-1"
+      features={[
+        {
+          favorite: false,
+          id: 'feature-1',
+          name: '従業員リスト',
+          position: null,
+          url: 'https://example.com'
+        },
+      ]}
+      navigations={[
+        {
+          children: 'ホーム',
+          href: 'https://example.com'
+        },
+      ]}
+      helpPageUrl="https://example.com"
+      schoolUrl="https://example.com"
+      userInfo={{
+        accountUrl: 'https://example.com',
+        email: 'smarthr@example.com',
+        empCode: '001',
+        firstName: '須磨',
+        lastName: '栄子'
+      }}
+    />
+    <NotificationBar type="warning" onClose={() => {}}>
+      { /* メッセージ領域はflexなので、本文とリンクを分けると別カラムに折り返される。1つの要素にまとめて本文中に流す。 */ }
+      <span>
+        管理者向け機能は、スマートフォンで正常に動作しない場合があります。
+        <HelpLink href="https://support.smarthr.jp/ja/help/articles/360035170054/" target="_blank">SmartHRの動作環境</HelpLink>
+      </span>
+    </NotificationBar>
+    <Container>
+      <Stack gap={2}>
+        <Stack>
+          { /* プロダクトではautoPageTitleはtrueがデフォルトですが、デザインシステムでは例にもかかわらずページの見出しが変わってしまうためfalseにしています。 */ }
+          <PageHeading autoPageTitle={false}>ページタイトル</PageHeading>
+          <p>このページについての説明。</p>
+        </Stack>
+        <Stack>
+          <Cluster align="center" justify="space-between">
+            <Heading>セクションタイトル</Heading>
+            <Button>ボタン</Button>
+          </Cluster>
+          <Base padding={{ block: 1.5, inline: 1 }}>
+            <Stack>
+              <Heading type="blockTitle">ブロックタイトル</Heading>
+              <DefinitionList>
+                <DefinitionListItem maxColumns={3} term="項目">内容</DefinitionListItem>
+                <DefinitionListItem maxColumns={3} term="項目">内容</DefinitionListItem>
+                <DefinitionListItem maxColumns={3} term="項目">内容</DefinitionListItem>
+              </DefinitionList>
+            </Stack>
+          </Base>
+        </Stack>
+      </Stack>
+    </Container>
+  </div>
+</EnvironmentProvider>
+```
+</div>
 
 ## 参考
 

--- a/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
+++ b/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
@@ -77,7 +77,7 @@ export const YourComponent = () => {
 
 モバイルからの利用を推奨しない管理者向けの画面には、デスクトップでの利用を促す[NotificationBar](/products/components/notification-bar/)を表示します。レスポンシブ/アダプティブレイアウトが十分に適用されていないことで、ユーザーのページの理解や操作が妨げられる可能性があるためです。
 
-`warning`の[NotificationBar](/products/components/notification-bar/)を表示します。文言は`管理者向け機能は、スマートフォンで正常に動作しない場合があります。`とし、[SmartHRの動作環境](https://support.smarthr.jp/ja/help/articles/360035170054/)への[HelpLink](/products/components/text-link/help-link/)も合わせて表示します。
+`info`の[NotificationBar](/products/components/notification-bar/)を表示します。文言は`スマートフォンでは、この画面のレイアウトが正しく表示されない場合があります。`とします。
 
 <div style="max-width: 448px">
 ```tsx editable background=DOT hideCode
@@ -111,12 +111,8 @@ export const YourComponent = () => {
         lastName: '栄子'
       }}
     />
-    <NotificationBar type="warning" onClose={() => {}}>
-      { /* メッセージ領域はflexなので、本文とリンクを分けると別カラムに折り返される。1つの要素にまとめて本文中に流す。 */ }
-      <span>
-        管理者向け機能は、スマートフォンで正常に動作しない場合があります。
-        <HelpLink href="https://support.smarthr.jp/ja/help/articles/360035170054/" target="_blank">SmartHRの動作環境</HelpLink>
-      </span>
+    <NotificationBar type="info" onClose={() => {}}>
+        スマートフォンでは、この画面のレイアウトが正しく表示されない場合があります。
     </NotificationBar>
     <Container>
       <Stack gap={2}>

--- a/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
+++ b/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
@@ -80,67 +80,148 @@ export const YourComponent = () => {
 [NotificationBar](/products/components/notification-bar/)（`info`タイプ）で`管理者・担当者向け画面はスマートフォンで正しく表示されない場合があります。`と表示します。
 
 <div style="max-width: 448px">
-```tsx editable background=DOT hideCode
-<EnvironmentProvider environment={{ mobile: true }}>
-  <div className="shr-w-full shr-bg-background">
-    <AppHeader
-      appName="すごいアプリ"
-      currentTenantId="tenant-1"
-      features={[
-        {
-          favorite: false,
-          id: 'feature-1',
-          name: '従業員リスト',
-          position: null,
-          url: 'https://example.com'
-        },
-      ]}
-      navigations={[
-        {
-          children: 'ホーム',
-          href: 'https://example.com'
-        },
-      ]}
-      helpPageUrl="https://example.com"
-      schoolUrl="https://example.com"
-      userInfo={{
-        accountUrl: 'https://example.com',
-        email: 'smarthr@example.com',
-        empCode: '001',
-        firstName: '須磨',
-        lastName: '栄子'
-      }}
-    />
-    <NotificationBar type="info" onClose={() => {}}>
-        管理者・担当者向け画面はスマートフォンで正しく表示されない場合があります。
-    </NotificationBar>
-    <Container>
-      <Stack gap={2}>
-        <Stack>
-          { /* プロダクトではautoPageTitleはtrueがデフォルトですが、デザインシステムでは例にもかかわらずページの見出しが変わってしまうためfalseにしています。 */ }
-          <PageHeading autoPageTitle={false}>ページタイトル</PageHeading>
-          <p>このページについての説明。</p>
-        </Stack>
-        <Stack>
-          <Cluster align="center" justify="space-between">
-            <Heading>セクションタイトル</Heading>
-            <Button>ボタン</Button>
-          </Cluster>
-          <Base padding={{ block: 1.5, inline: 1 }}>
+```tsx editable background=DOT hideCode withStyled
+const MobileUnsupportedPage = () => {
+  const pagination = {
+    currentPage: 1,
+    limitValue: 25,
+    totalCount: 100,
+    totalPages: 4,
+  }
+  const sampleObjects = [...Array(3).fill(0)].map((_, i) => ({
+    id: `${i}`,
+    href: '#',
+    empCode: `SHR${`${i}`.padStart(3, '0')}`,
+    name: `須磨 英子`,
+    status: 'ステータス',
+  }))
+
+  const { totalPages, currentPage, totalCount, limitValue } = pagination
+  const isInitialState = totalCount === 0
+  const hasNoSearchResult = totalCount === 0
+
+  return (
+    <EnvironmentProvider environment={{ mobile: true }}>
+      <div className="shr-w-full shr-bg-background">
+        <AppHeader
+          appName="すごいアプリ"
+          currentTenantId="tenant-1"
+          features={[
+            {
+              favorite: false,
+              id: 'feature-1',
+              name: '従業員リスト',
+              position: null,
+              url: 'https://example.com'
+            },
+          ]}
+          navigations={[
+            {
+              children: 'ホーム',
+              href: 'https://example.com'
+            },
+          ]}
+          helpPageUrl="https://example.com"
+          schoolUrl="https://example.com"
+          userInfo={{
+            accountUrl: 'https://example.com',
+            email: 'smarthr@example.com',
+            empCode: '001',
+            firstName: '須磨',
+            lastName: '栄子'
+          }}
+        />
+        <NotificationBar type="info" onClose={() => {}}>
+          管理者・担当者向け画面はスマートフォンで正しく表示されない場合があります。
+        </NotificationBar>
+        <Container>
+          <Stack gap={2}>
             <Stack>
-              <Heading type="blockTitle">ブロックタイトル</Heading>
-              <DefinitionList>
-                <DefinitionListItem maxColumns={3} term="項目">内容</DefinitionListItem>
-                <DefinitionListItem maxColumns={3} term="項目">内容</DefinitionListItem>
-                <DefinitionListItem maxColumns={3} term="項目">内容</DefinitionListItem>
-              </DefinitionList>
+              { /* プロダクトではautoPageTitleはtrueがデフォルトですが、デザインシステムでは例にもかかわらずページの見出しが変わってしまうためfalseにしています。 */ }
+              <PageHeading autoPageTitle={false}>ページタイトル</PageHeading>
+              <p>このページについての説明。</p>
             </Stack>
-          </Base>
-        </Stack>
-      </Stack>
-    </Container>
-  </div>
-</EnvironmentProvider>
+            <Section>
+              <Stack>
+                <Cluster align="center" justify="space-between">
+                  <Heading>セクションタイトル</Heading>
+                  <Button prefix={<FaCirclePlusIcon />}>オブジェクトを追加</Button>
+                </Cluster>
+
+                <Stack gap={1.5}>
+                  <Base>
+                    <Cluster justify="space-between" align="center" className="shr-p-1">
+                      <form onSubmit={(e) => e.preventDefault()}>
+                        <Cluster align="center" gap={1}>
+                          <Cluster>
+                            <SearchInput tooltipMessage="オブジェクト名で検索できます。" name="search" />
+                            <Button type="submit">検索</Button>
+                          </Cluster>
+                          <FilterDropdown onApply={() => null}>絞り込みの中身</FilterDropdown>
+                          <Button type="submit" prefix={<FaCloudArrowDownIcon />}>
+                            ダウンロード
+                          </Button>
+                        </Cluster>
+                      </form>
+                      <Cluster gap={1} align="center">
+                        <PageCounter start={1 + (currentPage - 1) * limitValue} end={currentPage * limitValue} total={totalCount} />
+                        <Pagination current={currentPage} total={totalPages} withoutNumbers onClick={() => null} />
+                      </Cluster>
+                    </Cluster>
+
+                    <Table reel rounded="bottom">
+                      <thead>
+                        <tr>
+                          <ThCheckbox name="allRowCheckbox" />
+                          <Th>ステータス</Th>
+                          <Th>社員番号</Th>
+                          <Th>氏名</Th>
+                          <Th>操作</Th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {sampleObjects.map(({ id, status, href, empCode, name }) => {
+                          const ariaLabelledBy = `name-${id}`
+                          return (
+                            <tr key={id}>
+                              <TdCheckbox name="tableCheckbox" aria-labelledby={ariaLabelledBy} />
+                              <Td contentWidth="1px">
+                                <StatusLabel>{status}</StatusLabel>
+                              </Td>
+                              <Td>{empCode}</Td>
+                              <Td id={ariaLabelledBy}><TextLink href={href}>{name}</TextLink></Td>
+                              <Td contentWidth="1px">
+                                <Cluster inline className="shr-min-w-max">
+                                  <Button size="S" prefix={<FaPenIcon />}>
+                                    操作1
+                                  </Button>
+                                  <Button size="S" prefix={<FaCopyIcon />}>
+                                    操作2
+                                  </Button>
+                                  <Button size="S" prefix={<FaTrashCanIcon/>}>
+                                    操作3
+                                  </Button>
+                                </Cluster>
+                              </Td>
+                            </tr>
+                        )})}
+                      </tbody>
+                    </Table>
+                  </Base>
+                  <Center>
+                    <Pagination current={currentPage} total={totalPages} onClick={() => null} />
+                  </Center>
+                </Stack>
+              </Stack>
+            </Section>
+          </Stack>
+        </Container>
+      </div>
+    </EnvironmentProvider>
+  )
+}
+
+render(<MobileUnsupportedPage />)
 ```
 </div>
 

--- a/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
+++ b/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
@@ -77,7 +77,7 @@ export const YourComponent = () => {
 
 モバイルからの利用を推奨しない管理者向けの画面には、デスクトップでの利用を促す[NotificationBar](/products/components/notification-bar/)を表示します。レスポンシブ/アダプティブレイアウトが十分に適用されていないことで、ユーザーのページの理解や操作が妨げられる可能性があるためです。
 
-`info`の[NotificationBar](/products/components/notification-bar/)を表示します。文言は`スマートフォンでは、この画面のレイアウトが正しく表示されない場合があります。`とします。
+`info`の[NotificationBar](/products/components/notification-bar/)を表示します。文言は`管理者・担当者向け画面はスマートフォンで正しく表示されない場合があります。`とします。
 
 <div style="max-width: 448px">
 ```tsx editable background=DOT hideCode
@@ -112,7 +112,7 @@ export const YourComponent = () => {
       }}
     />
     <NotificationBar type="info" onClose={() => {}}>
-        スマートフォンでは、この画面のレイアウトが正しく表示されない場合があります。
+        管理者・担当者向け画面はスマートフォンで正しく表示されない場合があります。
     </NotificationBar>
     <Container>
       <Stack gap={2}>

--- a/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
+++ b/src/content/articles/products/design-patterns/mobile-friendly-layout/index.mdx
@@ -75,9 +75,9 @@ export const YourComponent = () => {
 
 ### モバイルからの利用を推奨しない管理者向けの画面にはNotificationBarを表示する
 
-モバイルからの利用を推奨しない管理者向けの画面には、デスクトップでの利用を促す[NotificationBar](/products/components/notification-bar/)を表示します。レスポンシブ/アダプティブレイアウトが十分に適用されていないことで、ユーザーのページの理解や操作が妨げられる可能性があるためです。
+モバイルからの利用を推奨しない管理者向けの画面には、デスクトップでの利用を促す[NotificationBar](/products/components/notification-bar/)を表示します。モバイルレイアウトが十分に適用されていないことで、ユーザーのページの理解や操作が妨げられる可能性があるためです。
 
-`info`の[NotificationBar](/products/components/notification-bar/)を表示します。文言は`管理者・担当者向け画面はスマートフォンで正しく表示されない場合があります。`とします。
+[NotificationBar](/products/components/notification-bar/)（`info`タイプ）で`管理者・担当者向け画面はスマートフォンで正しく表示されない場合があります。`と表示します。
 
 <div style="max-width: 448px">
 ```tsx editable background=DOT hideCode


### PR DESCRIPTION
## 課題・背景

モバイル非対応画面にスマートフォンでアクセスしたユーザーがレイアウトを不具合と感じ、問い合わせに繋がっている。
https://kufuinc.slack.com/archives/CDG1XRPTP/p1785211027438539?thread_ts=1785211007.306969&cid=CDG1XRPTP
<!--
簡単な概要、課題・背景を書こう。
issueのURLも貼ってね。
-->

## やったこと
- 「モバイルレイアウト」に、管理者向け画面にモバイルでアクセスした際にNotificationBarを出すガイドラインを追記

<!--
- 〇〇に追記
- 〇〇ページを追加
-->

## やらなかったこと
- 管理者画面ではないがモバイル対応が十分でない画面についても、同様のNotificationBarの表示を検討したが、今回は記載していない。
    - 従業員向けの画面がうまく動作していないのであれば[SmartHRの動作環境](https://support.smarthr.jp/ja/help/articles/360035170054/)を満たせておらず、プロダクトそのものの改善が必要なため
    - [Slackの投稿](https://kufuinc.slack.com/archives/CDG1XRPTP/p1785211027438539?thread_ts=1785211007.306969&cid=CDG1XRPTP
)で挙げられているプロダクトに関しては、使いづらさはあれど特定の機能や情報へのアクセスができない致命的な状態ではない（今回対象とした管理者画面は致命的である可能性がある）

<!--
e.g.
- 見た目の調整
-->

## 動作確認

https://deploy-preview-2434--smarthr-design-system.netlify.app/products/design-patterns/mobile-friendly-layout/#h3-4

## キャプチャ

|Before|After|
| --- | --- |
| <!-- Before --> | <!-- After --> |

<!--
画面の変更がある場合は、修正前後のキャプチャを貼りつけ、
「どこ」が「どのように」変化しているのかをレビューしやすい状態にしましょう
-->
