### PR TITLE
chore: smarthr-ui を v99.5.0 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-instantsearch-core": "^7.46.0",
     "react-live": "^4.1.8",
     "smarthr-normalize-css": "^1.1.0",
-    "smarthr-ui": "^99.3.2",
+    "smarthr-ui": "^99.5.0",
     "styled-components": "^6.5.3",
     "typescript": "^6.0.3",
     "yaml": "^2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       smarthr-ui:
-        specifier: ^99.3.2
-        version: 99.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.12)(yaml@2.9.0)
+        specifier: ^99.5.0
+        version: 99.5.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.12)(yaml@2.9.0)
       styled-components:
         specifier: ^6.5.3
         version: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -220,8 +220,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0
       smarthr-ui:
-        specifier: ^99.3.2
-        version: 99.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.12)(yaml@2.9.0)
+        specifier: ^99.5.0
+        version: 99.5.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -5174,8 +5174,8 @@ packages:
   smarthr-normalize-css@1.1.0:
     resolution: {integrity: sha512-RNi5bkp8dYvZs/yqOihZ+an5Wf3oXiBMRRvSYhCKNhV+Qkg1otqIxmP3ELUWVwMZx9v+zZG1LLAJ0sxPkHXOcg==}
 
-  smarthr-ui@99.3.2:
-    resolution: {integrity: sha512-kIxgntdXsFdKAJ4zv3EwQctRrlso4RhRbVjkYDJp34V7Jv+BW8YgLIoD3iSF/xC63P/Jg466rOICw7IrrC//FQ==}
+  smarthr-ui@99.5.0:
+    resolution: {integrity: sha512-SdMjJf4WBiDVQ9MAh29qNj6T682V3jeENbvBbHq5nQ/746LWM69prnOcfjDT/X+0ha5cONHG33VHvunNRksD6w==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -6080,18 +6080,6 @@ packages:
 
   write-file-atomic@1.3.4:
     resolution: {integrity: sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==}
-
-  ws@8.21.2:
-    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
@@ -7476,7 +7464,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.8.5
       util: 0.12.5
-      ws: 8.21.2
+      ws: 8.21.3
     optionalDependencies:
       prettier: 3.9.6
     transitivePeerDependencies:
@@ -12189,7 +12177,7 @@ snapshots:
     transitivePeerDependencies:
       - styled-components
 
-  smarthr-ui@99.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.12)(yaml@2.9.0):
+  smarthr-ui@99.5.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-intl@10.1.6(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       '@smarthr/wareki': 1.3.1
       dayjs: 1.11.23
@@ -13364,8 +13352,6 @@ snapshots:
       graceful-fs: 4.2.11
       imurmurhash: 0.1.4
       slide: 1.1.6
-
-  ws@8.21.2: {}
 
   ws@8.21.3: {}
 

--- a/scripts/component-thumbnails/thumbnails-cache.json
+++ b/scripts/component-thumbnails/thumbnails-cache.json
@@ -113,12 +113,6 @@
     "iframeUrl": "https://story.smarthr-ui.dev/iframe.html?id=components-floatarea--playground&viewMode=story&shortcuts=false&singleStory=true",
     "displayName": "FloatArea"
   },
-  "Components/FormControl-Components-FormControl.png": {
-    "kindName": "Components/FormControl",
-    "thumbnailFileName": "Components-FormControl.png",
-    "iframeUrl": "https://story.smarthr-ui.dev/iframe.html?id=components-formcontrol--default&viewMode=story&shortcuts=false&singleStory=true",
-    "displayName": "FormControl"
-  },
   "Components/Header-Components-Header.png": {
     "kindName": "Components/Header",
     "thumbnailFileName": "Components-Header.png",

--- a/scripts/fetch-ui-data.ts
+++ b/scripts/fetch-ui-data.ts
@@ -23,6 +23,7 @@ type ReleaseResponse = {
 
 type CommitResponse = {
   sha: string;
+  parents?: { sha: string }[];
 };
 
 type PropsResponse = {
@@ -108,23 +109,54 @@ const getUIProps = (): UIProps[] => {
   return uiProps;
 };
 
+const CHROMATIC_SHA_LOOKUP_LIMIT = 5;
+
+/**
+ * Chromatic の SHA パーマリンクから index.json を取得する。
+ * リリースコミット自体にビルドが無い場合があるため、親コミットも順に探す。
+ */
+async function fetchChromaticIndex(startSha: string): Promise<{ commitHash: string; json: StoryIndex }> {
+  let sha = startSha;
+
+  for (let attempt = 0; attempt < CHROMATIC_SHA_LOOKUP_LIMIT; attempt++) {
+    const commitHash = sha.substring(0, 7);
+    const endpoint = new URL('index.json', `https://${commitHash}--${CHROMATIC_DOMAIN}`);
+    const res = await fetch(endpoint.toString());
+
+    if (res.ok) {
+      const json: StoryIndex = await res.json();
+      if (json) {
+        if (attempt > 0) {
+          console.log(`ℹ️ Chromatic は親コミット ${commitHash} の Storybook を使用します`);
+        }
+        return { commitHash, json };
+      }
+    }
+
+    const commitEndpoint = new URL(`/repos/kufu/smarthr-ui/commits/${sha}`, GH_API_BASE_URL);
+    const commitRes = await fetch(commitEndpoint.toString());
+    if (!commitRes.ok) {
+      break;
+    }
+
+    const commit: CommitResponse = await commitRes.json();
+    const parentSha = commit.parents?.[0]?.sha;
+    if (!parentSha) {
+      break;
+    }
+
+    console.log(`⚠️ Chromatic に ${commitHash} の Storybook がありません。親コミット ${parentSha.substring(0, 7)} を試します`);
+    sha = parentSha;
+  }
+
+  throw new Error(`Chromatic から index.json を取得できませんでした（起点: ${startSha.substring(0, 7)}）`);
+}
+
 /**
  * Chromatic から Storybook の情報を取得
- * @param commitHash 対象のコミットハッシュ
+ * @param json Chromatic の index.json
  */
-async function fetchStories(commitHash: string): Promise<Record<string, UIStories>> {
-  const endpoint = new URL('index.json', `https://${commitHash}--${CHROMATIC_DOMAIN}`);
-
-  const res = await fetch(endpoint.toString());
-  if (!res.ok) {
-    throw new Error(`Chromatic から index.json を取得できませんでした: ${res.statusText}`);
-  }
-
-  const json: StoryIndex = await res.json();
-  if (!json) {
-    throw new Error('index.json が見つかりませんでした');
-  }
-
+function fetchStories(json: StoryIndex): Record<string, UIStories> {
   // *.stories.tsxのファイルごとに、storyの情報をまとめる
   const uiStories: Record<string, UIStories> = {};
 
@@ -197,10 +229,9 @@ if (cached) {
   console.log('📦️ リリース情報を取得中');
   const usedVersionRelease = await fetchSmartHRUIRelease();
 
-  const commitHash = usedVersionRelease.sha.substring(0, 7);
-
   console.log('📚️ stories.json を取得中');
-  const uiStories = await fetchStories(commitHash);
+  const { commitHash, json } = await fetchChromaticIndex(usedVersionRelease.sha);
+  const uiStories = fetchStories(json);
 
   console.log('✅️ 取得完了');
 

--- a/scripts/generate-skills/coverage.ts
+++ b/scripts/generate-skills/coverage.ts
@@ -17,7 +17,8 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
-import { parseMetadata, loadPublicExports, type ComponentGroup } from './lib/parse-metadata.js';
+import { parseMetadata, loadPublicExports } from './lib/parse-metadata.js';
+import { autoSplitGroups } from './lib/auto-split-groups.js';
 import { collectRelatedComponents } from './lib/related-components.js';
 import { buildDirMapping, loadManualMappings } from './lib/name-mapping.js';
 import {
@@ -35,37 +36,6 @@ const DESIGN_SYSTEM_DIR = process.env.DESIGN_SYSTEM_DIR ?? path.join(REPO_ROOT, 
 const MANUAL_MAPPING_PATH = path.join(__dirname, 'mapping/component-dir-map.json');
 const COVERAGE_BASELINE_PATH = path.join(__dirname, 'coverage-baseline.json');
 
-/**
- * index.ts と同じ autoSplitGroups ロジック。coverage 単独で実行する際にも
- * groups を split 後の形に揃える必要があるため複製している。
- */
-function autoSplitGroups(groups: Map<string, ComponentGroup>, relatedNames: Set<string>): Map<string, ComponentGroup> {
-  const result = new Map<string, ComponentGroup>();
-  for (const [dirName, group] of groups) {
-    const splitTargets = group.components.filter((c) => relatedNames.has(c.displayName));
-    if (splitTargets.length < 2) {
-      result.set(dirName, group);
-      continue;
-    }
-    for (const target of splitTargets) {
-      result.set(target.displayName, {
-        dirName: target.displayName,
-        displayNames: [target.displayName],
-        components: [target],
-      });
-    }
-    const primary = group.components.filter((c) => c.displayName === dirName);
-    if (primary.length > 0) {
-      result.set(dirName, {
-        dirName,
-        displayNames: primary.map((c) => c.displayName),
-        components: primary,
-      });
-    }
-  }
-  return result;
-}
-
 function main() {
   console.log('📂 metadata.json を読み込み中…');
   const publicExports = loadPublicExports();
@@ -74,7 +44,7 @@ function main() {
   console.log('🧬 relatedComponents 宣言を集約中…');
   const relatedSkills = collectRelatedComponents(DESIGN_SYSTEM_DIR);
 
-  const groups = autoSplitGroups(rawGroups, new Set(relatedSkills.keys()));
+  const groups = autoSplitGroups(rawGroups, new Set(relatedSkills.keys()), DESIGN_SYSTEM_DIR);
 
   console.log('🗺️  デザインシステムディレクトリのマッピング構築中…');
   const manualMappings = loadManualMappings(MANUAL_MAPPING_PATH);

--- a/scripts/generate-skills/index.ts
+++ b/scripts/generate-skills/index.ts
@@ -3,7 +3,8 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { parseMetadata, loadPublicExports, type ComponentGroup } from './lib/parse-metadata.js';
+import { parseMetadata, loadPublicExports } from './lib/parse-metadata.js';
+import { autoSplitGroups } from './lib/auto-split-groups.js';
 import { fetchEslintRules, buildComponentRuleMap, type EslintRuleWithContent } from './lib/fetch-eslint-rules.js';
 import { parseChecklist } from './lib/parse-checklist.js';
 import { parseIndexMdx, type IndexMdxInfo } from './lib/parse-index-mdx.js';
@@ -27,50 +28,6 @@ const COVERAGE_BASELINE_PATH = path.join(__dirname, 'coverage-baseline.json');
 const ESLINT_SNAPSHOT_PATH = path.join(__dirname, 'eslint-rules-snapshot.json');
 const ESLINT_RULE_NAMES_PATH = path.join(REPO_ROOT, '.github/data/eslint-rule-names.txt');
 
-/**
- * smarthr-ui の親ディレクトリ単位グループから、design-system 側の `relatedComponents` 宣言に
- * 含まれる displayName を個別グループとして分離する。残った displayName は元の親グループ名
- * で保持する。
- *
- * 例: smarthr-ui `Dialog/RemoteDialogTrigger/` 配下に `ActionDialog/FormDialog/MessageDialog/
- * StepFormDialog/RemoteDialogTrigger` がまとめられている場合、design-system `dialog/index.mdx`
- * の `relatedComponents` 宣言を起点に各 displayName を独立グループへ分離する。
- */
-function autoSplitGroups(groups: Map<string, ComponentGroup>, relatedNames: Set<string>): Map<string, ComponentGroup> {
-  const result = new Map<string, ComponentGroup>();
-  for (const [dirName, group] of groups) {
-    const splitTargets = group.components.filter((c) => relatedNames.has(c.displayName));
-    // 分離トリガは「relatedComponents 宣言が 2 件以上 group 内に存在する」ときに発動する。
-    // これにより、smarthr-ui の親ディレクトリに複数の displayName が同居しているグループ
-    // (例: `Dialog/RemoteDialogTrigger/` 配下に 5 つの Dialog) のみが分離対象となる。
-    // 1 件以下の場合は元グループをそのまま保持し、`ControlledStepFormDialog` グループの
-    // `StepFormDialogItem` のような同居 named export を取りこぼさない。
-    if (splitTargets.length < 2) {
-      result.set(dirName, group);
-      continue;
-    }
-    for (const target of splitTargets) {
-      result.set(target.displayName, {
-        dirName: target.displayName,
-        displayNames: [target.displayName],
-        components: [target],
-      });
-    }
-    // 親グループ自体は、group 名と同名の displayName のみを含める。
-    // group 名と一致しない displayName(例: smarthr-ui の Table 配下にある WakuWakuButton や
-    // TableScrollContext 等の内部部品で `relatedComponents` 宣言もないもの) は SKILL 生成対象外とする。
-    const primary = group.components.filter((c) => c.displayName === dirName);
-    if (primary.length > 0) {
-      result.set(dirName, {
-        dirName,
-        displayNames: primary.map((c) => c.displayName),
-        components: primary,
-      });
-    }
-  }
-  return result;
-}
-
 async function main() {
   console.log('📂 metadata.json を読み込み中…');
   const publicExports = loadPublicExports();
@@ -81,7 +38,7 @@ async function main() {
   const relatedSkills = collectRelatedComponents(DESIGN_SYSTEM_DIR);
   console.log(`   ${relatedSkills.size} 件の relatedComponents 宣言を検出`);
 
-  const groups = autoSplitGroups(rawGroups, new Set(relatedSkills.keys()));
+  const groups = autoSplitGroups(rawGroups, new Set(relatedSkills.keys()), DESIGN_SYSTEM_DIR);
   console.log(`   ${groups.size} コンポーネントグループを検出`);
 
   console.log('🌐 eslint-plugin-smarthr ルール README を読み込み中…（コミット済みスナップショット優先）');

--- a/scripts/generate-skills/lib/auto-split-groups.ts
+++ b/scripts/generate-skills/lib/auto-split-groups.ts
@@ -1,0 +1,80 @@
+import type { ComponentGroup } from './parse-metadata.js';
+import { buildDirMapping } from './name-mapping.js';
+
+/**
+ * smarthr-ui の親ディレクトリ単位グループから、個別ドキュメント対象の displayName を分離する。
+ *
+ * 1. design-system 側の `relatedComponents` 宣言に 2 件以上含まれる displayName を独立グループにする
+ *    （例: Dialog/ 配下の ActionDialog / FormDialog など）
+ * 2. 親ディレクトリ名と一致する displayName が無く、かつ独自の index.mdx を持つ displayName がある場合
+ *    それらを独立グループにする（例: FormGroup/ 配下の FormControl と Fieldset）
+ *
+ * 残った displayName は元の親グループ名で保持する。
+ */
+export function autoSplitGroups(
+  groups: Map<string, ComponentGroup>,
+  relatedNames: Set<string>,
+  designSystemDir: string,
+): Map<string, ComponentGroup> {
+  const result = new Map<string, ComponentGroup>();
+  for (const [dirName, group] of groups) {
+    const splitTargets = group.components.filter((c) => relatedNames.has(c.displayName));
+    const hasPrimary = group.components.some((c) => c.displayName === dirName);
+
+    // 分離トリガは「relatedComponents 宣言が 2 件以上 group 内に存在する」ときに発動する。
+    // これにより、smarthr-ui の親ディレクトリに複数の displayName が同居しているグループ
+    // (例: `Dialog/RemoteDialogTrigger/` 配下に 5 つの Dialog) のみが分離対象となる。
+    // 1 件以下の場合は元グループをそのまま保持し、`ControlledStepFormDialog` グループの
+    // `StepFormDialogItem` のような同居 named export を取りこぼさない。
+    const shouldSplitByRelated = splitTargets.length >= 2;
+
+    // 親ディレクトリ名と一致する公開コンポーネントが無い場合（FormGroup/FormControl.tsx 等）は
+    // フォルダ名では index.mdx に辿れない。独自ページを持つ displayName だけを分離する。
+    const pageMapping = buildDirMapping(
+      group.components.map((c) => c.displayName),
+      designSystemDir,
+      {},
+    );
+    const ownPageTargets = hasPrimary ? [] : group.components.filter((c) => pageMapping.has(c.displayName));
+
+    if (!shouldSplitByRelated && ownPageTargets.length === 0) {
+      result.set(dirName, group);
+      continue;
+    }
+
+    const targets = shouldSplitByRelated ? splitTargets : ownPageTargets;
+    const splitNames = new Set(targets.map((c) => c.displayName));
+    for (const target of targets) {
+      result.set(target.displayName, {
+        dirName: target.displayName,
+        displayNames: [target.displayName],
+        components: [target],
+      });
+    }
+
+    // 親グループ自体は、group 名と同名の displayName のみを含める。
+    // group 名と一致しない displayName(例: smarthr-ui の Table 配下にある WakuWakuButton や
+    // TableScrollContext 等の内部部品で `relatedComponents` 宣言もないもの) は SKILL 生成対象外とする。
+    if (shouldSplitByRelated) {
+      const primary = group.components.filter((c) => c.displayName === dirName);
+      if (primary.length > 0) {
+        result.set(dirName, {
+          dirName,
+          displayNames: primary.map((c) => c.displayName),
+          components: primary,
+        });
+      }
+      continue;
+    }
+
+    const rest = group.components.filter((c) => !splitNames.has(c.displayName));
+    if (rest.length > 0) {
+      result.set(dirName, {
+        dirName,
+        displayNames: rest.map((c) => c.displayName),
+        components: rest,
+      });
+    }
+  }
+  return result;
+}

--- a/scripts/generate-skills/package.json
+++ b/scripts/generate-skills/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "js-yaml": "^5.4.0",
-    "smarthr-ui": "^99.3.2"
+    "smarthr-ui": "^99.5.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
Chromatic の SHA パーマリンクがリリースコミットに無い場合は親コミットを参照する。

## 課題・背景

smarthr-ui を v99.3.2 から v99.5.0 に更新するための追従作業。

## やったこと
- smarthr-ui のバージョンを v99.5.0 に更新
- FormGroup配下のFormControlとFieldsetをcoverageで対応付け

## やらなかったこと
- v99.3.2〜v99.5.0 のバグ修正・内部最適化（useImperativeHandle、debounce クリーンアップ等）はドキュメント影響なしのため対応不要

## 動作確認
- pnpm lint でエラーなし
- pnpm --filter ./scripts/generate-skills validate でエラーなし

## checklist.yaml の更新

<!--
コンポーネントの index.mdx / _components/*.mdx を変更・追加した場合は、まず生成/更新スキル（generate-checklist / update-checklist）を実行してください。更新要否はスキルが判定します（typo・description のみの軽微な変更でも、まずスキルを実行）。
index.mdx を変更していない場合は、この節を削除して構いません。
差分が出なかった理由（スキルの報告内容）を description に記載するとレビューしやすくなります。
詳細は CONTRIBUTING.md「smarthr-ui コンポーネント向け AI スキルの整備」を参照。
-->

- [ ] checklist.yaml に差分が出たコンポーネントは、その差分を PR に含めた
- [ ] 一部のコンポーネントで差分が出なかった（差分あり・なしが混在）→ `skip-checklist-update` ラベルを付与
- [ ] すべてのコンポーネントで差分が出なかった → `skip-checklist-update` ラベルを付与

## キャプチャ
特になし