### PR TITLE
fix: Tableコンポーネントページへのデッドリンクを修正する

### DIFF
--- a/scripts/content-checker/README.md
+++ b/scripts/content-checker/README.md
@@ -10,7 +10,7 @@ MDXファイル内のリンク（アンカーリンク含む）と画像につ�
 
 #### 手動での実行
 ```sh
-pnpx tsx scripts/content-checker/linkChecker.ts --fix ./src/content/articles/**/*.mdx
+pnpm exec tsx scripts/content-checker/linkChecker.ts --fix ./src/content/articles/**/*.mdx
 ```
 
 - `--fix`オプションをつけると、末尾スラッシュについては自動的に修正します。
@@ -34,7 +34,7 @@ pnpx tsx scripts/content-checker/linkChecker.ts --fix ./src/content/articles/**/
 
 #### 手動での実行
 ```
-pnpx tsx ./scripts/content-checker/storybookUrlChecker.ts
+pnpm exec tsx ./scripts/content-checker/storybookUrlChecker.ts
 ```
 
 指定できるオプションはありません。

--- a/src/content/articles/products/components/checkbox/index.mdx
+++ b/src/content/articles/products/components/checkbox/index.mdx
@@ -325,8 +325,8 @@ import { Cluster, Text } from 'smarthr-ui'
 
 詳しい実装方法と注意点については、以下の[Table](/products/components/table/)コンポーネントのドキュメントを参照してください。
 
-- [セル内にチェックボックスやラジオボタンをそのまま配置しない](/products/components/table/#h3-0)
-- [`TdCheckbox`および`TdRadioButton`では行を特定できる要素をIDで参照する](/products/components/table/#h3-1)
+- [セル内にチェックボックスやラジオボタンをそのまま配置しない](/products/components/table/#h4-0)
+- [`TdCheckbox`および`TdRadioButton`では行を特定できる要素をIDで参照する](/products/components/table/#h4-1)
 
 #### Fieldsetでグループ化する
 複数のCheckboxをグループとして提示する場合は、[Fieldset](/products/components/fieldset/)コンポーネントを使用してグループ化し、`legend` propsでグループの目的を説明してください。これにより、関連するCheckboxを「同じ質問・設定グループ」としてスクリーンリーダーへ正しく伝えられ、フォームの文脈を理解しやすくなります。

--- a/src/content/articles/products/components/radio-button/index.mdx
+++ b/src/content/articles/products/components/radio-button/index.mdx
@@ -134,8 +134,8 @@ RadioButtonは常に1つの選択肢が選択されているコンポーネン�
 
 詳しい実装方法と注意点については、以下の[Table](/products/components/table/)コンポーネントのドキュメントを参照してください。
 
-- [セル内にチェックボックスやラジオボタンをそのまま配置しない](/products/components/table/#h3-0)
-- [TdCheckboxおよびTdRadioButtonでは行を特定できる要素をIDで参照する](/products/components/table/#h3-1)
+- [セル内にチェックボックスやラジオボタンをそのまま配置しない](/products/components/table/#h4-0)
+- [`TdCheckbox`および`TdRadioButton`では行を特定できる要素をIDで参照する](/products/components/table/#h4-1)
 
 #### Fieldsetでグループ化する
 `RadioButton`は、複数の選択肢から1つだけ選択するためのコンポーネントです。

--- a/src/content/articles/products/design-patterns/table-bulk-action/index.mdx
+++ b/src/content/articles/products/design-patterns/table-bulk-action/index.mdx
@@ -86,7 +86,7 @@ SmartHR UIではこのエリアを`BulkActionRow`と呼んでいます。
 #### すべてのオブジェクトの選択
 複数のページに分けてオブジェクトを表示している場合に、ページの枠を超えてすべてのオブジェクトを選択できるUIです。
 
-「すべてのオブジェクトを選択」のボタンを配置する際は、[Button[variant="tertiary"]](/products/components/button/#h3-3)を使用してください。詳しくは[Tableコンポーネント | BulkActionRowではTertiaryボタンを使用する](/products/components/table/#h3-2)を参照してください。
+「すべてのオブジェクトを選択」のボタンを配置する際は、[Button[variant="tertiary"]](/products/components/button/#h3-3)を使用してください。詳しくは[Tableコンポーネント | BulkActionRowではTertiaryボタンを使用する](/products/components/table/#h4-2)を参照してください。
 
 具体的な動作については、[すべてのオブジェクトを選択する動作](#h2-2)を参照してください。
 


### PR DESCRIPTION
## 課題・背景

[Tableコンポーネントのページ構成が変更された](https://github.com/kufu/smarthr-design-system/pull/2358/changes#diff-4c8160278266a8f059783396ca787f59ebae57aa127a0ae20cbbbb60ac78b906R37)のでいくつかのページからのリンクが無効になっていました。

## やったこと
- リンク先を修正した
- リンクチェックのスクリプト例を修正した

## 動作確認

- [テーブル内の一括操作](https://deploy-preview-2435--smarthr-design-system.netlify.app/products/design-patterns/table-bulk-action/#h4-2)ページの `詳しくはTableコンポーネント | BulkActionRowではTertiaryボタンを使用するを参照してください。` のリンク先がラベル通りか
- [Checbkoxコンポーネント](https://deploy-preview-2435--smarthr-design-system.netlify.app/products/components/checkbox/#h4-5)ページの `セル内にチェックボックスやラジオボタンをそのまま配置しない` と `TdCheckboxおよびTdRadioButtonでは行を特定できる要素をIDで参照する` のリンク先がラベル通りか
- [RadioButtonコンポーネント](https://deploy-preview-2435--smarthr-design-system.netlify.app/products/components/radio-button/#h3-4)ページの `セル内にチェックボックスやラジオボタンをそのまま配置しない` と `TdCheckboxおよびTdRadioButtonでは行を特定できる要素をIDで参照する` のリンク先がラベル通りか

